### PR TITLE
Improve Wi-Fi connect form placeholder text for clarity

### DIFF
--- a/webapp/src/services/Network.tsx
+++ b/webapp/src/services/Network.tsx
@@ -102,7 +102,7 @@ export const MainThird: Component = () => {
                             oninput={(e) =>
                                 setKeyNew(e.currentTarget.value)
                             }
-                            placeholder={!getSsidNew() && getSsid() ? 'Redacted' : 'Secret'}
+                            placeholder={!getSsidNew() && getSsid() ? '********' : 'Password'}
                             type="password"
                         />
                     </div>


### PR DESCRIPTION
### Summary
This PR updates the placeholder text in the "Key" field of the Wi-Fi connect form in the web app to make it more intuitive and user-friendly.

### Changes
* When connected to Wi-Fi: Display `********` as the placeholder to indicate a saved password exists.

* When connecting to a new Wi-Fi network: Display `Password` as the placeholder to clarify that the "Key" field is where the Wi-Fi password should be entered.

Removed ambiguous technical terms (`Redacted` and `Secret`) that could confuse non-technical users.

### Benefits
* Improves clarity for users unfamiliar with terms like "Wi-Fi encryption key".

* Reduces potential confusion for users expecting a simple password field.

* Keeps UI consistent with common password field behavior in other applications.