### PR TITLE
Refactor WebSocket to send initial messages directly to connecting client

### DIFF
--- a/firmware/include/extensions/WebSocketExtension.h
+++ b/firmware/include/extensions/WebSocketExtension.h
@@ -11,14 +11,12 @@
 class WebSocketExtension : public ExtensionModule
 {
 private:
-    bool pending = false;
-
     static void onEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventType type, void *arg, uint8_t *data, size_t len);
 
 public:
     WebSocketExtension();
 
-    AsyncWebSocket *server = new AsyncWebSocket("/ws");
+    AsyncWebSocket *ws = new AsyncWebSocket("/ws");
 
     void ready() override;
     void handle() override;

--- a/firmware/src/extensions/WebSocketExtension.cpp
+++ b/firmware/src/extensions/WebSocketExtension.cpp
@@ -15,26 +15,13 @@ WebSocketExtension::WebSocketExtension() : ExtensionModule("WebSocket")
 
 void WebSocketExtension::ready()
 {
-    server->onEvent(&onEvent);
-    WebServer.http->addHandler(server);
+    ws->onEvent(&onEvent);
+    WebServer.http->addHandler(ws);
 }
 
 void WebSocketExtension::handle()
 {
-    if (pending)
-    {
-        pending = false;
-        const JsonDocument doc = Device.getTransmits();
-        const size_t length = measureJson(doc);
-        char *payload = new char[length + 1];
-        serializeJson(doc, payload, length + 1);
-        server->textAll(payload);
-        delete[] payload;
-    }
-    else
-    {
-        server->cleanupClients();
-    }
+    ws->cleanupClients();
 }
 
 void WebSocketExtension::transmitterHook(const JsonDocument &doc, const char *const source)
@@ -44,37 +31,50 @@ void WebSocketExtension::transmitterHook(const JsonDocument &doc, const char *co
     const size_t length = measureJson(_doc);
     char *payload = new char[length + 1];
     serializeJson(_doc, payload, length + 1);
-    server->textAll(payload);
+    ws->textAll(payload, length);
     delete[] payload;
 }
 
 void WebSocketExtension::onEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventType type, void *arg, uint8_t *data, size_t len)
 {
-    AwsFrameInfo *info = (AwsFrameInfo *)arg;
-    if (type == AwsEventType::WS_EVT_DATA && info->opcode == AwsFrameType::WS_TEXT)
+    switch (type)
     {
+    case AwsEventType::WS_EVT_CONNECT:
+    {
+        const JsonDocument doc = Device.getTransmits();
+        const size_t length = measureJson(doc);
+        char *payload = new char[length + 1];
+        serializeJson(doc, payload, length + 1);
+        client->text(payload, length);
+        delete[] payload;
+    }
+    break;
+    case AwsEventType::WS_EVT_DATA:
+    {
+        AwsFrameInfo *info = (AwsFrameInfo *)arg;
+        if (info->opcode == AwsFrameType::WS_TEXT)
+        {
 #ifdef F_DEBUG
-        if (len < info->len)
-        {
-                Serial.printf("%s: chunked messages is currently not supported\n", WebSocket->name);
-            return;
-        }
-#endif
-        JsonDocument doc;
-        if (!deserializeJson(doc, data, len) && doc.is<JsonObjectConst>())
-        {
-            for (const JsonPairConst pair : doc.as<JsonObjectConst>())
+            if (len < info->len)
             {
-                if (pair.value().is<JsonObjectConst>())
+                Serial.printf("%s: chunked messages is currently not supported\n", WebSocket->name);
+                return;
+            }
+#endif
+            JsonDocument doc;
+            if (!deserializeJson(doc, data, len) && doc.is<JsonObjectConst>())
+            {
+                for (const JsonPairConst pair : doc.as<JsonObjectConst>())
                 {
-                    Device.receive(pair.value(), WebSocket->name, pair.key().c_str());
+                    if (pair.value().is<JsonObjectConst>())
+                    {
+                        Device.receive(pair.value(), WebSocket->name, pair.key().c_str());
+                    }
                 }
             }
         }
     }
-    else if (type == AwsEventType::WS_EVT_CONNECT)
-    {
-        WebSocket->pending = true;
+    break;
     }
 }
 

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -398,7 +398,7 @@ void DeviceService::power(bool state)
     Mqtt->disconnect();
 #endif
 #if EXTENSION_WEBSOCKET
-    WebSocket->server->closeAll();
+    WebSocket->ws->closeAll();
 #endif
     WiFi.disconnect(true);
     state ? ESP.restart() : esp_deep_sleep_start();


### PR DESCRIPTION
### Summary
This PR updates the WebSocket handling logic to improve message targeting during client connections.

### Changes
* Replaces broadcast-based approach with direct messaging to the newly connected client.

* Ensures only the intended recipient receives initialization or state sync messages on connect.

### Motivation
Previously, messages sent on client connect were broadcast to all connected clients, which could result in unnecessary traffic and redundant updates. This refactor improves efficiency and clarity by addressing only the new connection.

### Impact
* More efficient WebSocket communication.

* Reduced risk of race conditions or unintended message duplication across clients.