### PR TITLE
Add Release Notes for Available Updates

### DIFF
--- a/firmware/include/services/DeviceService.h
+++ b/firmware/include/services/DeviceService.h
@@ -31,7 +31,9 @@ private:
     const char *reset = nullptr;
 #endif
 
-    std::string latest = "";
+    std::string
+        releaseNotes = "",
+        versionLatest = "";
 
     JsonDocument transmits;
 

--- a/webapp/src/services/Device.tsx
+++ b/webapp/src/services/Device.tsx
@@ -25,7 +25,7 @@ export const receiver = (json: any) => {
     json[name]?.event !== undefined && event(json[name].event);
     json[name]?.model !== undefined && setModel(json[name].model);
     json[name]?.name !== undefined && setName(json[name].name);
-    json[name]?.version_available !== undefined && setVersionLatest(json[name].version_available);
+    json[name]?.version_latest !== undefined && setVersionLatest(json[name].version_latest);
 };
 
 createEffect(() => {


### PR DESCRIPTION
### Summary
This PR makes release notes for available updates accessible both programmatically and via Home Assistant’s Update entity.

### Changes
* API:

  * Added endpoint support to retrieve release notes for available updates.

* Home Assistant:

  * Integrated release notes display into the Update entity for improved visibility.

### Impact
* Users can view update details directly in Home Assistant without leaving the interface.

* Improves transparency and decision-making before performing updates.