### PR TITLE
Streamline Playlist Creation by Merging Save and Play Actions

### DIFF
--- a/firmware/src/extensions/PlaylistExtension.cpp
+++ b/firmware/src/extensions/PlaylistExtension.cpp
@@ -176,11 +176,6 @@ void PlaylistExtension::transmitterHook(const JsonDocument &doc, const char *con
 
 void PlaylistExtension::receiverHook(const JsonDocument doc)
 {
-    // Active
-    if (doc["active"].is<bool>())
-    {
-        set(doc["active"].as<bool>());
-    }
     // Playlist
     if (doc["playlist"].is<JsonArrayConst>())
     {
@@ -196,6 +191,11 @@ void PlaylistExtension::receiverHook(const JsonDocument doc)
             }
         }
         load(_playlist);
+    }
+    // Active
+    if (doc["active"].is<bool>())
+    {
+        set(doc["active"].as<bool>());
     }
 }
 


### PR DESCRIPTION
### Summary
Improves the Playlist creation user interface in the Playlist web app by streamlining the save and play actions into a single step.

### Changes
* Merged the *Save* and *Play* buttons into one workflow.

* Pressing *Play* now automatically saves any changes made to the playlist before playback begins.

* Removes the previous requirement to manually save before pressing play.

### Impact
* Simplifies user workflow and reduces the number of clicks needed.

* Makes the playlist editing and playback process more intuitive for end-users.