### PR TITLE
Refactor IR Extension: Exclude Unused IR Codes

### DIFF
--- a/firmware/include/extensions/InfraredExtension.h
+++ b/firmware/include/extensions/InfraredExtension.h
@@ -19,10 +19,14 @@ private:
             displayBrightnessDecrease,
             displayBrightnessIncrease,
             displayPowerToggle,
-            extensionMicToggle,
+#if EXTENSION_MICROPHONE
+            extensionMicrophoneToggle,
+#endif // EXTENSION_MICROPHONE
+#if EXTENSION_PLAYLIST
             extensionPlaylistToggle,
-            modesSetNext,
-            modesSetPrevious;
+#endif // EXTENSION_PLAYLIST
+            modeNext,
+            modePrevious;
     };
 
     const std::vector<Code> codes = {
@@ -38,13 +42,17 @@ private:
             {
                 0xC, // Philips: Power
             },
+#if EXTENSION_MICROPHONE
             {
                 0xD, // Philips: Mute
             },
+#endif // EXTENSION_MICROPHONE
+#if EXTENSION_PLAYLIST
             {
                 0x35, // Philips: Play/pause
                 0x36, // Philips: Stop
             },
+#endif // EXTENSION_PLAYLIST
             {
                 0x1E, // Philips: Album next
                 0x20, // Philips: Title next
@@ -68,14 +76,18 @@ private:
                 0x15,   // Sony: Power
                 0x7115, // Sony: Power
             },
+#if EXTENSION_MICROPHONE
             {
                 0x14, // Sony: Mute
             },
+#endif // EXTENSION_MICROPHONE
+#if EXTENSION_PLAYLIST
             {
                 0x7118, // Sony: Stop
                 0x7119, // Sony: Pause
                 0x711A, // Sony: Play
             },
+#endif // EXTENSION_PLAYLIST
             {
                 0x10,   // Sony: Program+
                 0x711C, // Sony: Fast forward

--- a/firmware/src/extensions/InfraredExtension.cpp
+++ b/firmware/src/extensions/InfraredExtension.cpp
@@ -108,7 +108,7 @@ bool InfraredExtension::parse(decode_results results)
                     {
 #ifdef F_INFO
                         Serial.printf("%s: brightness -\n", name);
-#endif
+#endif // F_INFO
                         Display.setGlobalBrightness(max(0, brightness - 5));
                         lastMillis = millis();
                     }
@@ -124,7 +124,7 @@ bool InfraredExtension::parse(decode_results results)
                     {
 #ifdef F_INFO
                         Serial.printf("%s: brightness +\n", name);
-#endif
+#endif // F_INFO
                         Display.setGlobalBrightness(min(UINT8_MAX, brightness + 5));
                         lastMillis = millis();
                     }
@@ -137,20 +137,20 @@ bool InfraredExtension::parse(decode_results results)
                 {
 #ifdef F_INFO
                     Serial.printf("%s: power\n", name);
-#endif
+#endif // F_INFO
                     Display.setPower(!Display.getPower());
                     lastMillis = millis();
                 }
                 return true;
             }
 #if EXTENSION_MICROPHONE
-            else if (std::find(code.extensionMicToggle.begin(), code.extensionMicToggle.end(), results.command) != code.extensionMicToggle.end())
+            else if (std::find(code.extensionMicrophoneToggle.begin(), code.extensionMicrophoneToggle.end(), results.command) != code.extensionMicrophoneToggle.end())
             {
                 if (millis() - lastMillis > 1000)
                 {
 #ifdef F_INFO
                     Serial.printf("%s: microphone\n", name);
-#endif
+#endif // F_INFO
                     Microphone->set(!Microphone->get());
                     lastMillis = millis();
                 }
@@ -164,32 +164,32 @@ bool InfraredExtension::parse(decode_results results)
                 {
 #ifdef F_INFO
                     Serial.printf("%s: playlist\n", name);
-#endif
+#endif // F_INFO
                     Playlist->set(!Playlist->get());
                     lastMillis = millis();
                 }
                 return true;
             }
 #endif // EXTENSION_PLAYLIST
-            else if (std::find(code.modesSetNext.begin(), code.modesSetNext.end(), results.command) != code.modesSetNext.end())
+            else if (std::find(code.modeNext.begin(), code.modeNext.end(), results.command) != code.modeNext.end())
             {
                 if (millis() - lastMillis > 500)
                 {
 #ifdef F_INFO
                     Serial.printf("%s: mode +\n", name);
-#endif
+#endif // F_INFO
                     Modes.next();
                     lastMillis = millis();
                 }
                 return true;
             }
-            else if (std::find(code.modesSetPrevious.begin(), code.modesSetPrevious.end(), results.command) != code.modesSetPrevious.end())
+            else if (std::find(code.modePrevious.begin(), code.modePrevious.end(), results.command) != code.modePrevious.end())
             {
                 if (millis() - lastMillis > 500)
                 {
 #ifdef F_INFO
                     Serial.printf("%s: mode -\n", name);
-#endif
+#endif // F_INFO
                     Modes.previous();
                     lastMillis = millis();
                 }


### PR DESCRIPTION
### Summary

This PR streamlines the Infrared extension by stripping out unused IR codes from compilation and improving code clarity.

### Changes

* IR codes for microphone toggle are only included if the Microphone extension is compiled.

* IR codes for playlist toggle are only included if the Playlist extension is compiled.

* Renamed a few variables for improved readability and consistency.

* Added comments for clarity.

### Impact

* Reduces binary size by excluding unnecessary IR codes.

* Improves maintainability and readability of the IR extension codebase.