### PR TITLE
Fix missing identify symbol

### DIFF
--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -461,6 +461,7 @@ void DeviceService::identify()
 #endif
     Display.clear();
     TextHandler("!", FontLarge).draw();
+    Display.flush();
     Display.setGlobalBrightness(UINT8_MAX);
 }
 


### PR DESCRIPTION
### Summary

Corrects an issue with the `identify` API method where the intended display symbol was not rendered, even though the brightness increased to maximum.

### Changes

* Added a missing display flush call to ensure the identify symbol is drawn properly when the API method is invoked.

### Impact

* Restores the intended functionality of the `identify` API method.

* No breaking changes — only improves behavior for this optional and niche feature.