### PR TITLE
Flip FONT_SMALL Conditions for Simpler Logic

### DIFF
--- a/firmware/include/config/fonts.h
+++ b/firmware/include/config/fonts.h
@@ -20,8 +20,6 @@
  * Starting with v2.0.0, the small font will always be included.
  * To maintain forward compatibility, remove FONT_SMALL from your configuration.
  */
-#if defined(FONT_SMALL) && !FONT_SMALL
-#pragma message("WARNING: 'FONT_SMALL' is deprecated since v1.1.0 and will be removed in v2.0.0. The small font will always be included in the future.")
-#elif !defined(FONT_SMALL)
-#define FONT_SMALL true
+#ifdef FONT_SMALL
+#pragma message("WARNING: 'FONT_SMALL' is deprecated since v1.1.0 and will be removed in v2.0.0. The font will always be included in the future.")
 #endif

--- a/firmware/include/services/FontsService.h
+++ b/firmware/include/services/FontsService.h
@@ -20,7 +20,7 @@ private:
 #endif
         new MicroFont(),
         new MiniFont(),
-#if FONT_SMALL
+#if !defined(FONT_SMALL) || FONT_SMALL
         new SmallFont(),
 #endif
         new MediumFont(),

--- a/firmware/src/extensions/MessageExtension.cpp
+++ b/firmware/src/extensions/MessageExtension.cpp
@@ -6,7 +6,6 @@
 
 #include "extensions/HomeAssistantExtension.h"
 #include "extensions/MessageExtension.h"
-#include "extensions/MqttExtension.h"
 #include "fonts/MiniFont.h"
 #include "fonts/SmallFont.h"
 #include "services/DeviceService.h"
@@ -56,11 +55,11 @@ void MessageExtension::ready()
     }
     if (!font)
     {
-#if FONT_SMALL
-        font = FontSmall;
-#else
+#if defined(FONT_SMALL) && !FONT_SMALL
         font = FontMini;
-#endif // FONT_SMALL
+#else
+        font = FontSmall;
+#endif // defined(FONT_SMALL) && !FONT_SMALL
     }
     pending = true;
 }

--- a/firmware/src/modes/TickerMode.cpp
+++ b/firmware/src/modes/TickerMode.cpp
@@ -2,7 +2,6 @@
 
 #include "config/constants.h"
 #include "extensions/HomeAssistantExtension.h"
-#include "extensions/MqttExtension.h"
 #include "fonts/MiniFont.h"
 #include "fonts/SmallFont.h"
 #include "modes/TickerMode.h"
@@ -49,11 +48,11 @@ void TickerMode::setup()
     }
     if (!font)
     {
-#if FONT_SMALL
-        font = FontSmall;
-#else
+#if defined(FONT_SMALL) && !FONT_SMALL
         font = FontMini;
-#endif // FONT_SMALL
+#else
+        font = FontSmall;
+#endif // defined(FONT_SMALL) && !FONT_SMALL
     }
     if (_transmit)
     {


### PR DESCRIPTION
### Summary

Refactors the internal handling of the `FONT_SMALL` compile-time flag to simplify logic and prepare for its eventual removal in v2.0.0.

### Key Changes

* Reverses the conditional logic: `FONT_SMALL` is now treated as enabled by default, unless it is explicitly defined and set to `false`.

* Maintains current build behavior—projects that explicitly disable the flag continue to work as before.

* Prepares the codebase for v2.0.0, where `FONT_SMALL` will be permanently included and the flag fully removed.

### Impact

* No functional changes or build differences are expected.

* Purely an internal optimization to streamline code and reduce unnecessary condition checks.