### PR TITLE
Refactor abnormality preventive measures to target only risky operations

### DIFF
--- a/firmware/src/extensions/PlaylistExtension.cpp
+++ b/firmware/src/extensions/PlaylistExtension.cpp
@@ -63,9 +63,27 @@ void PlaylistExtension::setup()
 
 void PlaylistExtension::ready()
 {
+    bool _active = false;
     Preferences Storage;
-    Storage.begin(name, true);
-    bool _active = Storage.isKey("active") && Storage.getBool("active");
+    Storage.begin(name);
+    switch (esp_reset_reason())
+    {
+    case esp_reset_reason_t::ESP_RST_BROWNOUT:
+    case esp_reset_reason_t::ESP_RST_INT_WDT:
+    case esp_reset_reason_t::ESP_RST_PANIC:
+    case esp_reset_reason_t::ESP_RST_TASK_WDT:
+    case esp_reset_reason_t::ESP_RST_WDT:
+        if (Storage.isKey("active"))
+        {
+            Storage.remove("active");
+        }
+        break;
+    default:
+        if (Storage.isKey("active") && Storage.getBool("active"))
+        {
+            _active = true;
+        }
+    }
     Storage.end();
     _active ? set(_active) : transmit();
 }

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -100,28 +100,6 @@ void DeviceService::init()
 
 void DeviceService::ready()
 {
-    Preferences Storage;
-    switch (esp_reset_reason())
-    {
-    case esp_reset_reason_t::ESP_RST_BROWNOUT:
-    case esp_reset_reason_t::ESP_RST_INT_WDT:
-    case esp_reset_reason_t::ESP_RST_PANIC:
-    case esp_reset_reason_t::ESP_RST_TASK_WDT:
-    case esp_reset_reason_t::ESP_RST_WDT:
-        for (const char *const _name : getNames())
-        {
-            Storage.begin(std::string(_name).substr(0, NVS_KEY_NAME_MAX_SIZE - 1).c_str());
-            if (Storage.isKey("active"))
-            {
-#ifdef F_DEBUG
-                Serial.printf("%s: resetting %s\n", name, _name);
-#endif
-                Storage.remove("active");
-            }
-            Storage.end();
-        }
-        break;
-    }
 #if EXTENSION_BUILD
     (*Build->config)[Config::env][ENV] = "";
     (*Build->config)[Config::env][__STRING(NAME)] = NAME;


### PR DESCRIPTION
### Summary
This PR refines the system’s abnormality preventive measures, which are triggered after resets caused by brownouts, watchdog timeouts, or crashes. Instead of applying restrictions globally, these measures now only affect operations that carry a higher risk of causing repeated failures.

### Changes
* Limited preventive restrictions to:

  * Display mode selection

  * Activation of the playlist extension

* Removed unnecessary safeguards from low-risk operations.

* Maintained existing reset detection logic for brownout, watchdog, and crash events.

### Impact
* Reduces unnecessary operational limitations after abnormal resets.

* Maintains protection against reboot loops for high-risk functions.

* Slightly improves normal usability after recovery from an abnormal reset.