### PR TITLE
Always re-subscribe to MQTT after reboot

### DIFF
--- a/firmware/include/extensions/MqttExtension.h
+++ b/firmware/include/extensions/MqttExtension.h
@@ -15,8 +15,11 @@ private:
 
     unsigned long lastMillis = 0;
 
-    static constexpr size_t prefixLength = sizeof("frekvens/" HOSTNAME);
-    static constexpr size_t suffixLength = sizeof("set");
+    static inline bool subscribe = true;
+
+    static constexpr size_t
+        prefixLength = sizeof("frekvens/" HOSTNAME),
+        suffixLength = sizeof("set");
 
     void transmit();
 


### PR DESCRIPTION
### Summary

Ensures the device always re-subscribes to MQTT topics after a reboot or wake from deep sleep, even if a previous session is still active. This resolves an issue where certain extensions could fail to receive messages after being re-enabled and compiled.

### Changes

* Modified MQTT logic to force re-subscription on every reboot or deep sleep wake-up, regardless of session status.

* Added comments for improved code readability.

### Impact

* Fixes a potential missed-subscription issue when previously disabled extensions are later compiled and re-enabled.

* No breaking changes — existing MQTT setups will continue to function normally.

* Improves reliability of MQTT message handling across reboots and power cycles.