### PR TITLE
Move diagnostics output behind F_VERBOSE flag

### DIFF
--- a/firmware/include/services/ExtensionsService.h
+++ b/firmware/include/services/ExtensionsService.h
@@ -92,7 +92,11 @@ public:
 
     void setup();
     void ready();
+
+#ifdef F_VERBOSE
     void handle();
+#endif
+
     const std::vector<ExtensionModule *> &getAll() const;
 
     static ExtensionsService &getInstance();

--- a/firmware/include/services/ModesService.h
+++ b/firmware/include/services/ModesService.h
@@ -201,9 +201,11 @@ private:
 
     bool pending = false;
 
-    unsigned long
-        lastMillis = 0,
-        _lastMillis = 0;
+    unsigned long lastMillis = 0;
+
+#ifdef F_VERBOSE
+    unsigned long _lastMillis = 0;
+#endif
 
 #ifdef TASK_STACK_MODES
     static constexpr uint16_t stackSize = TASK_STACK_MODES;

--- a/firmware/include/services/WebServerService.h
+++ b/firmware/include/services/WebServerService.h
@@ -10,7 +10,10 @@ class WebServerService : public ServiceModule
 {
 private:
     static void onOptionsCanonical(AsyncWebServerRequest *request);
+
+#if EXTENSION_WEBAPP || defined(F_VERBOSE)
     static void onNotFound(AsyncWebServerRequest *request);
+#endif // EXTENSION_WEBAPP || defined(F_VERBOSE)
 
 public:
     WebServerService() : ServiceModule("WebServer") {};

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -449,7 +449,9 @@ void DeviceService::transmit()
     doc["model"] = MODEL;
     doc["name"] = NAME;
     doc["releases_url"] = "https://github.com/VIPnytt/Frekvens/releases";
+#ifdef F_VERBOSE
     doc["stack"] = CONFIG_ARDUINO_LOOP_STACK_SIZE - uxTaskGetStackHighWaterMark(nullptr);
+#endif
     doc["temperature"] = temperatureRead();
     doc["version_current"] = VERSION;
     doc["version_available"] = latest.empty() ? VERSION : latest;

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -24,7 +24,7 @@ void DeviceService::init()
     Serial.begin(MONITOR_SPEED);
 #endif
 #ifdef F_VERBOSE
-    delay(1 << 11);
+    delay(1 << 10);
 #endif
 #ifdef F_INFO
     Serial.printf("%s: Frekvens " VERSION "\n", name);
@@ -208,6 +208,7 @@ void DeviceService::ready()
 #endif // EXTENSION_BUILD
 #if EXTENSION_HOMEASSISTANT
     const std::string topic = std::string("frekvens/" HOSTNAME "/").append(name);
+#ifdef F_VERBOSE
     {
         const std::string id = std::string(name).append("_heap");
         JsonObject component = (*HomeAssistant->discovery)[Abbreviations::components][id].to<JsonObject>();
@@ -226,6 +227,7 @@ void DeviceService::ready()
         component[Abbreviations::unit_of_measurement] = "kB";
         component[Abbreviations::value_template] = "{{value_json.heap/2**10}}";
     }
+#endif // F_VERBOSE
     {
         const std::string id = std::string(name).append("_identify");
         JsonObject component = (*HomeAssistant->discovery)[Abbreviations::components][id].to<JsonObject>();
@@ -267,6 +269,7 @@ void DeviceService::ready()
         component[Abbreviations::platform] = "button";
         component[Abbreviations::unique_id] = HomeAssistant->uniquePrefix + id;
     }
+#ifdef F_VERBOSE
     {
         const std::string id = std::string(name).append("_stack");
         JsonObject component = (*HomeAssistant->discovery)[Abbreviations::components][id].to<JsonObject>();
@@ -283,6 +286,7 @@ void DeviceService::ready()
         component[Abbreviations::unit_of_measurement] = "kB";
         component[Abbreviations::value_template] = "{{value_json.stack/2**10}}";
     }
+#endif // F_VERBOSE
     {
         const std::string id = std::string(name).append("_temperature");
         JsonObject component = (*HomeAssistant->discovery)[Abbreviations::components][id].to<JsonObject>();
@@ -336,7 +340,9 @@ void DeviceService::run()
 {
     Network.handle();
     Display.handle();
+#ifdef F_VERBOSE
     Extensions.handle();
+#endif
     Modes.handle();
     if (millis() - lastMillis > UINT16_MAX)
     {
@@ -437,7 +443,9 @@ void DeviceService::transmit()
 #ifdef BOARD_NAME
     doc["board"] = BOARD_NAME;
 #endif
+#ifdef F_VERBOSE
     doc["heap"] = ESP.getHeapSize() - ESP.getFreeHeap();
+#endif
     doc["model"] = MODEL;
     doc["name"] = NAME;
     doc["releases_url"] = "https://github.com/VIPnytt/Frekvens/releases";

--- a/firmware/src/services/ExtensionsService.cpp
+++ b/firmware/src/services/ExtensionsService.cpp
@@ -62,7 +62,7 @@ void ExtensionsService::ready()
     (*Build->config)[Config::h][__STRING(EXTENSION_WEBSOCKET)] = false;
 #endif
 
-#if EXTENSION_HOMEASSISTANT
+#if EXTENSION_HOMEASSISTANT && defined(F_VERBOSE)
     const std::string topic = std::string("frekvens/" HOSTNAME "/").append(name);
     {
         const std::string id = std::string(name).append("_stack");
@@ -80,7 +80,7 @@ void ExtensionsService::ready()
         component[Abbreviations::unit_of_measurement] = "kB";
         component[Abbreviations::value_template] = "{{value_json.stack/2**10 }}";
     }
-#endif // EXTENSION_HOMEASSISTANT
+#endif // EXTENSION_HOMEASSISTANT && defined(F_VERBOSE)
     for (ExtensionModule *extension : modules)
     {
         extension->ready();
@@ -89,6 +89,7 @@ void ExtensionsService::ready()
     transmit();
 }
 
+#ifdef F_VERBOSE
 void ExtensionsService::handle()
 {
     if (millis() - lastMillis > UINT16_MAX)
@@ -96,6 +97,7 @@ void ExtensionsService::handle()
         transmit();
     }
 }
+#endif // F_VERBOSE
 
 const std::vector<ExtensionModule *> &ExtensionsService::getAll() const
 {
@@ -111,7 +113,9 @@ void ExtensionsService::transmit()
         list.add(extension->name);
     }
     lastMillis = millis();
+#ifdef F_VERBOSE
     doc["stack"] = stackSize - uxTaskGetStackHighWaterMark(taskHandle);
+#endif
     Device.transmit(doc, name);
 }
 

--- a/firmware/src/services/ModesService.cpp
+++ b/firmware/src/services/ModesService.cpp
@@ -171,6 +171,7 @@ void ModesService::setup()
         component[Abbreviations::unique_id] = HomeAssistant->uniquePrefix + id;
         component[Abbreviations::value_template] = "{{value_json.mode}}";
     }
+#ifdef F_VERBOSE
     {
         const std::string id = std::string(name).append("_stack");
         JsonObject component = (*HomeAssistant->discovery)[Abbreviations::components][id].to<JsonObject>();
@@ -187,6 +188,7 @@ void ModesService::setup()
         component[Abbreviations::unit_of_measurement] = "kB";
         component[Abbreviations::value_template] = "{{value_json.stack/2**10}}";
     }
+#endif // F_VERBOSE
 #endif // EXTENSION_HOMEASSISTANT
 
     for (ModeModule *mode : modules)
@@ -230,10 +232,12 @@ void ModesService::handle()
         }
         pending = false;
     }
+#ifdef F_VERBOSE
     else if (active && Display.getPower() && millis() - _lastMillis > UINT16_MAX)
     {
         transmit();
     }
+#endif // F_VERBOSE
 }
 
 void ModesService::set(bool enable, const char *const source)
@@ -427,8 +431,10 @@ void ModesService::transmit()
     {
         doc["mode"] = active->name;
     }
+#ifdef F_VERBOSE
     doc["stack"] = stackSize - uxTaskGetStackHighWaterMark(taskHandle);
     _lastMillis = millis();
+#endif
     Device.transmit(doc, name);
 }
 

--- a/firmware/src/services/WebServerService.cpp
+++ b/firmware/src/services/WebServerService.cpp
@@ -7,7 +7,11 @@
 void WebServerService::setup()
 {
     http->on("/canonical", WebRequestMethod::HTTP_OPTIONS, &onOptionsCanonical);
+
+#if EXTENSION_WEBAPP
     http->onNotFound(&onNotFound);
+#endif // EXTENSION_WEBAPP
+
     http->begin();
 }
 
@@ -26,8 +30,10 @@ void WebServerService::onOptionsCanonical(AsyncWebServerRequest *request)
     }
 }
 
+#if EXTENSION_WEBAPP || defined(F_VERBOSE)
 void WebServerService::onNotFound(AsyncWebServerRequest *request)
 {
+#if EXTENSION_WEBAPP
     if (WiFi.getMode() == wifi_mode_t::WIFI_MODE_AP)
     {
 #ifdef F_VERBOSE
@@ -36,6 +42,7 @@ void WebServerService::onNotFound(AsyncWebServerRequest *request)
         request->redirect("http://" + WiFi.softAPIP().toString(), t_http_codes::HTTP_CODE_FOUND);
     }
     else
+#endif // EXTENSION_WEBAPP
     {
 #ifdef F_VERBOSE
         Serial.printf("%s: HTTP 404, %s %s\n", WebServer.name, request->methodToString(), request->url());
@@ -43,6 +50,7 @@ void WebServerService::onNotFound(AsyncWebServerRequest *request)
         request->send(t_http_codes::HTTP_CODE_NOT_FOUND);
     }
 }
+#endif // EXTENSION_WEBAPP || defined(F_VERBOSE)
 
 WebServerService &WebServerService::getInstance()
 {


### PR DESCRIPTION
### Summary
This PR relocates internal diagnostics features—such as ESP32 task stack size monitoring and heap usage tracking—behind the `F_VERBOSE` compilation flag.

### Changes
* Disabled runtime diagnostics by default for production builds.

* Diagnostics features (e.g., stack size and heap reporting) are now only active when `F_VERBOSE` is defined at compile time.

### Motivation
These diagnostics were introduced to assist during development and debugging. However, they are not relevant in production environments and can clutter the output or introduce unnecessary overhead.

### Impact
* Cleaner output in release builds.

* Developers can still enable detailed diagnostics as needed by defining `F_VERBOSE`.