### PR TITLE
Refine Button Device Triggers in Home Assistant Extension

### DIFF
--- a/firmware/include/extensions/HomeAssistantExtension.h
+++ b/firmware/include/extensions/HomeAssistantExtension.h
@@ -4,8 +4,6 @@
 
 #if EXTENSION_HOMEASSISTANT
 
-#include <ArduinoJson.h>
-
 #include "modules/ExtensionModule.h"
 
 class HomeAssistantExtension : public ExtensionModule

--- a/firmware/src/extensions/ButtonExtension.cpp
+++ b/firmware/src/extensions/ButtonExtension.cpp
@@ -47,7 +47,7 @@ void ButtonExtension::setup()
                 component[Abbreviations::automation_type] = "trigger";
                 component[Abbreviations::payload] = payload;
                 component[Abbreviations::platform] = "device_automation";
-                component[Abbreviations::subtype] = "button_1";
+                component[Abbreviations::subtype] = "Power button";
                 component[Abbreviations::topic] = topic;
                 component[Abbreviations::type] = std::string("button_").append(payload).append("_press");
                 component[Abbreviations::value_template] = "{{value_json.event.power}}";
@@ -60,7 +60,7 @@ void ButtonExtension::setup()
                 component[Abbreviations::automation_type] = "trigger";
                 component[Abbreviations::payload] = payload;
                 component[Abbreviations::platform] = "device_automation";
-                component[Abbreviations::subtype] = "button_2";
+                component[Abbreviations::subtype] = "Mode button";
                 component[Abbreviations::topic] = topic;
                 component[Abbreviations::type] = std::string("button_").append(payload).append("_press");
                 component[Abbreviations::value_template] = "{{value_json.event.mode}}";


### PR DESCRIPTION
### Summary

This PR improves the naming of button device triggers in the Home Assistant extension to make them more intuitive and user-friendly.

### Changes

* Replaced generic trigger labels "Button 1" and "Button 2" with descriptive names:

  * Power button

  * Mode button

### Impact

* Improves clarity for end-users in Home Assistant.

* No functional changes; existing automations may need to be updated if they relied on the old labels.