### PR TITLE
Remove incorrect packageManager entry for pnpm

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -33,6 +33,5 @@
         "vite-plugin-singlefile": "2.3.0",
         "vite-plugin-solid": "2.11.8"
     },
-    "packageManager": "pnpm@9.15.2+sha512.93e57b0126f0df74ce6bff29680394c0ba54ec47246b9cf321f0121d8d9bb03f750a705f24edc3c1180853afd7c2c3b94196d0a3d53d3e069d9e2793ef11f321",
     "private": true
 }


### PR DESCRIPTION
### Summary

This PR removes an incorrect `packageManager` field from `package.json`. The project uses npm exclusively and does not rely on pnpm.

### Changes

* Removed the `packageManager` field from `package.json`

### Impact

* No functional changes.

* Prevents potential confusion or misconfiguration regarding the package manager.

* Enables GitHub dependabot lock-file updates.