### PR TITLE
Fix Dependabot Configuration for github-actions Ecosystem

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -48,4 +48,3 @@ body:
       label: Inspiration or References
       description: Add sketches, videos, or links to similar effects for inspiration.
       placeholder: "Here's a link to a video on YouTube that has a similar effect."
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
       - "no-changelog"
     schedule:
       interval: "weekly"
-    versioning-strategy: "increase-if-necessary"
 
   - package-ecosystem: "npm"
     directory: "/webapp"


### PR DESCRIPTION
### Summary
Corrects a configuration error introduced in the previous PR #44 where the `versioning-strategy` field was applied to the `github-actions` package ecosystem, which is not supported.

### Changes
* Removed `versioning-strategy` from the `github-actions` ecosystem in Dependabot configuration.

* Removed a excessive empty line.

### Impact
* Restores proper Dependabot functionality for GitHub Actions updates.

* Prevents potential workflow errors or warnings during automated dependency checks.

# Related
* Fixes #44

* Replaces #45