### PR TITLE
Refactor Display Shutdown Handling and Update Documentation

### DIFF
--- a/docs/wiki/IKEA-Frekvens.md
+++ b/docs/wiki/IKEA-Frekvens.md
@@ -130,13 +130,13 @@ The last step is to connect the buttons, `SW` and `SW1` both connects to separat
 
 ## ↔️ Logic level shifter
 
-The [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) operates at 3.3 V logic, while the [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf) operates at 4 V logic. Therefore, a bidirectional logic level shifter compatible with SPI, such as the [TXB0104](https://www.adafruit.com/product/1875) or [TXB0108](https://www.adafruit.com/product/395), is required to ensure reliable and safe communication between the devices.
+The [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) operates at 3.3 V logic, while the [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf) operates at 4 V logic. To ensure reliable and safe communication between the two devices, a suitable logic level shifter designed for SPI signals is required.
 
-- The [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf)'s logic *HIGH* level is above [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)'s absolute maximum voltage rating on its GPIO pins:
+- The [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf)'s logic *HIGH* level is above [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)'s absolute maximum voltage rating on the following GPIO pins:
   - SPI MISO *`DA`*
   - Enable *`EN`*
 
-It is considered best practice to keep all logic signals at a consistent voltage level within each interface. Therefore, it is recommended to use a logic level shifter on all relevant signal lines, even if not strictly required.
+> It is considered best practice to keep all logic signals at a consistent voltage level within each interface. Therefore, it is recommended to use a logic level shifter on all relevant signal lines — even if not strictly required.
 
 > While there are reports suggesting that these devices can work together without level shifting, this is strongly discouraged. Exceeding the [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)’s voltage ratings may result in unpredictable behavior or permanent damage to the microcontroller.
 

--- a/docs/wiki/IKEA-Obegransad.md
+++ b/docs/wiki/IKEA-Obegransad.md
@@ -121,14 +121,14 @@ There's different options based on skill level and time investment:
 
 ## ↔️ Logic level shifter
 
-The [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) operates at 3.3 V logic, while the [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf) operates at 5 V logic. Therefore, a bidirectional logic level shifter compatible with SPI, such as the [TXB0104](https://www.adafruit.com/product/1875) or [TXB0108](https://www.adafruit.com/product/395), is required to ensure reliable and safe communication between the devices.
+The [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) operates at 3.3 V logic, while the [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf) operates at 5 V logic. To ensure reliable and safe communication between the two devices, a suitable logic level shifter designed for SPI signals is required.
 
-- The [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)'s logic *HIGH* level is below [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf)'s minimum voltage requirement:
+- The [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)'s logic *HIGH* level is below [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf)'s minimum voltage requirement on the following GPIO pins:
   - SPI SCLK *`CLK`*
   - SPI MOSI *`DI`*
   - SPI CS *`CLA`*
   - Enable *`EN`*
-- The [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf)'s logic *HIGH* level is above [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)'s absolute maximum voltage rating on its GPIO pins:
+- The [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf)'s logic *HIGH* level is above [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)'s absolute maximum voltage rating on these GPIO pins:
   - SPI MISO *`DO`*
   - Enable *`EN`*
 

--- a/docs/wiki/Infrared.md
+++ b/docs/wiki/Infrared.md
@@ -43,8 +43,7 @@ While virtually *any* IR sensor can be used, the simplest way to getting started
 
 ## ↔️ Logic level shifter
 
-Components connected to voltage levels above 3.3 V often requires an voltage-level translator to remain compatible with ESP32's logic pins.
-Most IR-remote sensors are 3.3 V compatible, but if 5 V logic is desired, the easiest solution might be to use an [TXB0104](https://www.adafruit.com/product/1875) or [TXB0108](https://www.adafruit.com/product/395).
+Components operating at voltages higher than 3.3 V often require level translation to remain compatible with the ESP32. While many IR sensors are designed for 3.3 V logic, some variants may use 5 V. To ensure reliable and safe communication between the two devices in such cases, a suitable logic level shifter should be used.
 
 ## 🔧 Configuration
 

--- a/docs/wiki/RTC.md
+++ b/docs/wiki/RTC.md
@@ -144,8 +144,7 @@ SPI SDIO  ─┤             ├─ SPI SDIO
 
 ## ↔️ Logic level shifter
 
-Components connected to voltage levels above 3.3 V often requires an voltage-level translator to remain ESP32-compatible.
-Most RTC-modules are 3.3 V compatible, but if 5 V logic is desired, the easiest solution might be to use an [TXS0108E](https://www.sparkfun.com/sparkfun-level-shifter-8-channel-txs0108e.html) which is both SPI and I2C compatible. For SPI specifically it's also possible to use [TXB0104](https://www.adafruit.com/product/1875) or [TXB0108](https://www.adafruit.com/product/395), but be aware that these does not work as well with strong pull-up or pull-down resistors *some* RTC-modules *may* have on the `INT` pin.
+Components operating at voltages higher than 3.3 V often require level translation to remain compatible with the ESP32. While many RTC modules are designed for 3.3 V logic, some variants may use 5 V. To ensure reliable and safe communication between the two devices in such cases, a suitable logic level shifter should be used.
 
 ## 🔧 Configuration
 

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -477,8 +477,7 @@ void DeviceService::power(bool state)
         Modes.active->sleep();
         Modes.set(false, name);
     }
-    Display.clear();
-    Display.flush();
+    Display.setPower(false);
 #if EXTENSION_MQTT
     Mqtt->disconnect();
 #endif
@@ -501,8 +500,7 @@ void DeviceService::restore()
     {
         Modes.set(false, name);
     }
-    Display.clear();
-    Display.flush();
+    Display.setPower(false);
 #if EXTENSION_HOMEASSISTANT
     HomeAssistant->undiscover();
 #endif

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -238,6 +238,7 @@ void DisplayService::setPower(bool state)
     }
     else
     {
+        memset(frameReady, 0, sizeof(frameReady));
         ledcDetachPin(PIN_EN);
         digitalWrite(PIN_EN, HIGH);
     }

--- a/firmware/src/services/ModesService.cpp
+++ b/firmware/src/services/ModesService.cpp
@@ -309,13 +309,6 @@ void ModesService::set(ModeModule *mode)
 
 void ModesService::splash()
 {
-    if (!Display.getPower())
-    {
-#ifdef F_INFO
-        Serial.printf("%s: power\n", name);
-#endif
-        Display.setPower(true);
-    }
     const String _name = active->name;
     std::vector<String> chunks = {""};
     uint8_t line = 0;
@@ -352,6 +345,13 @@ void ModesService::splash()
         y += text.getHeight() + max<uint8_t>(1, margin);
     }
     Display.flush();
+    if (!Display.getPower())
+    {
+#ifdef F_INFO
+        Serial.printf("%s: power\n", name);
+#endif
+        Display.setPower(true);
+    }
 }
 
 void ModesService::teardown()


### PR DESCRIPTION
### Summary

This PR refines documentation regarding logic-level shifters and introduces a small firmware refactor to reduce potential side effects from faulty or suboptimal hardware.

### Changes

* Minor refactor to display shutdown logic, ensuring SPI data is fully cleared when the display is turned off.

* Rephrased logic-level shifter sections for clarity.

* Removed model-specific recommendations to keep guidance hardware-agnostic.

### Impact

* Prevents faulty or poor-quality logic-level shifters (or similar hardware issues) from unintentionally reactivating the display.

* Improves clarity and neutrality in documentation.

* No breaking changes for normal operation.