### PR TITLE
Auto-uppercase for Tiny Fonts

### DIFF
--- a/firmware/src/fonts/BrailleFont.cpp
+++ b/firmware/src/fonts/BrailleFont.cpp
@@ -11,7 +11,9 @@ FontModule::Symbol BrailleFont::getChar(wchar_t character)
 {
     if (character >= 0x20 && character <= 0x7F && character < ascii.size() + 0x20)
     {
-        return ascii[character - 0x20];
+        return character >= 0x61 && character <= 0x7A && ascii[character - 0x20].bitmap.empty()
+                   ? ascii[character - 0x40]
+                   : ascii[character - 0x20];
     }
     return {};
 }

--- a/firmware/src/fonts/MicroFont.cpp
+++ b/firmware/src/fonts/MicroFont.cpp
@@ -11,7 +11,9 @@ FontModule::Symbol MicroFont::getChar(wchar_t character)
 {
     if (character >= 0x20 && character <= 0x7F && character < ascii.size() + 0x20)
     {
-        return ascii[character - 0x20];
+        return character >= 0x61 && character <= 0x7A && ascii[character - 0x20].bitmap.empty()
+                   ? ascii[character - 0x40]
+                   : ascii[character - 0x20];
     }
     else if (character >= 0xC280 && character <= 0xDFBF)
     {

--- a/firmware/src/services/ModesService.cpp
+++ b/firmware/src/services/ModesService.cpp
@@ -317,15 +317,14 @@ void ModesService::splash()
         Display.setPower(true);
     }
     String _name = active->name;
-    std::transform(_name.begin(), _name.end(), _name.begin(), toupper);
     std::vector<String> chunks = {""};
     uint8_t line = 0;
     for (uint8_t i = 0; i < _name.length(); ++i)
     {
         switch (_name[i])
         {
-        case 32: // Space
-        case 45: // Hyphen-minus
+        case 0x20: //   Space
+        case 0x2D: // - Hyphen-minus
             chunks.push_back("");
             ++line;
             break;


### PR DESCRIPTION
### Summary
Adds automatic conversion of lowercase characters to uppercase when using fonts too small to support lowercase letters.

### Changes
* Automatically converts lowercase characters to uppercase before rendering *"Braille"* or *"Micro"* fonts.

### Motivation
* These tiny fonts do not have sufficient pixel height to display lowercase letters clearly.

* Prevents missing or blank characters when rendering text in these fonts.

### Impact
* End users will see uppercase letters rendered even if lowercase is entered when using the affected fonts.

* No changes for other fonts.