### PR TITLE
Skip DNS3 lookup if not configured when reporting servers in debug mode

### DIFF
--- a/firmware/src/services/NetworkService.cpp
+++ b/firmware/src/services/NetworkService.cpp
@@ -470,7 +470,9 @@ void NetworkService::transmit()
     for (esp_netif_dns_type_t dnsType : {
              esp_netif_dns_type_t::ESP_NETIF_DNS_MAIN,
              esp_netif_dns_type_t::ESP_NETIF_DNS_BACKUP,
+#ifdef DNS3
              esp_netif_dns_type_t::ESP_NETIF_DNS_FALLBACK,
+#endif // DNS3
          })
     {
         String _dns = WiFi.dnsIP(dnsType).toString();


### PR DESCRIPTION
### Summary
This PR optimizes the debug-mode DNS server reporting by skipping the `DNS3` lookup when it has not been configured.

### Changes
* Added a check to bypass `DNS3` entirely if no address is defined.

* Avoids unnecessary loop iteration for unused DNS entries.

### Motivation
<!-- Explain the reasoning behind this change. What problem does it solve or what improvement does it bring? -->

### Impact
* Cleaner and more efficient debug API output.

* No change in behavior when DNS3 is configured and in use.