### PR TITLE
Refactor Serial.print

### DIFF
--- a/firmware/include/handlers/BitmapHandler.h
+++ b/firmware/include/handlers/BitmapHandler.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <stdint.h>
+#include <string_view>
 #include <vector>
 
 class BitmapHandler
 {
 private:
+    static constexpr std::string_view name = "BitmapHandler";
+
     const std::vector<uint16_t> bitmap;
 
     uint8_t

--- a/firmware/include/handlers/TextHandler.h
+++ b/firmware/include/handlers/TextHandler.h
@@ -7,6 +7,8 @@
 class TextHandler
 {
 private:
+    static constexpr std::string_view name = "TextHandler";
+
     const String text;
 
     FontModule *font;

--- a/firmware/include/handlers/WeatherHandler.h
+++ b/firmware/include/handlers/WeatherHandler.h
@@ -48,6 +48,8 @@ public:
     void draw();
 
 private:
+    static constexpr std::string_view name = "WeatherHandler";
+
     const std::vector<uint16_t>
         conditionClear = {
             0b0011100,

--- a/firmware/src/extensions/AlexaExtension.cpp
+++ b/firmware/src/extensions/AlexaExtension.cpp
@@ -42,8 +42,7 @@ void AlexaExtension::onSetState(unsigned char deviceId, const char *deviceName, 
     if (!strcmp(deviceName, NAME))
     {
 #ifdef F_INFO
-        Serial.print(Alexa->name);
-        Serial.println(state == Display.getPower() ? ": brightness" : ": power");
+        Serial.printf(state == Display.getPower() ? "%s: brightness\n" : "%s: power\n", Alexa->name);
 #endif
         Display.setGlobalBrightness(static_cast<uint8_t>(value));
         Display.setPower(state);

--- a/firmware/src/extensions/ButtonExtension.cpp
+++ b/firmware/src/extensions/ButtonExtension.cpp
@@ -77,8 +77,7 @@ void ButtonExtension::handle()
     if (powerShort)
     {
 #ifdef F_INFO
-        Serial.print(Button->name);
-        Serial.println(": power");
+        Serial.printf("%s: power\n", Button->name);
 #endif // F_INFO
         Display.setPower(!Display.getPower());
 #if EXTENSION_MQTT || EXTENSION_WEBSOCKET
@@ -94,8 +93,7 @@ void ButtonExtension::handle()
             brightnessIncrease = !brightnessIncrease;
         }
 #ifdef F_INFO
-        Serial.print(Button->name);
-        Serial.println(brightnessIncrease ? ": brightness +" : ": brightness -");
+        Serial.printf(brightnessIncrease ? "%s: brightness +\n" : "%s: brightness -\n", Button->name);
 #endif // F_INFO
         Display.setGlobalBrightness(brightnessIncrease ? brightness + 1 : brightness - 1);
 #if EXTENSION_MQTT || EXTENSION_WEBSOCKET
@@ -113,14 +111,12 @@ void ButtonExtension::handle()
     {
 #ifdef PIN_SW1
 #ifdef F_INFO
-        Serial.print(Button->name);
-        Serial.println(": mode");
+        Serial.printf("%s: mode\n", Button->name);
 #endif // F_INFO
         Modes.next();
 #else
 #ifdef F_INFO
-        Serial.print(Button->name);
-        Serial.println(": power");
+        Serial.printf("%s: power\n", Button->name);
 #endif // F_INFO
         Display.setPower(!Display.getPower());
 #endif // PIN_SW1
@@ -133,8 +129,7 @@ void ButtonExtension::handle()
     {
         modeMillis = millis();
 #ifdef F_INFO
-        Serial.print(Button->name);
-        Serial.println(": mode");
+        Serial.printf("%s: mode\n", Button->name);
 #endif // F_INFO
         Modes.next();
 #if EXTENSION_MQTT || EXTENSION_WEBSOCKET

--- a/firmware/src/extensions/HomeAssistantExtension.cpp
+++ b/firmware/src/extensions/HomeAssistantExtension.cpp
@@ -119,8 +119,7 @@ void HomeAssistantExtension::undiscover()
 {
     Mqtt->client.publish(discoveryTopic.c_str(), 1, true, reinterpret_cast<const uint8_t *>(""), 0);
 #ifdef F_INFO
-    Serial.print(name);
-    Serial.println(": discovery packet removed");
+    Serial.printf("%s: discovery packet removed\n", name);
 #endif
 }
 

--- a/firmware/src/extensions/InfraredExtension.cpp
+++ b/firmware/src/extensions/InfraredExtension.cpp
@@ -66,26 +66,22 @@ void InfraredExtension::handle()
 #ifdef F_VERBOSE
         if (!results.repeat && results.decode_type != decode_type_t::UNKNOWN && !parse(results))
         {
-            Serial.print(name);
-            Serial.print(": ");
             switch (results.decode_type)
             {
 #if DECODE_RC5
             case decode_type_t::RC5:
-                Serial.print(D_STR_RC5);
+                Serial.printf("%s: " D_STR_RC5 " 0x%X\n", name, results.command);
                 break;
 #endif // DECODE_RC5
 #if DECODE_SONY
             case decode_type_t::SONY:
-                Serial.print(D_STR_SONY);
+                Serial.printf("%s: " D_STR_SONY " 0x%X\n", name, results.command);
                 break;
 #endif // DECODE_SONY
             default:
-                Serial.print(results.decode_type);
+                Serial.printf("%s: protocol %d code 0x%X\n", name, results.decode_type, results.command);
                 break;
             }
-            Serial.print(", 0x");
-            Serial.println(results.command, HEX);
         }
 #else
         if (!results.repeat && results.decode_type != decode_type_t::UNKNOWN)
@@ -111,8 +107,7 @@ bool InfraredExtension::parse(decode_results results)
                     if (brightness > 0)
                     {
 #ifdef F_INFO
-                        Serial.print(name);
-                        Serial.println(": brightness -");
+                        Serial.printf("%s: brightness -\n", name);
 #endif
                         Display.setGlobalBrightness(max(0, brightness - 5));
                         lastMillis = millis();
@@ -128,8 +123,7 @@ bool InfraredExtension::parse(decode_results results)
                     if (brightness < UINT8_MAX)
                     {
 #ifdef F_INFO
-                        Serial.print(name);
-                        Serial.println(": brightness +");
+                        Serial.printf("%s: brightness +\n", name);
 #endif
                         Display.setGlobalBrightness(min(UINT8_MAX, brightness + 5));
                         lastMillis = millis();
@@ -142,8 +136,7 @@ bool InfraredExtension::parse(decode_results results)
                 if (millis() - lastMillis > 1000)
                 {
 #ifdef F_INFO
-                    Serial.print(name);
-                    Serial.println(": power");
+                    Serial.printf("%s: power\n", name);
 #endif
                     Display.setPower(!Display.getPower());
                     lastMillis = millis();
@@ -156,8 +149,7 @@ bool InfraredExtension::parse(decode_results results)
                 if (millis() - lastMillis > 1000)
                 {
 #ifdef F_INFO
-                    Serial.print(name);
-                    Serial.println(": mic");
+                    Serial.printf("%s: microphone\n", name);
 #endif
                     Microphone->set(!Microphone->get());
                     lastMillis = millis();
@@ -171,8 +163,7 @@ bool InfraredExtension::parse(decode_results results)
                 if (millis() - lastMillis > 1000)
                 {
 #ifdef F_INFO
-                    Serial.print(name);
-                    Serial.println(": playlist");
+                    Serial.printf("%s: playlist\n", name);
 #endif
                     Playlist->set(!Playlist->get());
                     lastMillis = millis();
@@ -185,8 +176,7 @@ bool InfraredExtension::parse(decode_results results)
                 if (millis() - lastMillis > 500)
                 {
 #ifdef F_INFO
-                    Serial.print(name);
-                    Serial.println(": mode +");
+                    Serial.printf("%s: mode +\n", name);
 #endif
                     Modes.next();
                     lastMillis = millis();
@@ -198,8 +188,7 @@ bool InfraredExtension::parse(decode_results results)
                 if (millis() - lastMillis > 500)
                 {
 #ifdef F_INFO
-                    Serial.print(name);
-                    Serial.println(": mode -");
+                    Serial.printf("%s: mode -\n", name);
 #endif
                     Modes.previous();
                     lastMillis = millis();
@@ -232,8 +221,7 @@ void InfraredExtension::set(bool enable)
         transmit();
 
 #ifdef F_INFO
-        Serial.print(name);
-        Serial.println(active ? ": active" : ": inactive");
+        Serial.printf(active ? "%s: active\n" : "%s: inactive\n", name);
 #endif
     }
 }

--- a/firmware/src/extensions/MessageExtension.cpp
+++ b/firmware/src/extensions/MessageExtension.cpp
@@ -126,9 +126,7 @@ void MessageExtension::setFont(const char *const fontName)
             }
         }
 #ifdef F_DEBUG
-        Serial.print(name);
-        Serial.print(": unknown font ");
-        Serial.println(fontName);
+        Serial.printf("%s: unknown font %s\n", name, fontName);
 #endif
     }
 }
@@ -178,8 +176,7 @@ void MessageExtension::receiverHook(const JsonDocument doc)
             }
         }
 #ifdef F_DEBUG
-        Serial.print(name);
-        Serial.println(": received");
+        Serial.printf("%s: received\n", name);
 #endif
     }
 }

--- a/firmware/src/extensions/MicrophoneExtension.cpp
+++ b/firmware/src/extensions/MicrophoneExtension.cpp
@@ -114,9 +114,7 @@ void MicrophoneExtension::handle()
             {
                 detected = true;
 #ifdef F_VERBOSE
-                Serial.print(name);
-                Serial.print(": sound, level ");
-                Serial.println(level);
+                Serial.printf("%s: sound, level %d\n", name, level);
 #endif
             }
         }
@@ -124,9 +122,7 @@ void MicrophoneExtension::handle()
         {
             detected = false;
 #ifdef F_VERBOSE
-            Serial.print(name);
-            Serial.print(": silence, level ");
-            Serial.println(level);
+            Serial.printf("%s: silence, level %d\n", name, level);
 #endif
         }
     }
@@ -155,8 +151,7 @@ void MicrophoneExtension::set(bool enable)
         pending = true;
 
 #ifdef F_INFO
-        Serial.print(name);
-        Serial.println(active ? ": active" : ": inactive");
+        Serial.printf(active ? "%s: active\n" : "%s: inactive\n", name);
 #endif
     }
 }

--- a/firmware/src/extensions/MqttExtension.cpp
+++ b/firmware/src/extensions/MqttExtension.cpp
@@ -63,8 +63,7 @@ void MqttExtension::handle()
         {
             client.clearQueue();
 #ifdef F_DEBUG
-            Serial.print(Mqtt->name);
-            Serial.println(": queue dropped");
+            Serial.printf("%s: queue dropped\n", Mqtt->name);
 #endif // F_DEBUG
         }
     }
@@ -84,8 +83,7 @@ void MqttExtension::disconnect()
 void MqttExtension::onConnect(bool sessionPresent)
 {
 #ifdef F_DEBUG
-    Serial.print(Mqtt->name);
-    Serial.println(": connected");
+    Serial.printf("%s: connected\n", Mqtt->name);
 #endif
     if (!sessionPresent)
     {
@@ -103,8 +101,7 @@ void MqttExtension::onMessage(const espMqttClientTypes::MessageProperties &prope
 #ifdef F_DEBUG
     if (len < total)
     {
-        Serial.print(Mqtt->name);
-        Serial.println(": chunked messages is currently not supported");
+        Serial.printf("%s: chunked messages is currently not supported\n", Mqtt->name);
         return;
     }
 #endif
@@ -119,12 +116,9 @@ void MqttExtension::onMessage(const espMqttClientTypes::MessageProperties &prope
 void MqttExtension::onDisconnect(espMqttClientTypes::DisconnectReason reason)
 {
 #ifdef F_VERBOSE
-    Serial.print(Mqtt->name);
-    Serial.print(": disconnected, ");
-    Serial.println(espMqttClientTypes::disconnectReasonToString(reason));
+    Serial.printf("%s: disconnected, %s\n", Mqtt->name, espMqttClientTypes::disconnectReasonToString(reason));
 #elif defined(F_DEBUG)
-    Serial.print(Mqtt->name);
-    Serial.println(": disconnected");
+    Serial.printf("%s: disconnected\n", Mqtt->name);
 #endif // F_DEBUG
     Mqtt->pending = true;
 }

--- a/firmware/src/extensions/OtaExtension.cpp
+++ b/firmware/src/extensions/OtaExtension.cpp
@@ -70,8 +70,7 @@ void OtaExtension::onStart()
 {
     Modes.set(false, Ota->name);
 #ifdef F_INFO
-    Serial.print(Ota->name);
-    Serial.println(": updating");
+    Serial.printf("%s: updating\n", Ota->name);
 #endif
     Display.clear();
     TextHandler("U", FontLarge).draw();
@@ -82,8 +81,7 @@ void OtaExtension::onStart()
 void OtaExtension::onEnd()
 {
 #ifdef F_INFO
-    Serial.print(Ota->name);
-    Serial.println(": complete");
+    Serial.printf("%s: complete\n", Ota->name);
 #endif
     Device.power(true);
 }
@@ -91,9 +89,7 @@ void OtaExtension::onEnd()
 void OtaExtension::onError(ota_error_t error)
 {
 #ifdef F_INFO
-    Serial.print(Ota->name);
-    Serial.print(": ");
-    Serial.println(Update.errorString());
+    Serial.printf("%s: %s\n", Ota->name, Update.errorString());
 #endif
     Device.power(true);
 }
@@ -101,9 +97,7 @@ void OtaExtension::onError(ota_error_t error)
 #ifdef F_INFO
 void OtaExtension::onProgress(size_t index, size_t len)
 {
-    Serial.print(Ota->name);
-    Serial.print(": writing @ 0x");
-    Serial.println(index, HEX);
+    Serial.printf("%s: writing @ 0x%X\n", Ota->name, index);
 }
 #endif
 
@@ -117,9 +111,7 @@ void OtaExtension::onUpload(AsyncWebServerRequest *request, const String &filena
     if ((!index && !Update.begin(UPDATE_SIZE_UNKNOWN, filename.indexOf("spiffs") >= 0 ? U_SPIFFS : U_FLASH)) || Update.write(data, len) != len || (final && !Update.end(true)))
     {
 #ifdef F_INFO
-        Serial.print(Ota->name);
-        Serial.print(": ");
-        Serial.println(Update.errorString());
+        Serial.printf("%s: %s\n", Ota->name, Update.errorString());
 #endif
         request->send(t_http_codes::HTTP_CODE_INTERNAL_SERVER_ERROR);
         Device.power(true);

--- a/firmware/src/extensions/PlaylistExtension.cpp
+++ b/firmware/src/extensions/PlaylistExtension.cpp
@@ -80,8 +80,7 @@ void PlaylistExtension::handle()
             step = 0;
         }
 #ifdef F_INFO
-        Serial.print(name);
-        Serial.println(": next mode");
+        Serial.printf("%s: next mode\n", name);
 #endif
         Modes.set(playlist[step].mode.c_str());
         lastMillis = millis();
@@ -108,8 +107,7 @@ void PlaylistExtension::set(bool enable)
         transmit();
 
 #ifdef F_INFO
-        Serial.print(name);
-        Serial.println(active ? ": active" : ": inactive");
+        Serial.printf(active ? "%s: active\n" : "%s: inactive\n", name);
 #endif
     }
 }

--- a/firmware/src/extensions/RtcExtension.cpp
+++ b/firmware/src/extensions/RtcExtension.cpp
@@ -50,15 +50,13 @@ void RtcExtension::setup()
         tv.tv_sec = rtc.GetDateTime().Unix64Time();
         settimeofday(&tv, nullptr);
 #ifdef F_VERBOSE
-        Serial.print(Rtc->name);
-        Serial.println(": sync");
+        Serial.printf("%s: sync\n", Rtc->name);
 #endif // F_VERBOSE
     }
 #ifdef F_DEBUG
     else
     {
-        Serial.print(Rtc->name);
-        Serial.println(": out of sync");
+        Serial.printf("%s: out of sync\n", name);
     }
 #endif // F_INFO
     sntp_set_time_sync_notification_cb(&sntpSetTimeSyncNotificationCallback);
@@ -155,8 +153,7 @@ void RtcExtension::sntpSetTimeSyncNotificationCallback(struct timeval *tv)
     Rtc->rtc.SetDateTime(dt);
 
 #ifdef F_VERBOSE
-    Serial.print(Rtc->name);
-    Serial.println(": NTP sync");
+    Serial.printf("%s: NTP sync\n", Rtc->name);
 #endif // F_VERBOSE
 }
 

--- a/firmware/src/extensions/SignalExtension.cpp
+++ b/firmware/src/extensions/SignalExtension.cpp
@@ -104,8 +104,7 @@ void SignalExtension::receiverHook(const JsonDocument doc)
         }
         signals.push_back(sign);
 #ifdef F_DEBUG
-        Serial.print(name);
-        Serial.println(": received");
+        Serial.printf("%s: received\n", name);
 #endif
     }
 }

--- a/firmware/src/extensions/WebSocketExtension.cpp
+++ b/firmware/src/extensions/WebSocketExtension.cpp
@@ -56,8 +56,7 @@ void WebSocketExtension::onEvent(AsyncWebSocket *server, AsyncWebSocketClient *c
 #ifdef F_DEBUG
         if (len < info->len)
         {
-            Serial.print(WebSocket->name);
-            Serial.println(": chunked messages is currently not supported");
+                Serial.printf("%s: chunked messages is currently not supported\n", WebSocket->name);
             return;
         }
 #endif

--- a/firmware/src/handlers/TextHandler.cpp
+++ b/firmware/src/handlers/TextHandler.cpp
@@ -68,12 +68,7 @@ TextHandler::TextHandler(String text, FontModule *font) : text(text), font(font)
 #ifdef F_DEBUG
                 else
                 {
-                    Serial.print("TextHandler: missing symbol, ");
-                    Serial.print(font->name);
-                    Serial.print(" @ 0x");
-                    Serial.print((1U << 8) * multiplier + text[charIndex], HEX);
-                    Serial.print(" ");
-                    Serial.println(text[charIndex]);
+                    Serial.printf("%s: missing symbol, %s @ 0x%X %s\n", name, font->name, (1U << 8) * multiplier + text[charIndex], text[charIndex]);
                 }
 #endif
                 multiplier = 0;

--- a/firmware/src/handlers/WeatherHandler.cpp
+++ b/firmware/src/handlers/WeatherHandler.cpp
@@ -16,8 +16,7 @@ void WeatherHandler::parse(const std::string code, const std::vector<Codeset> co
         }
     }
 #ifdef F_VERBOSE
-    Serial.print("WeatherHandler: unknown condition code ");
-    Serial.println(code.c_str());
+    Serial.printf("%s: unknown condition code %s\n", name, code.c_str());
 #endif
 }
 
@@ -32,8 +31,7 @@ void WeatherHandler::parse(const uint8_t code, const std::vector<Codeset8> codes
         }
     }
 #ifdef F_VERBOSE
-    Serial.print("WeatherHandler: unknown condition code ");
-    Serial.println(code);
+    Serial.printf("%s: unknown condition code %d\n", name, code);
 #endif
 }
 
@@ -48,8 +46,7 @@ void WeatherHandler::parse(const uint16_t code, const std::vector<Codeset16> cod
         }
     }
 #ifdef F_VERBOSE
-    Serial.print("WeatherHandler: unknown condition code ");
-    Serial.println(code);
+    Serial.printf("%s: unknown condition code %d\n", name, code);
 #endif
 }
 

--- a/firmware/src/modes/AnimationMode.cpp
+++ b/firmware/src/modes/AnimationMode.cpp
@@ -101,8 +101,7 @@ void AnimationMode::receiverHook(const JsonDocument doc)
         Storage.end();
         transmit();
 #ifdef F_VERBOSE
-        Serial.print(name);
-        Serial.println(": frame saved");
+        Serial.printf("%s: frame saved\n", name);
 #endif
     }
     if (doc["duration"].is<uint16_t>())

--- a/firmware/src/modes/ArtNetMode.cpp
+++ b/firmware/src/modes/ArtNetMode.cpp
@@ -11,8 +11,7 @@ void ArtNetMode::wake()
         {
             udp->onPacket(&onPacket);
 #ifdef F_DEBUG
-            Serial.print(name);
-            Serial.println(": listening at port 6454");
+            Serial.printf("%s: listening at port 6454\n", name);
 #endif
         }
     }
@@ -30,7 +29,7 @@ void ArtNetMode::onPacket(AsyncUDPPacket packet)
         break;
 #ifdef F_DEBUG
     default:
-        Serial.println("Art-Net: unsupported package received");
+        Serial.printf("%s: : unsupported package received\n", "Art-Net");
 #endif
     }
 }

--- a/firmware/src/modes/DistributedDisplayProtocolMode.cpp
+++ b/firmware/src/modes/DistributedDisplayProtocolMode.cpp
@@ -11,8 +11,7 @@ void DistributedDisplayProtocolMode::wake()
         {
             udp->onPacket(&onPacket);
 #ifdef F_DEBUG
-            Serial.print(name);
-            Serial.println(": listening at port 4048");
+            Serial.printf("%s: listening at port 4048\n", name);
 #endif
         }
     }
@@ -36,7 +35,7 @@ void DistributedDisplayProtocolMode::onPacket(AsyncUDPPacket packet)
         break;
 #ifdef F_DEBUG
     default:
-        Serial.println("Distributed Display Protocol: unsupported package received");
+        Serial.printf("%s: unsupported package received\n", "Distributed Display Protocol");
 #endif
     }
 }

--- a/firmware/src/modes/DrawMode.cpp
+++ b/firmware/src/modes/DrawMode.cpp
@@ -92,8 +92,7 @@ void DrawMode::receiverHook(const JsonDocument doc)
         save(true);
         pending = true;
 #ifdef F_DEBUG
-        Serial.print(name);
-        Serial.println(": frame");
+        Serial.printf("%s: frame\n", name);
 #endif
     }
     // Pixel
@@ -143,8 +142,7 @@ void DrawMode::save(bool cache)
             Storage.putBytes(cache ? "cache" : "saved", drawing, COLUMNS * ROWS);
             Storage.end();
 #ifdef F_VERBOSE
-            Serial.print(name);
-            Serial.println(cache ? ": cached" : ": saved");
+            Serial.printf(cache ? "%s: cached\n" : "%s: saved\n", name);
 #endif
             break;
         }

--- a/firmware/src/modes/E131Mode.cpp
+++ b/firmware/src/modes/E131Mode.cpp
@@ -11,8 +11,7 @@ void E131Mode::wake()
         {
             udp->onPacket(&onPacket);
 #ifdef F_DEBUG
-            Serial.print(name);
-            Serial.println(": listening at port 5568");
+            Serial.printf("%s: listening at port 5568\n", name);
 #endif
         }
     }
@@ -36,7 +35,7 @@ void E131Mode::onPacket(AsyncUDPPacket packet)
         break;
 #ifdef F_DEBUG
     default:
-        Serial.println("E1.31: unsupported package received");
+        Serial.printf("%s: unsupported package received\n", "E1.31");
 #endif
     }
 }

--- a/firmware/src/modes/HomeAssistantWeatherMode.cpp
+++ b/firmware/src/modes/HomeAssistantWeatherMode.cpp
@@ -32,8 +32,7 @@ void HomeAssistantWeatherMode::wake()
 #ifdef F_INFO
     if (urls.empty())
     {
-        Serial.print(name);
-        Serial.println(": unable to fetch weather");
+        Serial.printf("%s: unable to fetch weather\n", name);
     }
     else
     {
@@ -64,9 +63,7 @@ void HomeAssistantWeatherMode::update()
     http.setUserAgent(Network.userAgent.data());
 
 #ifdef F_DEBUG
-    Serial.print(name);
-    Serial.print(": ");
-    Serial.println(urls.back().c_str());
+    Serial.printf("%s: %s\n", name, urls.back().c_str());
 #endif
 
     const int code = http.GET();
@@ -78,8 +75,7 @@ void HomeAssistantWeatherMode::update()
             urls.pop_back();
             lastMillis = 0;
 #ifdef F_DEBUG
-            Serial.print(name);
-            Serial.println(": unprocessable data");
+            Serial.printf("%s: unprocessable data\n", name);
 #endif
             return;
         }
@@ -95,8 +91,7 @@ void HomeAssistantWeatherMode::update()
 #ifdef F_INFO
         if (urls.empty())
         {
-            Serial.print(name);
-            Serial.println(": unable to fetch weather");
+            Serial.printf("%s: unable to fetch weather\n", name);
         }
 #endif
     }

--- a/firmware/src/modes/HomeThermometerMode.cpp
+++ b/firmware/src/modes/HomeThermometerMode.cpp
@@ -146,10 +146,6 @@ void HomeThermometerMode::set(const char *const where, const int16_t temperature
     transmit();
 
 #ifdef F_DEBUG
-    Serial.print(name);
-    Serial.print(": ");
-    Serial.print(where);
-    Serial.print(" ");
-    Serial.println(temperature);
+    Serial.printf("%s: %s %d\n", name, where, temperature);
 #endif
 }

--- a/firmware/src/modes/OpenMetroMode.cpp
+++ b/firmware/src/modes/OpenMetroMode.cpp
@@ -25,8 +25,7 @@ void OpenMetroMode::wake()
 #ifdef F_INFO
     if (urls.empty())
     {
-        Serial.print(name);
-        Serial.println(": unable to fetch weather");
+        Serial.printf("%s: unable to fetch weather\n", name);
     }
     else
     {
@@ -56,9 +55,7 @@ void OpenMetroMode::update()
     http.setUserAgent(Network.userAgent.data());
 
 #ifdef F_DEBUG
-    Serial.print(name);
-    Serial.print(": ");
-    Serial.println(urls.back());
+    Serial.printf("%s: %s\n", name, urls.back());
 #endif
 
     const int code = http.GET();
@@ -70,8 +67,7 @@ void OpenMetroMode::update()
             urls.pop_back();
             lastMillis = 0;
 #ifdef F_DEBUG
-            Serial.print(name);
-            Serial.println(": unprocessable data");
+            Serial.printf("%s: unprocessable data\n", name);
 #endif
             return;
         }
@@ -87,8 +83,7 @@ void OpenMetroMode::update()
 #ifdef F_INFO
         if (urls.empty())
         {
-            Serial.print(name);
-            Serial.println(": unable to fetch weather");
+            Serial.printf("%s: unable to fetch weather\n", name);
         }
 #endif
     }

--- a/firmware/src/modes/OpenWeatherMode.cpp
+++ b/firmware/src/modes/OpenWeatherMode.cpp
@@ -23,8 +23,7 @@ void OpenWeatherMode::wake()
 #ifdef F_INFO
     if (urls.empty())
     {
-        Serial.print(name);
-        Serial.println(": unable to fetch weather");
+        Serial.printf("%s: unable to fetch weather\n", name);
     }
     else
     {
@@ -54,9 +53,7 @@ void OpenWeatherMode::update()
     http.setUserAgent(Network.userAgent.data());
 
 #ifdef F_DEBUG
-    Serial.print(name);
-    Serial.print(": GET ");
-    Serial.println(urls.back());
+    Serial.printf("%s: %s\n", name, urls.back());
 #endif
 
     const int code = http.GET();
@@ -85,8 +82,7 @@ void OpenWeatherMode::update()
             urls.pop_back();
             lastMillis = 0;
 #ifdef F_DEBUG
-            Serial.print(name);
-            Serial.println(": unprocessable data");
+            Serial.printf("%s: unprocessable data\n", name);
 #endif
         }
     }
@@ -97,8 +93,7 @@ void OpenWeatherMode::update()
 #ifdef F_INFO
         if (urls.empty())
         {
-            Serial.print(name);
-            Serial.println(": unable to fetch weather");
+            Serial.printf("%s: unable to fetch weather\n", name);
         }
 #endif
     }

--- a/firmware/src/modes/TickerMode.cpp
+++ b/firmware/src/modes/TickerMode.cpp
@@ -108,9 +108,7 @@ void TickerMode::setFont(const char *const fontName)
         }
     }
 #ifdef F_DEBUG
-    Serial.print(name);
-    Serial.print(": unknown font ");
-    Serial.println(fontName);
+    Serial.printf("%s: unknown font %s\n", name, fontName);
 #endif
 }
 
@@ -147,8 +145,7 @@ void TickerMode::receiverHook(const JsonDocument doc)
     {
         setMessage(doc["message"].as<String>());
 #ifdef F_DEBUG
-        Serial.print(name);
-        Serial.println(": received");
+        Serial.printf("%s: received\n", name);
 #endif
     }
 }

--- a/firmware/src/modes/WorldWeatherOnlineMode.cpp
+++ b/firmware/src/modes/WorldWeatherOnlineMode.cpp
@@ -26,8 +26,7 @@ void WorldWeatherOnlineMode::wake()
 #ifdef F_INFO
     if (urls.empty())
     {
-        Serial.print(name);
-        Serial.println(": unable to fetch weather");
+        Serial.printf("%s: unable to fetch weather\n", name);
     }
     else
     {
@@ -57,9 +56,7 @@ void WorldWeatherOnlineMode::update()
     http.setUserAgent(Network.userAgent.data());
 
 #ifdef F_DEBUG
-    Serial.print(name);
-    Serial.print(": ");
-    Serial.println(urls.back());
+    Serial.printf("%s: %s\n", name, urls.back());
 #endif
 
     const int code = http.GET();
@@ -77,8 +74,7 @@ void WorldWeatherOnlineMode::update()
             urls.pop_back();
             lastMillis = 0;
 #ifdef F_DEBUG
-            Serial.print(name);
-            Serial.println(": unprocessable data");
+            Serial.printf("%s: unprocessable data\n", name);
 #endif
             return;
         }
@@ -98,8 +94,7 @@ void WorldWeatherOnlineMode::update()
 #ifdef F_INFO
         if (urls.empty())
         {
-            Serial.print(name);
-            Serial.println(": unable to fetch weather");
+            Serial.printf("%s: unable to fetch weather\n", name);
         }
 #endif
     }

--- a/firmware/src/modes/WttrInMode.cpp
+++ b/firmware/src/modes/WttrInMode.cpp
@@ -16,8 +16,7 @@ void WttrInMode::wake()
 #ifdef F_INFO
     if (urls.empty())
     {
-        Serial.print(name);
-        Serial.println(": unable to fetch weather");
+        Serial.printf("%s: unable to fetch weather\n", name);
     }
     else
     {
@@ -47,9 +46,7 @@ void WttrInMode::update()
     http.setUserAgent(Network.userAgent.data());
 
 #ifdef F_DEBUG
-    Serial.print(name);
-    Serial.print(": ");
-    Serial.println(urls.back());
+    Serial.printf("%s: %s\n", name, urls.back());
 #endif
 
     const int code = http.GET();
@@ -61,8 +58,7 @@ void WttrInMode::update()
             urls.pop_back();
             lastMillis = 0;
 #ifdef F_DEBUG
-            Serial.print(name);
-            Serial.println(": unprocessable data");
+            Serial.printf("%s: unprocessable data\n", name);
 #endif
             return;
         }
@@ -78,8 +74,7 @@ void WttrInMode::update()
 #ifdef F_INFO
         if (urls.empty())
         {
-            Serial.print(name);
-            Serial.println(": unable to fetch weather");
+            Serial.printf("%s: unable to fetch weather\n", name);
         }
 #endif
     }

--- a/firmware/src/modes/YrMode.cpp
+++ b/firmware/src/modes/YrMode.cpp
@@ -20,8 +20,7 @@ void YrMode::wake()
 #ifdef F_INFO
     if (urls.empty())
     {
-        Serial.print(name);
-        Serial.println(": unable to fetch weather");
+        Serial.printf("%s: unable to fetch weather\n", name);
     }
     else
     {
@@ -51,9 +50,7 @@ void YrMode::update()
     http.setUserAgent(Network.userAgent.data());
 
 #ifdef F_DEBUG
-    Serial.print(name);
-    Serial.print(": ");
-    Serial.println(urls.back());
+    Serial.printf("%s: %s\n", name, urls.back());
 #endif
 
     const int code = http.GET();
@@ -65,8 +62,7 @@ void YrMode::update()
             urls.pop_back();
             lastMillis = 0;
 #ifdef F_DEBUG
-            Serial.print(name);
-            Serial.println(": unprocessable data");
+            Serial.printf("%s: unprocessable data\n", name);
 #endif
             return;
         }
@@ -82,8 +78,7 @@ void YrMode::update()
 #ifdef F_INFO
         if (urls.empty())
         {
-            Serial.print(name);
-            Serial.println(": unable to fetch weather");
+            Serial.printf("%s: unable to fetch weather\n", name);
         }
 #endif
     }

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -27,12 +27,9 @@ void DeviceService::init()
     delay(1 << 11);
 #endif
 #ifdef F_INFO
-    Serial.print(name);
-    Serial.println(": Frekvens " VERSION);
-    Serial.print(name);
-    Serial.println(": " MANUFACTURER " " MODEL);
-    Serial.print(name);
-    Serial.println(": " BOARD_NAME);
+    Serial.printf("%s: Frekvens " VERSION "\n", name);
+    Serial.printf("%s: " MANUFACTURER " " MODEL "\n", name);
+    Serial.printf("%s: " BOARD_NAME "\n", name);
 #endif
 
     gpio_deep_sleep_hold_dis();
@@ -120,9 +117,7 @@ void DeviceService::ready()
             if (Storage.isKey("active"))
             {
 #ifdef F_DEBUG
-                Serial.print(name);
-                Serial.print(": resetting ");
-                Serial.println(_name);
+                Serial.printf("%s: resetting %s\n", name, _name);
 #endif
                 Storage.remove("active");
             }
@@ -333,8 +328,7 @@ void DeviceService::ready()
     transmit();
 
 #ifdef F_DEBUG
-    Serial.print(name);
-    Serial.println(": ready");
+    Serial.printf("%s: ready\n", name);
 #endif
 }
 
@@ -369,12 +363,7 @@ void DeviceService::update()
             if (latest != VERSION)
             {
 #ifdef F_INFO
-                Serial.print(name);
-                Serial.print(": update available, ");
-                Serial.print(VERSION);
-                Serial.print(" -> ");
-                Serial.print(latest.c_str());
-                Serial.println(" - release notes @ https://github.com/VIPnytt/Frekvens/releases");
+                Serial.printf("%s: update available, " VERSION " -> %s - release notes @ %s/releases/latest\n", name, latest.c_str(), repository.data());
 #endif
             }
         }
@@ -385,8 +374,7 @@ void DeviceService::identify()
 {
     Modes.set(false, name);
 #ifdef F_VERBOSE
-    Serial.print(name);
-    Serial.println(": identify");
+    Serial.printf("%s: identify\n", name);
 #endif
     Display.clear();
     TextHandler("!", FontLarge).draw();
@@ -396,8 +384,7 @@ void DeviceService::identify()
 void DeviceService::power(bool state)
 {
 #ifdef F_INFO
-    Serial.print(name);
-    Serial.println(state ? ": rebooting..." : ": powering off...");
+    Serial.printf(state ? "%s: rebooting...\n" : "%s: powering off...\n", name);
 #endif
     JsonDocument doc;
     doc["event"] = state ? "reboot" : "power";
@@ -474,9 +461,7 @@ void DeviceService::transmit(JsonDocument doc, const char *const source, bool re
     }
 #endif // F_DEBUG
 #ifdef F_VERBOSE
-    Serial.print(name);
-    Serial.print(": transmitting, ");
-    Serial.println(source);
+    Serial.printf("%s: transmitting, %s\n", name, source);
 #endif // F_VERBOSE
     if (retain)
     {
@@ -491,9 +476,7 @@ void DeviceService::transmit(JsonDocument doc, const char *const source, bool re
 void DeviceService::receive(const JsonDocument doc, const char *const source, const char *const destination)
 {
 #ifdef F_VERBOSE
-    Serial.print(name);
-    Serial.print(": receiving @ ");
-    Serial.println(source);
+    Serial.printf("%s: receiving @ %s\n", name, source);
 #endif
     ServiceModule *services[] = {
         &Device,
@@ -525,11 +508,6 @@ void DeviceService::receive(const JsonDocument doc, const char *const source, co
             return;
         }
     }
-#ifdef F_DEBUG
-    Serial.print(name);
-    Serial.print(": unknown module ");
-    Serial.println(destination);
-#endif
 }
 
 void DeviceService::receiverHook(const JsonDocument doc)

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -67,17 +67,9 @@ void DisplayService::setup()
     flush();
 
 #if defined(F_VERBOSE) && defined(SPI_FREQUENCY)
-    Serial.print(name);
-    Serial.print(": ");
-    Serial.print(1000000U / (float)(1U << 8) / (float)timerAlarmRead(timer));
-    Serial.print(" fps @ ");
-    Serial.print(SPI_FREQUENCY / (float)1000000);
-    Serial.println(" MHz");
+    Serial.printf("%s: %.0f fps @ %.1f MHz\n", name, 1000000U / (float)(1U << 8) / (float)timerAlarmRead(timer), SPI_FREQUENCY / (float)1000000);
 #elif defined(F_DEBUG)
-    Serial.print(name);
-    Serial.print(": ");
-    Serial.print(1000000U / (float)(1U << 8) / (float)timerAlarmRead(timer));
-    Serial.println(" fps");
+    Serial.printf("%s: %.0f fps\n", name, 1000000U / (float)(1U << 8) / (float)timerAlarmRead(timer));
 #endif
 }
 
@@ -259,11 +251,7 @@ uint8_t DisplayService::getPixel(uint8_t x, uint8_t y) const
 #ifdef F_VERBOSE
     if (x >= COLUMNS || y >= ROWS)
     {
-        Serial.print(name);
-        Serial.print(": overflow ");
-        Serial.print(x);
-        Serial.print(":");
-        Serial.println(y);
+        Serial.printf("%s: invalid %d:%d\n", name, x, y);
     }
 #endif
     return frameDraft[x + y * COLUMNS];
@@ -274,11 +262,7 @@ void DisplayService::setPixel(uint8_t x, uint8_t y, uint8_t brightness)
 #ifdef F_VERBOSE
     if (x >= COLUMNS || y >= ROWS)
     {
-        Serial.print(name);
-        Serial.print(": overflow ");
-        Serial.print(x);
-        Serial.print(":");
-        Serial.println(y);
+        Serial.printf("%s: invalid %d:%d\n", name, x, y);
     }
 #endif
     frameDraft[x + y * COLUMNS] = brightness;

--- a/firmware/src/services/ExtensionsService.cpp
+++ b/firmware/src/services/ExtensionsService.cpp
@@ -10,8 +10,7 @@ void ExtensionsService::setup()
         extension->setup();
     }
 #ifdef F_VERBOSE
-    Serial.print(name);
-    Serial.println(": setup complete");
+    Serial.printf("%s: setup complete\n", name);
 #endif
 }
 

--- a/firmware/src/services/ModesService.cpp
+++ b/firmware/src/services/ModesService.cpp
@@ -194,8 +194,7 @@ void ModesService::setup()
         mode->setup();
     }
 #ifdef F_VERBOSE
-    Serial.print(name);
-    Serial.println(": setup complete");
+    Serial.printf("%s: setup complete\n", name);
 #endif
 }
 
@@ -242,16 +241,14 @@ void ModesService::set(bool enable, const char *const source)
     if (enable && taskHandle && eTaskGetState(taskHandle) == eTaskState::eSuspended)
     {
 #ifdef F_DEBUG
-        Serial.print(source);
-        Serial.println(": resuming mode");
+        Serial.printf("%s: resuming mode\n", source);
 #endif
         vTaskResume(taskHandle);
     }
     else if (!enable && taskHandle && eTaskGetState(taskHandle) != eTaskState::eSuspended)
     {
 #ifdef F_DEBUG
-        Serial.print(source);
-        Serial.println(": suspending mode");
+        Serial.printf("%s: suspending mode\n", source);
 #endif
         vTaskSuspend(taskHandle);
     }
@@ -279,9 +276,7 @@ void ModesService::set(ModeModule *mode)
     teardown();
     active = mode;
 #ifdef F_INFO
-    Serial.print(name);
-    Serial.print(": ");
-    Serial.println(active->name);
+    Serial.printf("%s: %s\n", name, active->name);
 #endif
 
     Preferences Storage;
@@ -300,8 +295,7 @@ void ModesService::splash()
     if (!Display.getPower())
     {
 #ifdef F_INFO
-        Serial.print(name);
-        Serial.println(": power");
+        Serial.printf("%s: power\n", name);
 #endif
         Display.setPower(true);
     }

--- a/firmware/src/services/NetworkService.cpp
+++ b/firmware/src/services/NetworkService.cpp
@@ -32,8 +32,7 @@ void NetworkService::setup()
 #endif // defined(PIN_SW1) || defined(PIN_SW2)
     {
 #ifdef F_VERBOSE
-        Serial.print(name);
-        Serial.println(": initializing Wi-Fi hotspot");
+        Serial.printf("%s: initializing Wi-Fi hotspot\n", name);
 #endif // F_VERBOSE
         hotspot();
     }
@@ -185,9 +184,7 @@ bool NetworkService::vault()
         Storage.putString(ssidKey.c_str(), item.first.c_str());
         Storage.putString(keyKey.c_str(), item.second.c_str());
 #ifdef F_DEBUG
-        Serial.print(name);
-        Serial.print(": SSID ");
-        Serial.println(item.first.c_str());
+        Serial.printf("%s: SSID %s\n", name, item.first.c_str());
 #endif // F_DEBUG
         multi->addAP(item.first.c_str(), item.second.empty() ? nullptr : item.second.c_str());
         ++i;
@@ -228,30 +225,22 @@ void NetworkService::hotspot()
     }
 #ifdef F_INFO
 #ifdef WIFI_SSID_HOTSPOT
-    Serial.print(name);
-    Serial.print(": hotspot SSID " WIFI_SSID_HOTSPOT);
+    Serial.printf("%s: hotspot SSID " WIFI_SSID_HOTSPOT "\n", name);
 #else
-    Serial.print(name);
-    Serial.print(": hotspot SSID " NAME);
+    Serial.printf("%s: hotspot SSID " NAME "\n", name);
 #endif // WIFI_SSID_HOTSPOT
 #endif // F_INFO
 #if defined(WIFI_KEY_HOTSPOT) && defined(F_VERBOSE)
-    Serial.print(name);
-    Serial.println(": hotspot key " WIFI_KEY_HOTSPOT);
+    Serial.printf("%s: hotspot key " WIFI_KEY_HOTSPOT "\n", name);
 #endif
 #if EXTENSION_WEBAPP && defined(F_DEBUG)
-    Serial.print(name);
-    Serial.print(": user interface @ http://");
-    Serial.print(WiFi.softAPIP().toString());
-    String url = "/#/";
-    url += name;
-    url.toLowerCase();
-    Serial.println(url);
+    String _name = name;
+    _name.toLowerCase();
+    Serial.printf("%s: user interface @ http://%s/#/%s\n", name, WiFi.softAPIP().toString(), _name.c_str());
 #endif // EXTENSION_WEBAPP && defined(F_DEBUG)
-#ifdef MONITOR_SPEED
-    Serial.print(name);
-    Serial.println(": awaiting Wi-Fi config, please connect to the Wi-Fi hotspot...");
-#endif // MONITOR_SPEED
+#ifdef F_INFO
+    Serial.printf("%s: awaiting Wi-Fi config, please connect to the Wi-Fi hotspot...\n", name);
+#endif // F_INFO
 }
 
 void NetworkService::scan()
@@ -261,8 +250,7 @@ void NetworkService::scan()
     {
     case WIFI_SCAN_FAILED:
 #ifdef F_DEBUG
-        Serial.print(name);
-        Serial.println(": scanning for Wi-Fi networks...");
+        Serial.printf("%s: scanning for Wi-Fi networks...\n", name);
 #endif // F_DEBUG
 #ifdef F_DEBUG
         WiFi.scanNetworks(true, true);
@@ -272,8 +260,7 @@ void NetworkService::scan()
         return;
     case WIFI_SCAN_RUNNING:
 #ifdef F_VERBOSE
-        Serial.print(name);
-        Serial.println(": scan ongoing...");
+        Serial.printf("%s: scan ongoing...\n", name);
 #endif // F_VERBOSE
         return;
     }
@@ -308,9 +295,7 @@ void NetworkService::connect(const char *const ssid, const char *const key)
         WiFi.mode(wifi_mode_t::WIFI_MODE_APSTA);
     }
 #ifdef F_DEBUG
-    Serial.print(name);
-    Serial.print(": SSID ");
-    Serial.println(ssid);
+    Serial.printf("%s: SSID %s\n", name, ssid);
 #endif // F_DEBUG
     WiFi.begin(ssid, key);
     if (WiFi.waitForConnectResult() == wl_status_t::WL_CONNECTED)
@@ -321,8 +306,7 @@ void NetworkService::connect(const char *const ssid, const char *const key)
 #ifdef F_DEBUG
         if (WiFi.getMode() != wifi_mode_t::WIFI_MODE_STA)
         {
-            Serial.print(name);
-            Serial.println(": shutting down Wi-Fi hotspot");
+            Serial.printf("%s: terminating Wi-Fi hotspot\n", name);
         }
 #endif // F_DEBUG
         WiFi.mode(wifi_mode_t::WIFI_MODE_STA);
@@ -366,8 +350,7 @@ void NetworkService::setDns()
 #ifdef F_DEBUG
         if (!esp_netif_set_dns_info(netif, esp_netif_dns_type_t::ESP_NETIF_DNS_MAIN, &dns))
         {
-            Serial.print(name);
-            Serial.println(": DNS " DNS1);
+            Serial.printf("%s: DNS " DNS1 "\n", name);
         }
 #else
         esp_netif_set_dns_info(netif, esp_netif_dns_type_t::ESP_NETIF_DNS_MAIN, &dns);
@@ -383,8 +366,7 @@ void NetworkService::setDns()
 #ifdef F_DEBUG
         if (!esp_netif_set_dns_info(netif, esp_netif_dns_type_t::ESP_NETIF_DNS_BACKUP, &dns))
         {
-            Serial.print(name);
-            Serial.println(": DNS " DNS2);
+            Serial.printf("%s: DNS " DNS2 "\n", name);
         }
 #else
         esp_netif_set_dns_info(netif, esp_netif_dns_type_t::ESP_NETIF_DNS_BACKUP, &dns);
@@ -400,8 +382,7 @@ void NetworkService::setDns()
 #ifdef F_DEBUG
         if (!esp_netif_set_dns_info(netif, esp_netif_dns_type_t::ESP_NETIF_DNS_FALLBACK, &dns))
         {
-            Serial.print(name);
-            Serial.println(": DNS " DNS3);
+            Serial.printf("%s: DNS " DNS3 "\n", name);
         }
 #else
         esp_netif_set_dns_info(netif, esp_netif_dns_type_t::ESP_NETIF_DNS_FALLBACK, &dns);
@@ -413,21 +394,13 @@ void NetworkService::setDns()
 
 void NetworkService::onConnected(WiFiEvent_t event, WiFiEventInfo_t info)
 {
-#ifdef F_INFO
-    Serial.print(Network.name);
-    Serial.println(": connected");
-#endif
-
-#ifdef F_DEBUG
-    Serial.print(Network.name);
-    Serial.print(": ");
 #ifdef F_VERBOSE
-    Serial.print(WiFi.SSID());
-    Serial.print(" @ ");
+    Serial.printf("%s: connected, %d dBm @ %s\n", Network.name, WiFi.RSSI(), WiFi.SSID().c_str());
+#elif defined(F_DEBUG)
+    Serial.printf("%s: connected, %d dBm\n", Network.name, WiFi.RSSI());
+#elif defined(F_INFO)
+    Serial.printf("%s: connected\n", Network.name);
 #endif // F_VERBOSE
-    Serial.print(WiFi.RSSI());
-    Serial.println(" dBm");
-#endif // F_DEBUG
     String _ipv4 = WiFi.localIP().toString();
     String _ipv6 = WiFi.localIPv6().toString();
     if (Network.IPv4 != _ipv4 || Network.IPv6 != _ipv6)
@@ -440,22 +413,15 @@ void NetworkService::onConnected(WiFiEvent_t event, WiFiEventInfo_t info)
 #ifdef F_INFO
         if (Network.IPv4 != IPAddress().toString())
         {
-            Serial.print(Network.name);
-            Serial.print(": IPv4 ");
-            Serial.println(Network.IPv4);
+            Serial.printf("%s: IPv4 %s\n", Network.name, Network.IPv4.c_str());
         }
         if (Network.IPv6 != IPv6Address().toString())
         {
-            Serial.print(Network.name);
-            Serial.print(": IPv6 ");
-            Serial.println(Network.IPv6);
+            Serial.printf("%s: IPv6 %s\n", Network.name, Network.IPv6.c_str());
         }
 #endif // F_INFO
 #ifdef F_INFO
-        Serial.print(Network.name);
-        Serial.print(": domain ");
-        Serial.write(domain.data(), domain.size());
-        Serial.println();
+        Serial.printf("%s: domain %s\n", Network.name, domain.data());
 #endif // F_INFO
     }
 #if defined(DNS1) || defined(DNS2) || defined(DNS3)
@@ -470,12 +436,9 @@ void NetworkService::onDisconnected(WiFiEvent_t event, WiFiEventInfo_t info)
 {
     Network.lastMillis = millis();
 #ifdef F_DEBUG
-    Serial.print(Network.name);
-    Serial.print(": disconnected, ");
-    Serial.println(WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason)));
+    Serial.printf("%s: disconnected, %s\n", Network.name, WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason)));
 #elif defined(F_INFO)
-    Serial.print(Network.name);
-    Serial.println(": disconnected");
+    Serial.printf("%s: disconnected\n", Network.name);
 #endif // F_DEBUG
     WiFi.reconnect();
 }

--- a/firmware/src/services/WebServerService.cpp
+++ b/firmware/src/services/WebServerService.cpp
@@ -31,20 +31,15 @@ void WebServerService::onNotFound(AsyncWebServerRequest *request)
     if (WiFi.getMode() == wifi_mode_t::WIFI_MODE_AP)
     {
 #ifdef F_VERBOSE
-        Serial.print(WebServer.name);
-        Serial.println(": redirecting");
-#endif
+        Serial.printf("%s: redirecting\n", WebServer.name);
+#endif // F_VERBOSE
         request->redirect("http://" + WiFi.softAPIP().toString(), t_http_codes::HTTP_CODE_FOUND);
     }
     else
     {
 #ifdef F_VERBOSE
-        Serial.print(WebServer.name);
-        Serial.print(": HTTP 404, ");
-        Serial.print(request->methodToString());
-        Serial.print(" ");
-        Serial.println(request->url());
-#endif
+        Serial.printf("%s: HTTP 404, %s %s\n", WebServer.name, request->methodToString(), request->url());
+#endif // F_VERBOSE
         request->send(t_http_codes::HTTP_CODE_NOT_FOUND);
     }
 }


### PR DESCRIPTION
### Summary

This PR refactors several `Serial.print()` / `Serial.println()` sequences into single `Serial.printf()` calls.

### Motivation

Previously, multi-line output was constructed using multiple `Serial.print()` / `Serial.println()` statements. This increases the risk of fragmented or interleaved output if other code writes to the serial interface concurrently.

### Changes

* Replaced grouped `Serial.print()` / `Serial.println()` statements with `Serial.printf()`.
* Reduced code verbosity and improved output atomicity.

### Benefits

* Cleaner and more concise code.
* Reduced risk of fragmented serial output in concurrent environments.
* Potentially more efficient execution (minor).