### PR TITLE
Show hotspot Wi-Fi config on main page & fix redirect loop

### DIFF
--- a/firmware/src/services/NetworkService.cpp
+++ b/firmware/src/services/NetworkService.cpp
@@ -234,9 +234,7 @@ void NetworkService::hotspot()
     Serial.printf("%s: hotspot key " WIFI_KEY_HOTSPOT "\n", name);
 #endif
 #if EXTENSION_WEBAPP && defined(F_DEBUG)
-    String _name = name;
-    _name.toLowerCase();
-    Serial.printf("%s: user interface @ http://%s/#/%s\n", name, WiFi.softAPIP().toString(), _name.c_str());
+    Serial.printf("%s: user interface @ http://%s\n", name, WiFi.softAPIP().toString());
 #endif // EXTENSION_WEBAPP && defined(F_DEBUG)
 #ifdef F_INFO
     Serial.printf("%s: awaiting Wi-Fi config, please connect to the Wi-Fi hotspot...\n", name);

--- a/firmware/src/services/WebServerService.cpp
+++ b/firmware/src/services/WebServerService.cpp
@@ -34,7 +34,7 @@ void WebServerService::onOptionsCanonical(AsyncWebServerRequest *request)
 void WebServerService::onNotFound(AsyncWebServerRequest *request)
 {
 #if EXTENSION_WEBAPP
-    if (WiFi.getMode() == wifi_mode_t::WIFI_MODE_AP)
+    if (WiFi.getMode() == wifi_mode_t::WIFI_MODE_AP && request->host() != WiFi.softAPIP().toString() && request->host() != WiFi.softAPIPv6().toString())
     {
 #ifdef F_VERBOSE
         Serial.printf("%s: redirecting\n", WebServer.name);

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -28,7 +28,7 @@ createEffect(() => {
 
 const Page = () => (
     <div class="h-full">
-        {WebServerPath() == '/' ? (
+        {WebServerPath() == '/' && location.hostname != '192.168.4.1' && !location.hostname.startsWith('[fe80::') ? (
             <Primary />
         ) : (
             <Secondary />
@@ -80,7 +80,7 @@ const Secondary: Component = () => (
                 fallback={
                     <DeviceSecondary />
                 }>
-                <Match when={WebServerPath().startsWith(`/${NetworkName.toLowerCase()}`) || location.hostname.endsWith('.1') || location.hostname.startsWith('[fe80::')}>
+                <Match when={WebServerPath().startsWith(`/${NetworkName.toLowerCase()}`) || location.hostname == '192.168.4.1' || location.hostname.startsWith('[fe80::')}>
                     <NetworkThird />
                 </Match>
                 <Match when={WebServerPath().startsWith(`/${ExtensionsName.toLowerCase()}`)}>
@@ -103,7 +103,7 @@ const Secondary: Component = () => (
                             <NetworkSecondarySidebar />
                         </>
                     }>
-                    <Match when={WebServerPath().startsWith(`/${NetworkName.toLowerCase()}`) || location.hostname.endsWith('.1') || location.hostname.startsWith('[fe80::')}>
+                    <Match when={WebServerPath().startsWith(`/${NetworkName.toLowerCase()}`) || location.hostname == '192.168.4.1' || location.hostname.startsWith('[fe80::')}>
                         <NetworkThirdSidebar />
                     </Match>
                     <Match when={WebServerPath().startsWith(`/${ExtensionsName.toLowerCase()}`)}>


### PR DESCRIPTION
### Summary
This PR updates the web app to display Wi-Fi configuration details when connected via hotspot and resolves a bug causing a redirect loop in certain conditions.

### Changes
* Web app:

  * Added display of Wi-Fi configuration on the web app’s main landing page when connected via Wi-Fi hotspot.

* Firmware:

  * Resolved redirect loop occurring when the web app UI is missing (not uploaded) while connected via Wi-Fi hotspot.

### Impact
* Improves user experience by making Wi-Fi configuration more easily accessible.

* Prevents user lockout caused by unnecessary redirects in hotspot mode when the web app is not found (not uploaded).