### PR TITLE
Fix Brightness Overflow/Underflow on Button Dimming

### DIFF
--- a/firmware/src/extensions/ButtonExtension.cpp
+++ b/firmware/src/extensions/ButtonExtension.cpp
@@ -102,10 +102,20 @@ void ButtonExtension::handle()
                 brightnessIncrease = !brightnessIncrease;
             }
         }
+        if (brightnessIncrease && brightness < UINT8_MAX)
+        {
 #ifdef F_INFO
-        Serial.printf(brightnessIncrease ? "%s: brightness +\n" : "%s: brightness -\n", Button->name);
+            Serial.printf("%s: brightness +\n", Button->name);
 #endif // F_INFO
-        Display.setGlobalBrightness(brightnessIncrease ? brightness + 1 : brightness - 1);
+            Display.setGlobalBrightness(brightness + 1);
+        }
+        else if (!brightnessIncrease && brightness > 0)
+        {
+#ifdef F_INFO
+            Serial.printf("%s: brightness -\n", Button->name);
+#endif // F_INFO
+            Display.setGlobalBrightness(brightness - 1);
+        }
     }
 #endif // PIN_SW1
 


### PR DESCRIPTION
### Summary

This PR resolves an issue where the display brightness wrapped around when adjusted via button input, causing unintended jumps between minimum and maximum brightness.

### Changes

* Added boundary checks to prevent brightness overflow/underflow when dimming.

* Brightness now correctly stops at defined minimum and maximum values instead of wrapping.

### Impact

* Improves user experience by ensuring smooth and predictable brightness control.