### PR TITLE
Documentation iteration – ESP32 pins vs PCB labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Frekvens replicates all original display modes while introducing a range of new 
 
 ### ESP32 board
 
-Frekvens supports most Wi-Fi enabled ESP32 boards. For new installations, the `ESP32-S3` is recommended for its performance and broad compatibility. A compact board (such as [this](https://www.adafruit.com/product/5426) or [this](https://www.seeedstudio.com/XIAO-ESP32S3-p-5627.html)) are sufficient for most use cases.
+Frekvens works with most Wi-Fi enabled ESP32 boards that support the Arduino framework, as listed in [PlatformIO's board registry](https://registry.platformio.org/platforms/platformio/espressif32/boards).
 
-Due to significant variation in ESP32 board layouts, the documentation references pin types rather than fixed pin numbers. For board-specific recommendations, first check the [discussions section](https://github.com/VIPnytt/Frekvens/discussions/categories/general) — many common configurations are already covered there. If you're still unsure, refer to the [documentation](https://github.com/VIPnytt/Frekvens/wiki) or open a new topic for clarification.
+For new installations, the `ESP32-S3` is recommended due to its performance and broad compatibility. Compact boards (such as [this](https://www.adafruit.com/product/5426) or [this](https://www.seeedstudio.com/XIAO-ESP32S3-p-5627.html)) are sufficient for most use cases.
+
+Because board layouts can differ significantly, the documentation references pin types rather than fixed pin numbers. For board-specific recommendations, first check the [discussions section](https://github.com/VIPnytt/Frekvens/discussions/categories/general) — many common configurations are already covered there. If you’re still unsure, refer to the [documentation](https://github.com/VIPnytt/Frekvens/wiki) or open a new topic for clarification.
 
 ### Optional Accessories
 
@@ -115,26 +117,26 @@ ENV_FREKVENS=''
 ENV_OBEGRANSAD=''
 ```
 
-Define pin assignments in [`secrets.h`](firmware/include/config/secrets.h):
+Define pin assignments in [`secrets.h`](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h):
 
 ```h
 #pragma once
 
 // GPIO pins
-#define PIN_SCLK 1
-#define PIN_MOSI 2
-#define PIN_CS 3
-#define PIN_EN 4
-#define PIN_SW2 5
+#define PIN_SCLK 1 // CLK
+#define PIN_MOSI 2 // DA/DO
+#define PIN_CS 3   // LAK/CLA
+#define PIN_EN 4   // EN
+#define PIN_SW2 5  // SW
 
 // IKEA Frekvens only
-#define PIN_SW1 6
-#define PIN_MIC 7
+#define PIN_SW1 6  // SW1
+#define PIN_MIC 7  // U3 pin 7
 ```
 
 ### Wi-Fi
 
-Wi-Fi credentials can be defined in [`secrets.h`](firmware/include/config/secrets.h) or configured through the web UI.
+Wi-Fi credentials can be defined in [`secrets.h`](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) or configured through the web UI.
 
 ```h
 #define WIFI_SSID "name"

--- a/docs/wiki/Custom-devices.md
+++ b/docs/wiki/Custom-devices.md
@@ -1,6 +1,6 @@
 # ✨ Custom devices
 
-> Even if Frekvens was designed for [IKEA Frekvens](IKEA-Frekvens) and [IKEA Obegränsad](IKEA-Obegransad), which both are [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf)-based, the firmware can easily be adapted for custom or third-party devices, including those with different display resolutions or configurations.
+> Even if Frekvens was designed for [IKEA Frekvens](https://github.com/VIPnytt/Frekvens/wiki/IKEA-Frekvens) and [IKEA Obegränsad](https://github.com/VIPnytt/Frekvens/wiki/IKEA-Obegransad), which both are [SCT2024](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.pdf)-based, the firmware can easily be adapted for custom or third-party devices, including those with different display resolutions or configurations.
 
 ## 💻 Resolution
 

--- a/docs/wiki/Extensions.md
+++ b/docs/wiki/Extensions.md
@@ -68,14 +68,14 @@ Events such as `short` and `long` press is also implemented in [Home Assistant](
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_SW1 1 // GPIO #
+#define PIN_SW1 1 // Power button
 ```
 
 ```h
-#define PIN_SW2 2 // GPIO #
+#define PIN_SW2 2 // Mode button
 ```
 
-> Long press *any* button during startup to activate the [Wi-Fi hotspot](Services#-wi-fi-hotspot).
+> Long press *any* button during startup to activate the [Wi-Fi hotspot](https://github.com/VIPnytt/Frekvens/wiki/Services#-network).
 
 [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env) example:
 
@@ -155,7 +155,7 @@ API payload example:
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_IR 3 // GPIO #
+#define PIN_IR 3 // Data
 ```
 
 [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env) example:
@@ -213,7 +213,7 @@ API payload example:
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) examples:
 
 ```h
-#define PIN_MIC 4 // GPIO #
+#define PIN_MIC 4 // Amplifier
 ```
 
 [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env) example:
@@ -358,7 +358,7 @@ Reliable clock, even without Wi-Fi connectivity.
 EXTENSION_RTC=true
 ```
 
-> Enabled by default when a [*supported*](RTC#-supported-types) RTC-module is defined.
+> Enabled by default when a [supported](https://github.com/VIPnytt/Frekvens/wiki/RTC#-supported-types) RTC-module is defined.
 
 Check out the [RTC](https://github.com/VIPnytt/Frekvens/wiki/RTC) wiki for hardware instructions.
 

--- a/docs/wiki/IKEA-Frekvens.md
+++ b/docs/wiki/IKEA-Frekvens.md
@@ -60,9 +60,9 @@
 │            3V3 ├─ +3.3 V DC
 │            GND ├─ 0 V DC
 │                │
-│       SPI SCLK ├─ SPI SCLK
-│       SPI MISO ├─ SPI MISO
-│       SPI MOSI ├─ SPI MOSI
+│           SCLK ├─ SPI SCLK
+│           MISO ├─ SPI MISO
+│           MOSI ├─ SPI MOSI
 │                │
 │ Digital output ├─ SPI CS
 │                │
@@ -82,11 +82,11 @@
 +3.3 V DC ────┐   │   ┌──── +4 V DC
            ┌──┴───┴───┴──┐
            │ VCC GND VCC │
- SPI SCLK ─┤             ├─ SPI SCLK
- SPI MISO ─┤             ├─ SPI MISO
- SPI MOSI ─┤             ├─ SPI MOSI
-   SPI CS ─┤             ├─ SPI CS
-   Enable ─┤             ├─ Enable
+ SPI SCLK ─┤     ──►     ├─ SPI SCLK
+ SPI MISO ─┤     ◄──     ├─ SPI MISO
+ SPI MOSI ─┤     ──►     ├─ SPI MOSI
+   SPI CS ─┤     ──►     ├─ SPI CS
+   Enable ─┤     ──►     ├─ Enable
            └─────────────┘
 ```
 
@@ -157,16 +157,16 @@ The [SCT2024 datasheet](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.
 
 ## 🔧 Configuration
 
-| Frekvens    | Via                 | ESP32          | Function  | Constant |
-| ----------- | ------------------- | -------------- | --------- | ---------|
-| `CLK`       | Logic level shifter | SPI SCLK       | SPI SCLK  | `PIN_SCLK` |
-| `DA` output | Logic level shifter | SPI MISO       | SPI MISO  | `PIN_MISO` |
-| `DA` input  | Logic level shifter | SPI MOSI       | SPI MOSI  | `PIN_MOSI` |
-| `LAK`       | Logic level shifter | Digital output | SPI CS    | `PIN_CS`   |
-| `EN`        | Logic level shifter | PWM output     | Enable    | `PIN_EN`   |
-| `SW1`       |                     | Digital input  | Button 1  | `PIN_SW1`  |
-| `SW`        |                     | Digital input  | Button 2  | `PIN_SW2`  |
-| `U3` pin 7  |                     | Analog input   | Amplifier | `PIN_MIC`  |
+| Frekvens    | Via                 | ESP32          | Function   | Constant   |
+| ----------- | ------------------- | -------------- | ---------- | -----------|
+| `CLK`       | Logic level shifter | SPI SCLK       | SPI SCLK   | `PIN_SCLK` |
+| `DA` output | Logic level shifter | SPI MISO       | SPI MISO   | `PIN_MISO` |
+| `DA` input  | Logic level shifter | SPI MOSI       | SPI MOSI   | `PIN_MOSI` |
+| `LAK`       | Logic level shifter | Digital output | SPI CS     | `PIN_CS`   |
+| `EN`        | Logic level shifter | PWM output     | Enable     | `PIN_EN`   |
+| `SW1`       |                     | Digital input  | Button 1   | `PIN_SW1`  |
+| `SW`        |                     | Digital input  | Button 2   | `PIN_SW2`  |
+| `U3` pin 7  |                     | Analog input   | Microphone | `PIN_MIC`  |
 
 ### Power and ground
 
@@ -180,99 +180,99 @@ The [SCT2024 datasheet](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.
 
 [Logic level shifter](#%EF%B8%8F-logic-level-shifter) recommended.
 
-Any *SPI `SCLK`* pin can be used.
+Any SPI `SCLK` pin can be used.
 
 > The use of either the `HSPI` or `VSPI` bus is required for consistency on boards with two SPI interfaces.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_SCLK 1 // GPIO #
+#define PIN_SCLK 1 // CLK
 ```
 
 ### SPI MISO
 
 Optional to connect, [logic level shifter](#%EF%B8%8F-logic-level-shifter) required.
 
-Any *SPI `MISO`* pin can be used.
+Any SPI `MISO` pin can be used.
 
 > The use of either the `HSPI` or `VSPI` bus is required for consistency on boards with two SPI interfaces.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_MISO 2 // GPIO #
+#define PIN_MISO 2
 ```
 
 ### SPI MOSI
 
 [Logic level shifter](#%EF%B8%8F-logic-level-shifter) recommended.
 
-Any *SPI `MOSI`* pin can be used.
+Any SPI `MOSI` pin can be used.
 
 > The use of either the `HSPI` or `VSPI` bus is required for consistency on boards with two SPI interfaces.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_MOSI 3 // GPIO #
+#define PIN_MOSI 3 // DA
 ```
 
 ### SPI CS
 
 [Logic level shifter](#%EF%B8%8F-logic-level-shifter) recommended.
 
-Any *digital output* pin can be used.
+Any digital output pin can be used.
 
-> Avoid strapping pins as this pin is pulled *LOW* using a resistor. On ESP32 (LX6-based, original series) boards, it is recommended to use specialized pins, such as `CS` (often labeled `SS` on older boards).
+> Avoid strapping pins as this pin is pulled *LOW* using a 25 kΩ resistor. On ESP32 (LX6-based, original series) boards, it is recommended to use specialized pins, such as `CS` (often labeled `SS` on older boards).
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_CS 4 // GPIO #
+#define PIN_CS 4 // LAK
 ```
 
 ### Enable
 
 [Logic level shifter](#%EF%B8%8F-logic-level-shifter) required.
 
-Any *PWM output* pin can be used.
+Any PWM output pin can be used.
 
-> Avoid strapping pins as this pin is pulled *HIGH* using a resistor.
+> Avoid strapping pins as this pin is pulled *HIGH* using a 25 kΩ  resistor.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_EN 5 // GPIO #
+#define PIN_EN 5 // EN
 ```
 
 ### Buttons
 
 Optional to connect.
 
-Any *digital input* pins can be used, but those that are also RTC-capable are preferred.
+Any digital input pins can be used, but those that are also RTC-capable are preferred.
 
 > Avoid strapping pins as these is pulled *LOW* when pressed.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_SW1 6 // GPIO #
-#define PIN_SW2 7 // GPIO #
+#define PIN_SW1 6 // SW1
+#define PIN_SW2 7 // SW
 ```
 
-### Amplifier
+### Microphone amplifier
 
 Optional to connect.
 
-Any *analog input* pin can be used, but those on the ADC1 channel are preferred.
+Any analog input pin can be used, but those on the ADC1 channel are preferred.
 
 > Avoid strapping pins as this pin is biased. On ESP32 (LX6-based, original series) boards, the ADC2 channel pins are not supported.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_MIC 8 // GPIO #
+#define PIN_MIC 8 // U3 pin 7
 ```
 
 ## 📝 Template
@@ -293,13 +293,13 @@ NAME='Frekvens'
 #pragma once
 
 // GPIO pins
-#define PIN_SCLK 1
-#define PIN_MOSI 2
-#define PIN_CS 3
-#define PIN_EN 4
-#define PIN_SW1 5
-#define PIN_SW2 6
-#define PIN_MIC 7
+#define PIN_SCLK 1 // CLK
+#define PIN_MOSI 2 // DA
+#define PIN_CS 3   // LAK
+#define PIN_EN 4   // EN
+#define PIN_SW1 5  // SW1
+#define PIN_SW2 6  // SW
+#define PIN_MIC 7  // U3 pin 7
 
 // Wi-Fi credentials (optional)
 #define WIFI_SSID "name"

--- a/docs/wiki/IKEA-Obegransad.md
+++ b/docs/wiki/IKEA-Obegransad.md
@@ -41,10 +41,10 @@
 ### USB cable schema
 
 ```text
-───────┐
-White ─┼─ +5 V DC
-Black ─┼─ 0 V DC
-───────┘
+──────┐
+White ┼─ +5 V DC
+Black ┼─ 0 V DC
+──────┘
 ```
 
 ### ESP32 schema
@@ -55,9 +55,9 @@ Black ─┼─ 0 V DC
 │            3V3 ├─ +3.3 V DC
 │            GND ├─ 0 V DC
 │                │
-│       SPI SCLK ├─ SPI SCLK
-│       SPI MISO ├─ SPI MISO
-│       SPI MOSI ├─ SPI MOSI
+│           SCLK ├─ SPI SCLK
+│           MISO ├─ SPI MISO
+│           MOSI ├─ SPI MOSI
 │                │
 │ Digital output ├─ SPI CS
 │                │
@@ -74,12 +74,11 @@ Black ─┼─ 0 V DC
 +3.3 V DC ────┐   │   ┌──── +5 V DC
            ┌──┴───┴───┴──┐
            │ VCC GND VCC │
- SPI SCLK ─┤             ├─ SPI SCLK
- SPI MISO ─┤             ├─ SPI MISO
- SPI MOSI ─┤             ├─ SPI MOSI
-   SPI CS ─┤             ├─ SPI CS
-   Enable ─┤             ├─ Enable
-           │             │
+ SPI SCLK ─┤     ──►     ├─ SPI SCLK
+ SPI MISO ─┤     ◄──     ├─ SPI MISO
+ SPI MOSI ─┤     ──►     ├─ SPI MOSI
+   SPI CS ─┤     ──►     ├─ SPI CS
+   Enable ─┤     ──►     ├─ Enable
            └─────────────┘
 ```
 
@@ -170,84 +169,84 @@ The [SCT2024 datasheet](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.
 
 [Logic level shifter](#%EF%B8%8F-logic-level-shifter) required.
 
-Any *SPI `SCLK`* pin can be used.
+Any SPI `SCLK` pin can be used.
 
 > The use of either the `HSPI` or `VSPI` bus is required for consistency on boards with two SPI interfaces.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_SCLK 1 // GPIO #
+#define PIN_SCLK 1 // CLK
 ```
 
 ### SPI MISO
 
 Optional to connect, [logic level shifter](#%EF%B8%8F-logic-level-shifter) required.
 
-Any *SPI `MISO`* pin can be used.
+Any SPI `MISO` pin can be used.
 
 > The use of either the `HSPI` or `VSPI` bus is required for consistency on boards with two SPI interfaces.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_MISO 2 // GPIO #
+#define PIN_MISO 2 // DO
 ```
 
 ### SPI MOSI
 
 [Logic level shifter](#%EF%B8%8F-logic-level-shifter) required.
 
-Any *SPI `MOSI`* pin can be used.
+Any SPI `MOSI` pin can be used.
 
 > The use of either the `HSPI` or `VSPI` bus is required for consistency on boards with two SPI interfaces.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_MOSI 3 // GPIO #
+#define PIN_MOSI 3 // DI
 ```
 
 ### SPI CS
 
 [Logic level shifter](#%EF%B8%8F-logic-level-shifter) required.
 
-Any *digital output* pin can be used.
+Any digital output pin can be used.
 
-> Avoid strapping pins as this pin is pulled *LOW* using a resistor. On ESP32 (LX6-based, original series) boards, it is recommended to use specialized pins, such as `CS` (often labeled `SS` on older boards).
+> Avoid strapping pins as this pin is pulled *LOW* using a 25 kΩ resistor. On ESP32 (LX6-based, original series) boards, it is recommended to use specialized pins, such as `CS` (often labeled `SS` on older boards).
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_CS 4 // GPIO #
+#define PIN_CS 4 // CLA
 ```
 
 ### Enable
 
 [Logic level shifter](#%EF%B8%8F-logic-level-shifter) required.
 
-Any *PWM output* pin can be used.
+Any PWM output pin can be used.
 
-> Avoid strapping pins as this pin is pulled *HIGH* using a resistor.
+> Avoid strapping pins as this pin is pulled *HIGH* using a 25 kΩ resistor.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_EN 5 // GPIO #
+#define PIN_EN 5 // EN
 ```
 
 ### Button
 
 Optional to connect.
 
-Any *digital input* pin can be used, but those that are also RTC-capable are preferred.
+Any digital input pin can be used, but those that are also RTC-capable are preferred.
 
 > Avoid strapping pins as this pin is pulled *LOW* when pressed.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_SW2 6 // GPIO #
+#define PIN_SW2 6 // SW
 ```
 
 ## 📝 Template
@@ -268,11 +267,11 @@ NAME='Obegränsad'
 #pragma once
 
 // GPIO pins
-#define PIN_SCLK 1
-#define PIN_MOSI 2
-#define PIN_CS 3
-#define PIN_EN 4
-#define PIN_SW2 5
+#define PIN_SCLK 1 // CLK
+#define PIN_MOSI 2 // DI
+#define PIN_CS 3   // CLA
+#define PIN_EN 4   // EN
+#define PIN_SW2 5  // SW
 
 // Wi-Fi credentials (optional)
 #define WIFI_SSID "name"

--- a/docs/wiki/Infrared.md
+++ b/docs/wiki/Infrared.md
@@ -20,13 +20,13 @@ Most remotes operate around the 38 kHz frequency band. While many IR sensors and
 ### ESP32 schema
 
 ```text
-┌────────────────┐
-│            VIN ├─ +5 V DC
-│            3V3 ├─ +3.3 V DC
-│            GND ├─ 0 V DC
-│                │
-│  Digital input ├─ Data
-└────────────────┘
+┌───────────────┐
+│           VIN ├─ +5 V DC
+│           3V3 ├─ +3.3 V DC
+│           GND ├─ 0 V DC
+│               │
+│ Digital input ├─ Data
+└───────────────┘
 ```
 
 ### Logic level shifter schema
@@ -36,7 +36,7 @@ Most remotes operate around the 38 kHz frequency band. While many IR sensors and
 +3.3 V DC ────┐   │   ┌──── +5 V DC
            ┌──┴───┴───┴──┐
            │ VCC GND VCC │
-    Data  ─┤             ├─ Data
+    Data  ─┤     ◄──     ├─ Data
            └─────────────┘
 ```
 
@@ -48,14 +48,14 @@ Most IR sensors are 3.3 V compatible, but some variants use higher logic levels 
 
 ### Data
 
-Any *digital input* pin can be used.
+Any digital input pin can be used.
 
 > Avoid strapping pins as this pin is pulled *HIGH* when idle.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_IR 1 // GPIO #
+#define PIN_IR 1 // Data
 ```
 
 ## 🧩 Extension

--- a/docs/wiki/Microphone.md
+++ b/docs/wiki/Microphone.md
@@ -30,16 +30,16 @@ Most analog microphone modules with a built-in amplifier will work. A good start
 
 ## 🔧 Configuration
 
-### Amplifier
+### Microphone amplifier
 
-Any *analog input* pin can be used, but those on the ADC1 channel are preferred.
+Any analog input pin can be used, but those on the ADC1 channel are preferred.
 
 > Avoid strapping pins as this pin is biased. On ESP32 (LX6-based, original series) boards, the ADC2 channel pins are not supported.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_MIC 1 // GPIO #
+#define PIN_MIC 1 // Amplifier
 ```
 
 ## 🧩 Extension
@@ -50,5 +50,5 @@ The [Microphone](https://github.com/VIPnytt/Frekvens/wiki/Extensions#️-microph
 
 [IKEA Frekvens](https://github.com/VIPnytt/Frekvens/wiki/IKEA-Frekvens#wiring-the-microphone) has an MEMS microphone built-in.
 
-On the green PCB there's an [LM358](https://www.onsemi.com/download/data-sheet/pdf/lm358-d.pdf) amplifier, simply connect `U3` pin 7 to an *analog input* on the ESP32 board.
+On the green PCB there's an [LM358](https://www.onsemi.com/download/data-sheet/pdf/lm358-d.pdf) amplifier, simply connect `U3` pin 7 to an analog input on the ESP32 board.
 Since the [89F112](https://lceda.cn/components/89F112_aeaaa99e4cd44677a24b9884cee22ff3) chip should be desoldered, it might be easier to connect from `U2` pad 11 instead.

--- a/docs/wiki/RTC.md
+++ b/docs/wiki/RTC.md
@@ -108,14 +108,14 @@ Most common RTC modules will work. Good starting points include the [DS3231](htt
 │            3V3 ├─ +3.3 V DC
 │            GND ├─ 0 V DC
 │                │
-│        I²C SCL ├─ I²C SCL
-│        I²C SDA ├─ I²C SDA
+│            SCL ├─ I²C SCL
+│            SDA ├─ I²C SDA
 │                │
-│       SPI SCLK ├─ SPI SCLK
-│       SPI MISO ├─ SPI MISO
-│       SPI MOSI ├─ SPI MOSI
+│           SCLK ├─ SPI SCLK
+│           MISO ├─ SPI MISO
+│           MOSI ├─ SPI MOSI
 │                │
-│       SPI MISO ├─ SPI SDIO
+│           MISO ├─ SPI SDIO
 │                │
 │ Digital output ├─ SPI CS
 │                │
@@ -130,17 +130,17 @@ Most common RTC modules will work. Good starting points include the [DS3231](htt
 +3.3 V DC ────┐   │   ┌──── +5 V DC
            ┌──┴───┴───┴──┐
            │ VCC GND VCC │
- I²C SCL  ─┤             ├─ I²C SCL
- I²C SDA  ─┤             ├─ I²C SDA
+ I²C SCL  ─┤     ──►     ├─ I²C SCL
+ I²C SDA  ─┤     ◄─►     ├─ I²C SDA
            │             │
-SPI SCLK  ─┤             ├─ SPI SCLK
-SPI MISO  ─┤             ├─ SPI MISO
-SPI MOSI  ─┤             ├─ SPI MOSI
-  SPI CS  ─┤             ├─ SPI CS
+SPI SCLK  ─┤     ──►     ├─ SPI SCLK
+SPI MISO  ─┤     ◄──     ├─ SPI MISO
+SPI MOSI  ─┤     ──►     ├─ SPI MOSI
+  SPI CS  ─┤     ──►     ├─ SPI CS
            │             │
-SPI SDIO  ─┤             ├─ SPI SDIO
+SPI SDIO  ─┤     ◄─►     ├─ SPI SDIO
            │             │
- RTC INT  ─┤             ├─ RTC INT
+ RTC INT  ─┤     ◄──     ├─ RTC INT
            └─────────────┘
 ```
 
@@ -152,101 +152,101 @@ Most RTC modules are 3.3 V compatible, but some variants use higher logic levels
 
 ### I²C SCL
 
-Any *I²C `SCL`* pin can be used.
+Any I²C `SCL` pin can be used.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_SCL 1 // GPIO #
+#define PIN_SCL 1 // I²C SCL
 ```
 
 ### I²C SDA
 
-Any *I²C `SDA`* pin can be used.
+Any I²C `SDA` pin can be used.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_SDA 2 // GPIO #
+#define PIN_SDA 2 // I²C SDA
 ```
 
 ### SPI SCLK
 
-Any *SPI `SCLK`* pin can be used.
+Any SPI `SCLK` pin can be used.
 
 > On boards with two SPI interfaces, either the `HSPI` or `VSPI` bus can be used. However, you must choose the one that is not connected to the display, as these devices cannot share the same SPI bus.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_SCLK2 3 // GPIO #
+#define PIN_SCLK2 3 // SPI SCLK
 ```
 
 ### SPI MISO
 
-Any *SPI `MISO`* pin can be used.
+Any SPI `MISO` pin can be used.
 
 > On boards with two SPI interfaces, either the `HSPI` or `VSPI` bus can be used. However, you must choose the one that is not connected to the display, as these devices cannot share the same SPI bus.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_MISO2 4 // GPIO #
+#define PIN_MISO2 4 // SPI MISO
 ```
 
 ### SPI MOSI
 
-Any *SPI `MOSI`* pin can be used.
+Any SPI `MOSI` pin can be used.
 
 > On boards with two SPI interfaces, either the `HSPI` or `VSPI` bus can be used. However, you must choose the one that is not connected to the display, as these devices cannot share the same SPI bus.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_MOSI2 5 // GPIO #
+#define PIN_MOSI2 5 // SPI MOSI
 ```
 
 ### SPI SDIO
 
-Any *SPI `MISO`* pin can be used.
+Any SPI `MISO` pin can be used.
 
 > On boards with two SPI interfaces, either the `HSPI` or `VSPI` bus can be used. However, you must choose the one that is not connected to the display, as these devices cannot share the same SPI bus.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_SDIO2 6 // GPIO #
+#define PIN_SDIO2 6 // SPI SDIO
 ```
 
 ### SPI CS
 
-Any *digital output* pin can be used.
+Any digital output pin can be used.
 
 > Avoid strapping pins as this pin is pulled *LOW* using a resistor. On ESP32 (LX6-based, original series) boards, it is recommended to use specialized pins, such as `CS` (often labeled `SS` on older boards).
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_CS2 7 // GPIO #
+#define PIN_CS2 7 // SPI CS
 ```
 
 ### RTC INT
 
 Optional to connect.
 
-Any *Digital input* pin that are also RTC-capable can be used.
+Any digital input pin that are also RTC-capable can be used.
 
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_INT 8 // GPIO #
+#define PIN_INT 8 // RTC INT
 ```
 
 ## 🧩 Extension
 
-Using the [RTC](Extensions#-rtc) extension, the clock will automatically sync during during startup.
+Using the [RTC](https://github.com/VIPnytt/Frekvens/wiki/Extensions#-rtc) extension, the clock will automatically sync during during startup.
 
-Check out the [RTC](Extensions#-rtc) extension for more info.
+Check out the [RTC](https://github.com/VIPnytt/Frekvens/wiki/Extensions#-rtc) extension for more info.
 
 ## 📝 Templates
 
@@ -257,9 +257,9 @@ Check out the [RTC](Extensions#-rtc) extension for more info.
 ```h
 #define RTC_DS1302
 
-#define PIN_SCLK2 1
-#define PIN_SDIO2 2
-#define PIN_CS2 3
+#define PIN_SCLK2 1 // SPI SCLK
+#define PIN_SDIO2 2 // SPI SDIO
+#define PIN_CS2 3   // SPI CS
 ```
 
 > Make sure the ESP32 of choice supports both *HSPI* and *VSPI*, as one of them needs to be dedicated to the display.
@@ -273,11 +273,11 @@ Check out the [RTC](Extensions#-rtc) extension for more info.
 ```h
 #define RTC_DS1307
 
-#define PIN_SCL 1
-#define PIN_SDA 2
+#define PIN_SCL 1 // I²C SCL
+#define PIN_SDA 2 // I²C SDA
 ```
 
-> Incompatible with [IKEA Frekvens](IKEA-Frekvens) due to the lack of a 5 V power supply.
+> Incompatible with [IKEA Frekvens](https://github.com/VIPnytt/Frekvens/wiki/IKEA-Frekvens) due to the lack of a 5 V power supply.
 
 ### DS3231
 
@@ -286,9 +286,9 @@ Check out the [RTC](Extensions#-rtc) extension for more info.
 ```h
 #define RTC_DS3231
 
-#define PIN_SCL 1
-#define PIN_SDA 2
-#define PIN_INT 3
+#define PIN_SCL 1 // I²C SCL
+#define PIN_SDA 2 // I²C SDA
+#define PIN_INT 3 // RTC INT
 ```
 
 ### DS3232
@@ -298,9 +298,9 @@ Check out the [RTC](Extensions#-rtc) extension for more info.
 ```h
 #define RTC_DS3232
 
-#define PIN_SCL 1
-#define PIN_SDA 2
-#define PIN_INT 3
+#define PIN_SCL 1 // I²C SCL
+#define PIN_SDA 2 // I²C SDA
+#define PIN_INT 3 // RTC INT
 ```
 
 ### DS3234
@@ -310,11 +310,11 @@ Check out the [RTC](Extensions#-rtc) extension for more info.
 ```h
 #define RTC_DS3234
 
-#define PIN_SCLK2 1
-#define PIN_MISO2 2
-#define PIN_MOSI2 3
-#define PIN_CS2 4
-#define PIN_INT 5
+#define PIN_SCLK2 1 // SPI SCLK
+#define PIN_MISO2 2 // SPI MISO
+#define PIN_MOSI2 3 // SPI MOSI
+#define PIN_CS2 4   // SPI CS
+#define PIN_INT 5   // RTC INT
 ```
 
 > Make sure the ESP32 of choice supports both *HSPI* and *VSPI*, as one of them needs to be dedicated to the display.
@@ -326,7 +326,7 @@ Check out the [RTC](Extensions#-rtc) extension for more info.
 ```h
 #define RTC_PCF8563
 
-#define PIN_SCL 1
-#define PIN_SDA 2
-#define PIN_INT 3
+#define PIN_SCL 1 // I²C SCL
+#define PIN_SDA 2 // I²C SDA
+#define PIN_INT 3 // RTC INT
 ```

--- a/extra/ESPHome/IKEA-Frekvens-LED-spotlight/README.md
+++ b/extra/ESPHome/IKEA-Frekvens-LED-spotlight/README.md
@@ -85,30 +85,30 @@ The `DC+`/`LED+` and `DC-`/`MIC-` pins are internally connected via traces on th
 
 ### Enable
 
-Any *PWM output* pin can be used.
+Any PWM output pin can be used.
 
 > Avoid strapping pins as this pin may be floating.
 
 ```yaml
-PIN_LED: 1 # GPIO #
+PIN_LED: 1 # U6/U7
 ```
 
 ### Button
 
-Any *digital input* pin can be used, but those that are also RTC-capable are preferred.
+Any digital input pin can be used, but those that are also RTC-capable are preferred.
 
 > Avoid strapping pins as this pin is pulled *HIGH* using a resistor and *LOW* when pressed.
 
 ```yaml
-PIN_SW1: 2 # GPIO #
+PIN_SW1: 2 # K3
 ```
 
 ### Amplifier
 
-Any *analog input* pin can be used, but those on the ADC1 channel are preferred.
+Any analog input pin can be used, but those on the ADC1 channel are preferred.
 
 > Avoid strapping pins as this pin is biased. On ESP32 (LX6-based, original series) boards, the ADC2 channel pins are not supported.
 
 ```yaml
-PIN_MIC: 3 # GPIO #
+PIN_MIC: 3 # U3
 ```

--- a/firmware/include/config/fonts.h
+++ b/firmware/include/config/fonts.h
@@ -12,15 +12,16 @@
 #endif
 
 /*
- * Small
+ * FONT_SMALL
  *
  * Deprecated since v1.1.0.
- * This option will be removed in v2.0.0.
- * The font will always be included in the future.
- * To maintain forward compatibility, do not use this option.
+ * Scheduled for removal in v2.0.0.
+ *
+ * Starting with v2.0.0, the small font will always be included.
+ * To maintain forward compatibility, remove FONT_SMALL from your configuration.
  */
 #if defined(FONT_SMALL) && !FONT_SMALL
-#pragma message("WARNING: FONT_SMALL is deprecated and will be removed in the future.")
+#pragma message("WARNING: 'FONT_SMALL' is deprecated since v1.1.0 and will be removed in v2.0.0. The small font will always be included in the future.")
 #elif !defined(FONT_SMALL)
 #define FONT_SMALL true
 #endif

--- a/firmware/include/config/ikeaFrekvens.h
+++ b/firmware/include/config/ikeaFrekvens.h
@@ -33,47 +33,47 @@
 #define ROWS 16          // px
 
 /*
-#define PIN_SCLK 1 // GPIO #
+#define PIN_SCLK 1 // CLK
 */
 #ifndef PIN_SCLK
-#error "SPI Serial Clock pin is not defined."
+#error "Configuration error: SPI clock pin (PIN_SCLK, PCB label 'CLK') is not defined."
 #endif
 
 /*
-#define PIN_MISO 2 // GPIO #
+#define PIN_MISO 2
 */
 
 /*
-#define PIN_MOSI 3 // GPIO #
+#define PIN_MOSI 3 // DA
 */
 #ifndef PIN_MOSI
-#error "SPI MainOutSubIn pin is not defined."
+#error "Configuration error: SPI MOSI pin (PIN_MOSI, PCB label 'DA') is not defined."
 #endif
 
 /*
-#define PIN_CS 4 // GPIO #
+#define PIN_CS 4 // LAK
 */
 #ifndef PIN_CS
-#error "SPI Chip Select pin is not defined."
+#error "Configuration error: SPI chip select pin (PIN_CS, PCB label 'LAK') is not defined."
 #endif
 
 /*
-#define PIN_EN 5 // GPIO #
+#define PIN_EN 5 // EN
 */
 #ifndef PIN_EN
-#error "PWM Display Enable pin is not defined."
+#error "Configuration error: Enable pin (PIN_EN, PCB label 'EN') is not defined."
 #endif
 
 /*
-#define PIN_SW1 6 // GPIO #
+#define PIN_SW1 6 // SW1
 */
 
 /*
-#define PIN_SW2 7 // GPIO #
+#define PIN_SW2 7 // SW
 */
 
 /*
-#define PIN_MIC 8 // GPIO #
+#define PIN_MIC 8 // U3 pin 7
 */
 
 #endif // ENV

--- a/firmware/include/config/ikeaObegransad.h
+++ b/firmware/include/config/ikeaObegransad.h
@@ -33,39 +33,39 @@
 #define ROWS 16          // px
 
 /*
-#define PIN_SCLK 1 // GPIO #
+#define PIN_SCLK 1 // CLK
 */
 #ifndef PIN_SCLK
-#error "SPI Serial Clock pin is not defined."
+#error "Configuration error: SPI clock pin (PIN_SCLK, PCB label 'CLK') is not defined."
 #endif
 
 /*
-#define PIN_MISO 2 // GPIO #
+#define PIN_MISO 2 // DO
 */
 
 /*
-#define PIN_MOSI 3 // GPIO #
+#define PIN_MOSI 3 // DI
 */
 #ifndef PIN_MOSI
-#error "SPI MainOutSubIn pin is not defined."
+#error "Configuration error: SPI MOSI pin (PIN_MOSI, PCB label 'DI') is not defined."
 #endif
 
 /*
-#define PIN_CS 4 // GPIO #
+#define PIN_CS 4 // CLA
 */
 #ifndef PIN_CS
-#error "SPI Chip Select pin is not defined."
+#error "Configuration error: SPI chip select pin (PIN_CS, PCB label 'CLA') is not defined."
 #endif
 
 /*
-#define PIN_EN 5 // GPIO #
+#define PIN_EN 5 // EN
 */
 #ifndef PIN_EN
-#error "PWM Display Enable pin is not defined."
+#error "Configuration error: Enable pin (PIN_EN, PCB label 'EN') is not defined."
 #endif
 
 /*
-#define PIN_SW2 6 // GPIO #
+#define PIN_SW2 6 // SW
 */
 
 #endif // ENV

--- a/firmware/include/config/infrared.h
+++ b/firmware/include/config/infrared.h
@@ -5,5 +5,5 @@
 #include "secrets.h" // please put your custom definitions in the "secrets.h" file
 
 /*
-#define PIN_IR 1 // GPIO #
+#define PIN_IR 1 // Data
 */

--- a/firmware/include/config/microphone.h
+++ b/firmware/include/config/microphone.h
@@ -5,5 +5,5 @@
 #include "secrets.h" // please put your custom definitions in the "secrets.h" file
 
 /*
-#define PIN_MIC 1 // GPIO #
+#define PIN_MIC 1 // Amplifier
 */

--- a/firmware/include/config/rtc.h
+++ b/firmware/include/config/rtc.h
@@ -24,20 +24,20 @@
 */
 
 /*
-#define PIN_SCL 1 // GPIO #
-#define PIN_SDA 2 // GPIO #
+#define PIN_SCL 1 // I²C SCL
+#define PIN_SDA 2 // I²C SDA
 */
 
 /*
-#define PIN_SCLK2 4 // GPIO #
-#define PIN_CS2 3 // GPIO #
+#define PIN_SCLK2 3 // SPI SCLK
+#define PIN_CS2 4   // SPI CS
 */
 
 /*
-#define PIN_MISO2 5 // GPIO #
-#define PIN_MOSI2 6 // GPIO #
+#define PIN_MISO2 5 // SPI MISO
+#define PIN_MOSI2 6 // SPI MOSI
 */
 
 /*
-#define PIN_SDIO2 7 // GPIO #
+#define PIN_SDIO2 7 // SPI SDIO
 */


### PR DESCRIPTION
### Summary

This PR improves the documentation with a focus on clarifying the relationship between ESP32 pins and PCB labels on the displays, making it easier for new users to get started.

### Changes

* Expanded documentation around ESP32 pins and PCB labels for displays.

* Refined explanations to reduce potential confusion during setup.

* Applied several other minor improvements for clarity and readability.

### Impact

* Lowers the barrier to entry for new users.

* Provides clearer guidance for wiring and setup.