### PR TITLE
SPI fix for original ESP32-series

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Coordinates are required for weather services:
 Performance depends on SPI speed and signal quality:
 
 ```h
-#define FRAME_RATE 50 // fps
+#define FRAME_RATE 40 // fps
 #define SPI_FREQUENCY 10000000 // Hz
 ```
 

--- a/firmware/include/config/services.h
+++ b/firmware/include/config/services.h
@@ -15,7 +15,7 @@
  * Display
  */
 /*
-#define FRAME_RATE 50 // fps
+#define FRAME_RATE 40 // fps
 #define SPI_FREQUENCY 10000000 // Hz
 */
 

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -38,7 +38,7 @@ void DisplayService::setup()
 #ifdef FRAME_RATE
     timerAlarmWrite(timer, 1000000U / (1U << 8) / FRAME_RATE, true);
 #else
-    timerAlarmWrite(timer, 1000000U / (1U << 8) / 50, true);
+    timerAlarmWrite(timer, 1000000U / (1U << 8) / 40, true);
 #endif // FRAME_RATE
 
     timerAlarmEnable(timer);
@@ -113,9 +113,16 @@ IRAM_ATTR void DisplayService::onTimer()
         tx[i >> 3] |= (Display.frameReady[Display.pixelBitOrder[i]] > filter) << (7 - (i & 7));
     }
     ++filter;
+#if CONFIG_IDF_TARGET_ESP32
+    unsigned char *_tx = (unsigned char *)tx;
+    digitalWrite(PIN_CS, LOW);
+    SPI.writeBytes(_tx, sizeof(_tx));
+    digitalWrite(PIN_CS, HIGH);
+#else
     digitalWrite(PIN_CS, LOW);
     SPI.writeBytes(tx, sizeof(tx));
     digitalWrite(PIN_CS, HIGH);
+#endif // CONFIG_IDF_TARGET_ESP32
 }
 
 void DisplayService::flush()


### PR DESCRIPTION
SPI write fix for the original ESP32-series.
Reduce default frame rate to 40 fps.

Fixes #9