### PR TITLE
Fix Cell Ratio on Rotated Display + Minor Optimizations

### DIFF
--- a/firmware/include/services/DisplayService.h
+++ b/firmware/include/services/DisplayService.h
@@ -12,7 +12,8 @@ class DisplayService : public ServiceModule
 private:
     DisplayService() : ServiceModule("Display") {};
 
-    enum Orientation {
+    enum Orientation
+    {
         deg0,
         deg90,
         deg180,
@@ -39,9 +40,13 @@ private:
         pending = false,
         power = false;
 
+#if COLUMNS == ROWS
     float
+#else
+    static constexpr float
+#endif
         cellRatio = CELL_WIDTH / (float)CELL_HEIGHT,
-        globalRatio = (COLUMNS * CELL_WIDTH) / (float)(ROWS * CELL_HEIGHT);
+        globalRatio = COLUMNS * CELL_WIDTH / (float)ROWS / (float)CELL_HEIGHT;
 
     uint8_t
         globalBrightness = UINT8_MAX,

--- a/firmware/src/modes/FireworkMode.cpp
+++ b/firmware/src/modes/FireworkMode.cpp
@@ -50,7 +50,7 @@ void FireworkMode::launching()
         if (rocketY <= random(ROWS / 2))
         {
             radius = 0;
-#if defined(CELL_HEIGHT) && defined(CELL_HEIGHT)
+#if defined(CELL_HEIGHT) && defined(CELL_WIDTH)
             maxRadius = random(min(COLUMNS * CELL_WIDTH / (float)CELL_HEIGHT, ROWS / (float)CELL_WIDTH * CELL_HEIGHT) / 2);
 #else
             maxRadius = random(min(COLUMNS, ROWS) / 2);

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -184,7 +184,10 @@ void DisplayService::setGlobalOrientation(Orientation orientation)
     }
     memcpy(pixelBitOrder, _pixelBitOrder, sizeof(_pixelBitOrder));
     globalOrientation = orientation;
-    globalRatio = globalOrientation % 2 ? 1 / ((COLUMNS * CELL_WIDTH) / (float)(ROWS * CELL_HEIGHT)) : (COLUMNS * CELL_WIDTH) / (ROWS * CELL_HEIGHT);
+#if COLUMNS == ROWS
+    globalRatio = globalOrientation % 2 ? ROWS * CELL_HEIGHT / (float)COLUMNS / (float)CELL_WIDTH : COLUMNS * CELL_WIDTH / (float)ROWS / (float)CELL_HEIGHT;
+    cellRatio = globalOrientation % 2 ? CELL_HEIGHT / (float)CELL_WIDTH : CELL_WIDTH / (float)CELL_HEIGHT;
+#endif // COLUMNS == ROWS
 
     Preferences Storage;
     Storage.begin(name);
@@ -344,8 +347,8 @@ void DisplayService::transmit()
     doc["pixel"]["rows"] = globalOrientation % 2 ? ROWS : COLUMNS;
 #endif // COLUMNS == ROWS
 #if CELL_WIDTH != CELL_HEIGHT
-    doc["pixel"]["ratio"] = PIXEL_SIZE / min(CELL_WIDTH, CELL_HEIGHT);
-#endif
+    doc["pixel"]["ratio"] = PIXEL_SIZE / (float)min(CELL_WIDTH, CELL_HEIGHT);
+#endif // CELL_WIDTH != CELL_HEIGHT
     doc["power"] = power;
     doc["ratio"] = globalRatio;
     Device.transmit(doc, name);


### PR DESCRIPTION
### Summary
Corrects the `Display.getCellRatio()` return value when the display is rotated 90° or 270°, ensuring accurate pixel aspect ratios in all orientations. Includes small optimizations for `Display.globalRatio()`.

### Changes
* Fixed incorrect pixel ratio in `Display.getCellRatio()` for 90° and 270° orientations.

* Applied micro-optimizations to `Display.globalRatio()` calculations.

### Rationale
* Prior to this change, rotated displays had incorrect pixel aspect ratios, which potentially could leading to visual distortion.

* Optimizations improve performance on a microscale level, without affecting functionality.

### Impact
* Correct display scaling for all orientations.

* Hypotetical performance improvement during rendering calculations.
