### PR TITLE
Fix mDNS reinitialization and OTA-related setup conflict

### DIFF
--- a/firmware/src/extensions/OtaExtension.cpp
+++ b/firmware/src/extensions/OtaExtension.cpp
@@ -24,6 +24,7 @@ OtaExtension::OtaExtension() : ExtensionModule("OTA")
 void OtaExtension::setup()
 {
     ArduinoOTA.setHostname(HOSTNAME);
+    ArduinoOTA.setMdnsEnabled(false);
 
 #ifdef OTA_KEY_HASH
     ArduinoOTA.setPasswordHash(OTA_KEY_HASH);

--- a/firmware/src/services/NetworkService.cpp
+++ b/firmware/src/services/NetworkService.cpp
@@ -401,15 +401,28 @@ void NetworkService::onConnected(WiFiEvent_t event, WiFiEventInfo_t info)
 #elif defined(F_INFO)
     Serial.printf("%s: connected\n", Network.name);
 #endif // F_VERBOSE
+    if (!Network.mDNS)
+    {
+        Network.mDNS = MDNS.begin(HOSTNAME);
+        if (Network.mDNS)
+        {
+            MDNS.setInstanceName(NAME);
+#if EXTENSION_WEBAPP
+            MDNS.addService("http", "tcp", 80);
+#endif // EXTENSION_WEBAPP
+#if EXTENSION_OTA && (defined(OTA_KEY_HASH) || defined(OTA_KEY))
+            MDNS.enableArduino(3232, true);
+#elif EXTENSION_OTA
+            MDNS.enableArduino(3232, false);
+#endif // EXTENSION_OTA && (defined(OTA_KEY_HASH) || defined(OTA_KEY))
+        }
+    }
     String _ipv4 = WiFi.localIP().toString();
     String _ipv6 = WiFi.localIPv6().toString();
     if (Network.IPv4 != _ipv4 || Network.IPv6 != _ipv6)
     {
         Network.IPv4 = _ipv4;
         Network.IPv6 = _ipv6;
-        MDNS.begin(HOSTNAME);
-        MDNS.setInstanceName(NAME);
-        MDNS.addService("http", "tcp", 80);
 #ifdef F_INFO
         if (Network.IPv4 != IPAddress().toString())
         {


### PR DESCRIPTION
### Summary
This PR resolves issues related to mDNS setup during Wi-Fi reconnects and improves compatibility with the OTA update extension.

### Issues Addressed
* Prevents repeated mDNS setup attempts on Wi-Fi reconnection, which previously triggered terminal warnings.

* Fixes a possible bug where mDNS setup could fail if the OTA update extension was initialized and Wi-Fi disconnected.

### Changes
* Added a check to ensure mDNS is only initialized once.

* Improved resilience of mDNS setup logic when used alongside OTA features.

### Impact
Eliminates spurious terminal warnings and improves the stability of network service discovery, particularly in setups with OTA updates and fluctuating Wi-Fi connectivity.