### PR TITLE
Debug Serial.printf() Format Fix

### DIFF
--- a/firmware/src/handlers/TextHandler.cpp
+++ b/firmware/src/handlers/TextHandler.cpp
@@ -68,7 +68,7 @@ TextHandler::TextHandler(String text, FontModule *font) : text(text), font(font)
 #ifdef F_DEBUG
                 else
                 {
-                    Serial.printf("%s: missing symbol, %s @ 0x%X %s\n", name, font->name, (1U << 8) * multiplier + text[charIndex], text[charIndex]);
+                    Serial.printf("%s: missing symbol, %s @ 0x%X %c\n", name.data(), font->name, (1U << 8) * multiplier + text[charIndex], text[charIndex]);
                 }
 #endif
                 multiplier = 0;


### PR DESCRIPTION
### Summary
Corrects a `Serial.printf()` debug message to ensure proper formatting and avoid potential crashes when printing string and character values.

### Changes
* Updated `Serial.printf()` call:

  * Changed `%s` for `name` to `name.data()` to match expected parameter type.

  * Changed last argument format specifier from `%s` to `%c` for proper single-character output.

### Rationale
* Ensures debug output is accurate and matches the intended data types.

* Prevents undefined behavior or incorrect output during debugging.

### Impact
* No changes for end users.

* Developers using the `F_DEBUG` flag will now see correctly formatted messages.

### Related
* Related to #12