### PR TITLE
Fix Home Assistant offline detection

### DIFF
--- a/firmware/src/extensions/HomeAssistantExtension.cpp
+++ b/firmware/src/extensions/HomeAssistantExtension.cpp
@@ -63,7 +63,11 @@ void HomeAssistantExtension::setup()
 
 void HomeAssistantExtension::ready()
 {
-    (*discovery)[Abbreviations::availability][Abbreviations::topic] = "frekvens/" HOSTNAME "/availability";
+    {
+        JsonObject availability = (*discovery)[Abbreviations::availability].to<JsonObject>();
+        availability[Abbreviations::payload_not_available] = "";
+        availability[Abbreviations::topic] = "frekvens/" HOSTNAME "/availability";
+    }
     {
         JsonObject device = (*discovery)[Abbreviations::device].to<JsonObject>();
 #if EXTENSION_WEBAPP

--- a/firmware/src/extensions/MqttExtension.cpp
+++ b/firmware/src/extensions/MqttExtension.cpp
@@ -74,7 +74,7 @@ void MqttExtension::disconnect()
     lastMillis = millis();
     if (client.connected())
     {
-        client.publish("frekvens/" HOSTNAME "/availability", 1, true, "offline");
+        client.publish("frekvens/" HOSTNAME "/availability", 1, true, reinterpret_cast<const uint8_t *>(""), 0);
         client.loop();
         client.disconnect();
     }


### PR DESCRIPTION
### Summary
This PR corrects the MQTT availability handling used for Home Assistant integration.

### Problem
Due to a bug in how the availability message was configured, Home Assistant incorrectly assumed the device was online even when it was offline. This caused misleading device states in the UI and automations.

### Fix
* Updated the MQTT discovery payload to properly define `payload_not_available`.

* Ensures Home Assistant accurately reflects the device's online/offline state.

### Impact
Improves integration reliability and ensures Home Assistant can properly track the device's availability status.