### PR TITLE
Add display orientation control via Home Assistant

### DIFF
--- a/firmware/include/services/DisplayService.h
+++ b/firmware/include/services/DisplayService.h
@@ -59,10 +59,7 @@ public:
     hw_timer_t *timer;
 
     void setup();
-
-#if EXTENSION_BUILD
     void ready();
-#endif
 
     void handle();
 


### PR DESCRIPTION
### Summary
This PR introduces support for changing the display’s orientation through Home Assistant integration.

### Changes
* Added a Home Assistant–exposed control to adjust display orientation.

* Updated MQTT discovery and handling logic to process orientation change commands.

### Impact
* Users can now rotate or flip the display remotely via Home Assistant.

* Enhances flexibility for different mounting positions and use cases.