### PR TITLE
Fix RTC Interrupt Handling to Always Light the Display

### DIFF
--- a/firmware/src/extensions/RtcExtension.cpp
+++ b/firmware/src/extensions/RtcExtension.cpp
@@ -9,6 +9,7 @@
 #include "extensions/MqttExtension.h"
 #include "extensions/RtcExtension.h"
 #include "services/DeviceService.h"
+#include "services/DisplayService.h"
 
 RtcExtension *Rtc = nullptr;
 
@@ -114,6 +115,15 @@ void RtcExtension::handle()
             rtc.LatchAlarmTriggeredFlag();
             rtc.LatchTimerTriggeredFlag();
 #endif // defined(RTC_DS3231) || defined(RTC_DS3232) || defined(RTC_DS3234)
+#ifdef F_INFO
+            if (!Display.getPower())
+            {
+                Serial.printf("%s: power\n", name);
+                Display.setPower(true);
+            }
+#else
+            Display.setPower(true);
+#endif // F_INFO
         }
         pending = false;
     }


### PR DESCRIPTION
### Summary

This PR fixes an issue where the RTC interrupt only lit the display when waking from deep sleep.

### Changes

* Updated RTC interrupt handling logic so that it always lights the display, regardless of ESP32 state.

* Ensures consistent behavior when the ESP32 is already running but the display is off.

### Impact

* Bug fix: prevents missed wake events from the RTC when not in deep sleep.

* Ensures the display reliably turns on when triggered by the RTC.

* No breaking changes.