### PR TITLE
Rename PIN_EN to PIN_OE for clarity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,13 +80,13 @@ jobs:
           #define OPENWEATHER_PARAMETERS "units=metric"
           #define PIN_CS 1
           #define PIN_CS2 2
-          #define PIN_EN 3
-          #define PIN_INT 4
-          #define PIN_IR 5
-          #define PIN_MISO 6
-          #define PIN_MISO2 7
-          #define PIN_MOSI 8
-          #define PIN_MOSI2 9
+          #define PIN_INT 3
+          #define PIN_IR 4
+          #define PIN_MISO 5
+          #define PIN_MISO2 6
+          #define PIN_MOSI 7
+          #define PIN_MOSI2 8
+          #define PIN_OE 9
           #define PIN_SCL 10
           #define PIN_SCLK 11
           #define PIN_SCLK2 12
@@ -169,9 +169,9 @@ jobs:
           cat <<EOL > firmware/include/config/secrets.h
           #pragma once
           #define PIN_CS 1
-          #define PIN_EN 2
-          #define PIN_MIC 3
-          #define PIN_MOSI 4
+          #define PIN_MIC 2
+          #define PIN_MOSI 3
+          #define PIN_OE 4
           #define PIN_SCLK 5
           #define PIN_SW1 6
           #define PIN_SW2 7
@@ -217,8 +217,8 @@ jobs:
           cat <<EOL > firmware/include/config/secrets.h
           #pragma once
           #define PIN_CS 1
-          #define PIN_EN 2
-          #define PIN_MOSI 3
+          #define PIN_MOSI 2
+          #define PIN_OE 3
           #define PIN_SCLK 4
           #define PIN_SW2 5
           EOL

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ Each display model has its own hardware setup guide:
 
 - [IKEA Frekvens](https://github.com/VIPnytt/Frekvens/wiki/IKEA-Frekvens#-getting-started)
   - Unsolder the `U2` chip
-  - Connect power, SPI and enable
+  - Connect power, SPI and `EN`
   - Microphone input available at `U3` pin 7 or `U2` pin 11
 - [IKEA Obegränsad](https://github.com/VIPnytt/Frekvens/wiki/IKEA-Obegransad#getting-started)
   - Unsolder the `U1` chip
-  - Connect power, SPI and enable
+  - Connect power, SPI and `EN`
 
 ## 🏗️ Getting started
 
@@ -124,9 +124,9 @@ Define pin assignments in [`secrets.h`](https://github.com/VIPnytt/Frekvens/blob
 
 // GPIO pins
 #define PIN_SCLK 1 // CLK
-#define PIN_MOSI 2 // DA/DO
+#define PIN_MOSI 2 // DA/DI
 #define PIN_CS 3   // LAK/CLA
-#define PIN_EN 4   // EN
+#define PIN_OE 4   // EN
 #define PIN_SW2 5  // SW
 
 // IKEA Frekvens only

--- a/docs/wiki/IKEA-Frekvens.md
+++ b/docs/wiki/IKEA-Frekvens.md
@@ -10,7 +10,7 @@
              ┌────────────────────── SPI CS
              │   ┌────────────────── SPI SCLK
              │   │   ┌────────────── SPI MOSI
-             │   │   │   ┌────────── Enable
+             │   │   │   ┌────────── OE
 ┌────────────┼───┼───┼───┼────────┐
 │ ┌──────┴───┴───┴───┴───┴───┴──┐ │
 │ │     GND LAK CLK DA  EN  VCC │ │
@@ -66,7 +66,7 @@
 │                │
 │ Digital output ├─ SPI CS
 │                │
-│     PWM output ├─ Enable
+│     PWM output ├─ OE
 │                │
 │  Digital input ├─ Button 1
 │  Digital input ├─ Button 2
@@ -86,7 +86,7 @@
  SPI MISO ─┤     ◄──     ├─ SPI MISO
  SPI MOSI ─┤     ──►     ├─ SPI MOSI
    SPI CS ─┤     ──►     ├─ SPI CS
-   Enable ─┤     ──►     ├─ Enable
+       OE ─┤     ──►     ├─ OE
            └─────────────┘
 ```
 
@@ -163,7 +163,7 @@ The [SCT2024 datasheet](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.
 | `DA` output | Logic level shifter | SPI MISO       | SPI MISO   | `PIN_MISO` |
 | `DA` input  | Logic level shifter | SPI MOSI       | SPI MOSI   | `PIN_MOSI` |
 | `LAK`       | Logic level shifter | Digital output | SPI CS     | `PIN_CS`   |
-| `EN`        | Logic level shifter | PWM output     | Enable     | `PIN_EN`   |
+| `EN`        | Logic level shifter | PWM output     | OE         | `PIN_OE`   |
 | `SW1`       |                     | Digital input  | Button 1   | `PIN_SW1`  |
 | `SW`        |                     | Digital input  | Button 2   | `PIN_SW2`  |
 | `U3` pin 7  |                     | Analog input   | Microphone | `PIN_MIC`  |
@@ -201,7 +201,7 @@ Any SPI `MISO` pin can be used.
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_MISO 2
+#define PIN_MISO 2 // DA (unlabeled)
 ```
 
 ### SPI MOSI
@@ -215,7 +215,7 @@ Any SPI `MOSI` pin can be used.
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_MOSI 3 // DA
+#define PIN_MOSI 3 // DA (labeled)
 ```
 
 ### SPI CS
@@ -232,9 +232,9 @@ Any digital output pin can be used.
 #define PIN_CS 4 // LAK
 ```
 
-### Enable
+### Output Enable
 
-[Logic level shifter](#%EF%B8%8F-logic-level-shifter) required.
+Optional to connect, [logic level shifter](#%EF%B8%8F-logic-level-shifter) required. If left unconnected, `OE` must be tied to `GND`.
 
 Any PWM output pin can be used.
 
@@ -243,7 +243,7 @@ Any PWM output pin can be used.
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_EN 5 // EN
+#define PIN_OE 5 // EN
 ```
 
 ### Buttons
@@ -296,7 +296,7 @@ NAME='Frekvens'
 #define PIN_SCLK 1 // CLK
 #define PIN_MOSI 2 // DA
 #define PIN_CS 3   // LAK
-#define PIN_EN 4   // EN
+#define PIN_OE 4   // EN
 #define PIN_SW1 5  // SW1
 #define PIN_SW2 6  // SW
 #define PIN_MIC 7  // U3 pin 7

--- a/docs/wiki/IKEA-Obegransad.md
+++ b/docs/wiki/IKEA-Obegransad.md
@@ -11,7 +11,7 @@
            │   ┌──────────────────── SPI CS
            │   │   ┌──────────────── SPI SCLK
            │   │   │   ┌──────────── SPI MOSI
-           │   │   │   │   ┌──────── Enable
+           │   │   │   │   ┌──────── OE
            │   │   │   │   │   ┌──── 0 V DC
     ┌──────┼───┼───┼───┼───┼───┼──┐
     │     VCC CLA CLK DI  EN  GND │
@@ -61,7 +61,7 @@ Black ┼─ 0 V DC
 │                │
 │ Digital output ├─ SPI CS
 │                │
-│     PWM output ├─ Enable
+│     PWM output ├─ OE
 │                │
 │  Digital input ├─ Button
 └────────────────┘
@@ -78,7 +78,7 @@ Black ┼─ 0 V DC
  SPI MISO ─┤     ◄──     ├─ SPI MISO
  SPI MOSI ─┤     ──►     ├─ SPI MOSI
    SPI CS ─┤     ──►     ├─ SPI CS
-   Enable ─┤     ──►     ├─ Enable
+       OE ─┤     ──►     ├─ OE
            └─────────────┘
 ```
 
@@ -154,7 +154,7 @@ The [SCT2024 datasheet](http://www.starchips.com.tw/pdf/datasheet/SCT2024V01_03.
 | `DO`       | Logic level shifter | SPI MISO       | SPI MISO | `PIN_MISO` |
 | `DI`       | Logic level shifter | SPI MOSI       | SPI MOSI | `PIN_MOSI` |
 | `CLA`      | Logic level shifter | Digital output | SPI CS   | `PIN_CS`   |
-| `EN`       | Logic level shifter | PWM output     | Enable   | `PIN_EN`   |
+| `EN`       | Logic level shifter | PWM output     | OE       | `PIN_OE`   |
 | `SW`       |                     | Digital input  | Button   | `PIN_SW2`  |
 
 ### Power and ground
@@ -221,9 +221,9 @@ Any digital output pin can be used.
 #define PIN_CS 4 // CLA
 ```
 
-### Enable
+### Output Enable
 
-[Logic level shifter](#%EF%B8%8F-logic-level-shifter) required.
+Optional to connect, [logic level shifter](#%EF%B8%8F-logic-level-shifter) required. If left unconnected, `OE` must be tied to `GND`.
 
 Any PWM output pin can be used.
 
@@ -232,7 +232,7 @@ Any PWM output pin can be used.
 [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
 
 ```h
-#define PIN_EN 5 // EN
+#define PIN_OE 5 // EN
 ```
 
 ### Button
@@ -270,7 +270,7 @@ NAME='Obegränsad'
 #define PIN_SCLK 1 // CLK
 #define PIN_MOSI 2 // DI
 #define PIN_CS 3   // CLA
-#define PIN_EN 4   // EN
+#define PIN_OE 4   // EN
 #define PIN_SW2 5  // SW
 
 // Wi-Fi credentials (optional)

--- a/extra/ESPHome/IKEA-Frekvens-LED-spotlight/README.md
+++ b/extra/ESPHome/IKEA-Frekvens-LED-spotlight/README.md
@@ -15,7 +15,7 @@
          │     │   ┌┴┴┴┴┐ │ │  U3  └─┤ ├    │
          │     │   └┬┬┬┬┘ │ │  LM358 ┤ ├    │
          │     └────┘     │ │        └─┘    │
- Enable ─┼────────┬───────┤ └─────┬───────┬─┼─ Button
+     OE ─┼────────┬───────┤ └─────┬───────┬─┼─ Button
          │        │  ┌─┐  │  ┌─┐  │  ┌─┐  │ │
          │        │  ┤ ├  │  ┤ ├  │  ┤ ├  │ │
          │        │  ┤ ├  │  ┤ ├  └──┤ ├──┘ │
@@ -61,7 +61,7 @@
 │           VIN ├─ +4 V DC
 │           GND ├─ 0 V DC
 │               │
-│    PWM output ├─ Enable
+│    PWM output ├─ OE
 │               │
 │ Digital input ├─ Button
 │               │
@@ -83,7 +83,7 @@ The `DC+`/`LED+` and `DC-`/`MIC-` pins are internally connected via traces on th
 
 > To prevent backfeeding, never connect the ESP32 to USB while the 4 V power supply is connected — even if it is unplugged from the mains.
 
-### Enable
+### Output Enable
 
 Any PWM output pin can be used.
 

--- a/firmware/include/config/ikeaFrekvens.h
+++ b/firmware/include/config/ikeaFrekvens.h
@@ -49,10 +49,18 @@
 #error "Configuration error: SPI chip select pin (PIN_CS, PCB label 'LAK') is not defined."
 #endif
 
-// #define PIN_EN 5 // EN
-#ifndef PIN_EN
-#error "Configuration error: Enable pin (PIN_EN, PCB label 'EN') is not defined."
+/**
+ * PIN_EN
+ *
+ * PIN_EN has been replaced by PIN_OE.
+ * To ensure forward compatibility, update your configuration:
+ * Replace PIN_EN with PIN_OE.
+ */
+#ifdef PIN_EN
+#define PIN_OE PIN_EN
 #endif
+
+// #define PIN_OE 5 // EN
 
 // #define PIN_SW1 6 // SW1
 

--- a/firmware/include/config/ikeaObegransad.h
+++ b/firmware/include/config/ikeaObegransad.h
@@ -49,12 +49,18 @@
 #error "Configuration error: SPI chip select pin (PIN_CS, PCB label 'CLA') is not defined."
 #endif
 
-/*
-#define PIN_EN 5 // EN
-*/
-#ifndef PIN_EN
-#error "Configuration error: Enable pin (PIN_EN, PCB label 'EN') is not defined."
+/**
+ * PIN_EN
+ *
+ * PIN_EN has been replaced by PIN_OE.
+ * To ensure forward compatibility, update your configuration:
+ * Replace PIN_EN with PIN_OE.
+ */
+#ifdef PIN_EN
+#define PIN_OE PIN_EN
 #endif
+
+// #define PIN_OE 5 // EN
 
 // #define PIN_SW2 6 // SW
 

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -151,7 +151,6 @@ void DeviceService::ready()
 #ifdef PIN_CS2
     (*Build->config)[Config::h][__STRING(PIN_CS2)] = PIN_CS2;
 #endif
-    (*Build->config)[Config::h][__STRING(PIN_EN)] = PIN_EN;
 #ifdef PIN_INT
     (*Build->config)[Config::h][__STRING(PIN_INT)] = PIN_INT;
 #endif
@@ -170,6 +169,9 @@ void DeviceService::ready()
     (*Build->config)[Config::h][__STRING(PIN_MOSI)] = PIN_MOSI;
 #ifdef PIN_MOSI2
     (*Build->config)[Config::h][__STRING(PIN_MOSI2)] = PIN_MOSI2;
+#endif
+#ifdef PIN_OE
+    (*Build->config)[Config::h][__STRING(PIN_OE)] = PIN_OE;
 #endif
 #ifdef PIN_SCL
     (*Build->config)[Config::h][__STRING(PIN_SCL)] = PIN_SCL;


### PR DESCRIPTION
### Summary

Renames the brightness control pin from `PIN_EN` to `PIN_OE` to better reflect its actual hardware function and reduce confusion with PCB labeling.

### Changes

* Introduced `PIN_OE` (Output Enable) as the primary constant for the brightness control pin.

* Retained `PIN_EN` as an alias for backward compatibility. Existing configurations using `PIN_EN` will continue to work.

* Updated documentation to reference `PIN_OE`, clarifying that it should be connected to the PCB pad labeled `EN`.

* Made `PIN_OE` technically optional, allowing builds without it for simpler hardware setups (e.g., when selecting logic-level shifters), albeit at the cost of losing brightness control.

### Impact

* No breaking changes; existing configurations using `PIN_EN` remain valid.

* Future documentation and examples will exclusively use `PIN_OE` to promote correct terminology.