### PR TITLE
Prepare v1.1.0

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,4 +21,4 @@ Vulnerabilities will be publicly disclosed **after a fix has been released** and
 | Version | Supported          |
 |---------|--------------------|
 | 1.1.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 1.0.x   | :x:                |

--- a/firmware/include/config/fonts.h
+++ b/firmware/include/config/fonts.h
@@ -13,7 +13,14 @@
 
 /*
  * Small
+ *
+ * Deprecated since v1.1.0.
+ * This option will be removed in v2.0.0.
+ * The font will always be included in the future.
+ * To maintain forward compatibility, do not use this option.
  */
-#ifndef FONT_SMALL
+#if defined(FONT_SMALL) && !FONT_SMALL
+#pragma message("WARNING: FONT_SMALL is deprecated and will be removed in the future.")
+#elif !defined(FONT_SMALL)
 #define FONT_SMALL true
 #endif

--- a/firmware/include/config/version.h
+++ b/firmware/include/config/version.h
@@ -4,4 +4,4 @@
  */
 #include "secrets.h" // please put your custom definitions in the "secrets.h" file
 
-#define VERSION "1.0.1"
+#define VERSION "1.1.0"

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "Frekvens",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "homepage": "https://github.com/VIPnytt/Frekvens",
     "license": "MIT",
     "repository": {

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "frekvens"
 description = "Toolbox for the Frekvens ESP32 project."
-version = "1.0.1"
+version = "1.1.0"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "frekvens",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "frekvens",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
                 "@mdi/js": "7.4.47",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "frekvens",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "homepage": "https://github.com/VIPnytt/Frekvens",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Summary

This PR updates the internal version tag in preparation for the v1.1.0 release.

### Changes

* Bumped project version from v1.0.1 → v1.1.0.

### Impact

* No functional changes.

* Ensures version consistency across firmware, web app, and tooling for the upcoming release.