### PR TITLE
Fix typo in Microphone extension (treshold → threshold)

### DIFF
--- a/firmware/include/extensions/MicrophoneExtension.h
+++ b/firmware/include/extensions/MicrophoneExtension.h
@@ -17,7 +17,7 @@ private:
     uint16_t
         levelMax = INT8_MAX,
         mic,
-        treshold = INT8_MAX;
+        threshold = INT8_MAX;
 
     unsigned long
         lastMillis = 0,
@@ -34,7 +34,7 @@ public:
 
     bool get();
     void set(bool enable);
-    void set(uint16_t treshold);
+    void set(uint16_t floor);
     bool play();
 
     void receiverHook(const JsonDocument doc) override;

--- a/webapp/src/extensions/Microphone.tsx
+++ b/webapp/src/extensions/Microphone.tsx
@@ -11,14 +11,14 @@ export const name = 'Microphone';
 
 const [getActive, setActive] = createSignal<boolean>(false);
 const [getMax, setMax] = createSignal<number>(0);
-const [getTreshold, setTreshold] = createSignal<number>(0);
+const [getThreshold, setThreshold] = createSignal<number>(0);
 
 export const MicActive = getActive;
 
 export const receiver = (json: any) => {
     json[name]?.active !== undefined && setActive(json[name].active);
     json[name]?.max !== undefined && setMax(json[name].max);
-    json[name]?.treshold !== undefined && setTreshold(json[name].treshold);
+    json[name]?.threshold !== undefined && setThreshold(json[name].threshold);
 };
 
 const handleActive = () => {
@@ -66,12 +66,12 @@ export const Link: Component = () => (
 );
 
 export const MainThird: Component = () => {
-    const handleTreshold = (level: number, send: boolean = true) => {
-        setTreshold(level);
+    const handleThreshold = (level: number, send: boolean = true) => {
+        setThreshold(level);
         if (send) {
             ws.send(JSON.stringify({
                 [name]: {
-                    treshold: getTreshold(),
+                    threshold: getThreshold(),
                 },
             }));
         }
@@ -82,22 +82,22 @@ export const MainThird: Component = () => {
             <h3 class="text-4xl text-white tracking-wide">{name}</h3>
             <div class="bg-white p-6 rounded-md">
                 <div class="space-y-2">
-                    <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">Treshold</h3>
-                    <Tooltip text={`Treshold ${Math.round(getTreshold() / getMax() * 100)} %`}>
+                    <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">Threshold</h3>
+                    <Tooltip text={`Threshold ${Math.round(getThreshold() / getMax() * 100)} %`}>
                         <input
                             class="w-full"
                             type="range"
                             min="1"
                             max={getMax() - 1}
-                            value={getTreshold()}
+                            value={getThreshold()}
                             onInput={(e) =>
-                                handleTreshold(parseFloat(e.currentTarget.value), false)
+                                handleThreshold(parseFloat(e.currentTarget.value), false)
                             }
                             onKeyUp={(e) =>
-                                handleTreshold(getTreshold())
+                                handleThreshold(getThreshold())
                             }
                             onPointerUp={(e) =>
-                                handleTreshold(getTreshold())
+                                handleThreshold(getThreshold())
                             }
                         />
                     </Tooltip>


### PR DESCRIPTION
### Summary

Corrected a typo in the Microphone extension, changing `treshold` to `threshold`. This update touches both the internal implementation and the exposed APIs.

### Changes

* Renamed the Microphone threshold property from `treshold` → `threshold`.

* Updated API accordingly.

* Refactored related code for consistency.

### Impact

* **Breaking change**: The typo was also present in the API. Clients referencing the old `treshold` key must update to use `threshold`.

* Limited scope: affects only the optional Microphone extension, which requires additional hardware.

* Low real-world impact: the threshold value is generally a "set it and forget it" parameter, unlikely to be used dynamically outside this project.

* Justification: Fixing the typo now prevents long-term confusion and avoids cementing the incorrect spelling in the public API. Although semver would suggest delaying until `v2.0.0`, introducing the change earlier under a minor release is considered less disruptive in practice.