### PR TITLE
Auto-collapse Wi-Fi list sidebar on mobile devices

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -19,6 +19,7 @@ import './style.css';
 const [getSidebar, setSidebar] = createSignal<boolean>(true);
 
 export const PageSidebar = getSidebar;
+export const PageSidebarSet = setSidebar;
 
 createEffect(() => {
     if (!DisplayPower() && !getSidebar()) {

--- a/webapp/src/services/Network.tsx
+++ b/webapp/src/services/Network.tsx
@@ -6,6 +6,7 @@ import { Toast } from '../components/Toast';
 import { Tooltip } from '../components/Tooltip';
 import { Icon } from '../components/Vector';
 import { ws } from '../extensions/WebSocket';
+import { PageSidebarSet } from '../index'
 import { SidebarSection } from './WebServer';
 
 export const name = 'Network';
@@ -139,6 +140,9 @@ export const SidebarThird: Component = () => {
     };
 
     const handleSelect = (ssid: string | undefined) => {
+        if (window.innerWidth < 640) {
+            PageSidebarSet(false)
+        }
         if (ssid !== undefined) {
             setSsidNew(ssid);
         }


### PR DESCRIPTION
### Summary

Improves the web app’s usability on mobile devices by auto-collapsing the Wi-Fi network list sidebar once a network is selected.

### Changes

* Sidebar auto-collapses after selecting a Wi-Fi network.

* Behavior applies only when the sidebar covers more than 50% of the screen (mobile devices).

* Sidebar remains fully toggleable via the hamburger button as before.

### Impact

* Better mobile usability by reducing clutter after Wi-Fi selection.

* No changes to desktop behavior.

### Issues

Related to #102