### PR TITLE
Ensure display is lit when OTA starts

### DIFF
--- a/firmware/src/extensions/OtaExtension.cpp
+++ b/firmware/src/extensions/OtaExtension.cpp
@@ -76,6 +76,7 @@ void OtaExtension::onStart()
     Display.clear();
     TextHandler("U", FontLarge).draw();
     Display.flush();
+    Display.setPower(true);
     timerAlarmWrite(Display.timer, 1000000U / (1U << 8), true); // 1 fps
 }
 


### PR DESCRIPTION
### Summary
This PR ensures that the display is turned on when an OTA update begins so the in-progress indicator is visible even if the display was previously off.

### Changes
* Added logic to automatically light the display at the start of an OTA update.

* Guarantees that the OTA status indicator is always visible to the user.

### Impact
* Improves user awareness of OTA progress.

* Prevents situations where an OTA is running without visible indication due to the display being off.