### PR TITLE
Add "Restore to Factory Defaults" API Action

### DIFF
--- a/docs/wiki/Services.md
+++ b/docs/wiki/Services.md
@@ -63,6 +63,23 @@ API payload example:
 }
 ```
 
+**Restore:**
+
+Performs a full reset of the device’s non-volatile storage (NVS), clearing all user preferences, settings, and Wi-Fi credentials.
+This is functionally equivalent to a "factory reset" for this customized device.
+
+After the NVS partition is erased, the device will shut down automatically.
+
+API payload example:
+
+```json
+{
+    "action": "restore"
+}
+```
+
+> **Note:** A manual power cycle is required to restart the device.
+
 ## 📺 Display
 
 **Frame rate:**

--- a/firmware/include/services/DeviceService.h
+++ b/firmware/include/services/DeviceService.h
@@ -30,6 +30,7 @@ public:
 
     void identify();
     void power(bool state);
+    void restore();
     void update();
 
     void transmit(JsonDocument doc, const char *const source, bool retain = true);


### PR DESCRIPTION
### Summary
Added API support for restoring the device to "factory" defaults. The new `restore` action fully erases the non-volatile storage (NVS), removing all user preferences, settings, and Wi-Fi credentials.

### Changes
* Implemented restore API action.

* Erases the NVS partition, clearing all stored data.

* Updated documentation with usage instructions and example payload.

### Impact
Allows users to reset their customized device to a clean, out-of-box state without manual flashing or reconfiguration. Useful for troubleshooting, preparing a device for a new owner, or starting from scratch.