### PR TITLE
Fix Time-Zone detection on Linux

### DIFF
--- a/tools/src/services/Network.py
+++ b/tools/src/services/Network.py
@@ -17,11 +17,13 @@ class Network:
             zone_file = os.path.join(tz_path, tz_name)
             if os.path.exists(zone_file):
                 with open(zone_file, "rb") as f:
-                    data = f.read()
-                if b"\x00" in data:
-                    posix = (
-                        data.split(b"\x00")[-1].decode("ascii", errors="ignore").strip()
-                    )
-                    if posix:
-                        return posix
+                    lines = [
+                        line.strip()
+                        for line in f.read()
+                        .decode("ascii", errors="ignore")
+                        .splitlines()
+                        if line.strip()
+                    ]
+                    if len(lines) >= 2:
+                        return lines[-1]
         return None


### PR DESCRIPTION
### Summary

This PR addresses a bug in the build-script where non-printable characters were included in the POSIX time-zone string when detecting the time-zone from the host OS on Linux systems.

### Changes

* Sanitized the detected POSIX time-zone string to strip non-printable characters.

### Impact

* Ensures correct time-zone detection on Linux hosts.

* Prevents build issues caused by malformed time-zone strings.

### Testing

* Tested on Obegränsad

* Verified working on Windows 11

* Verified working on Linux Mint 22 (VM)

---

### Linked Issue

Fixes #100
