### PR TITLE
New board: WeMos LOLIN S3 MINI

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -104,3 +104,9 @@ board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
 board_build.partitions = default_16MB.csv
 ;extends = env:upload_ota
+
+; WeMos LOLIN S3 MINI
+[env:lolin_s3_mini]
+board = lolin_s3_mini
+board_build.partitions = min_spiffs.csv
+;extends = env:upload_ota


### PR DESCRIPTION
### Summary

This PR adds support for the WeMos LOLIN S3 MINI board.

### Changes

* Added WeMos LOLIN S3 MINI to `platformio.ini`.

### Impact

* Expands supported hardware.

* Ensures ongoing CI coverage for the new board.