### PR TITLE
Separate RTC Configuration Options

### DIFF
--- a/firmware/include/config/extensions.h
+++ b/firmware/include/config/extensions.h
@@ -93,6 +93,12 @@
 /**
  * RTC
  */
+// #define RTC_DS1302
+// #define RTC_DS1307
+// #define RTC_DS3231
+// #define RTC_DS3232
+// #define RTC_DS3234
+// #define RTC_PCF8563
 #if !defined(EXTENSION_RTC) && (defined(RTC_TYPE_DS1307) || defined(RTC_TYPE_DS3231) || defined(RTC_TYPE_PCF8523) || defined(RTC_TYPE_PCF8563))
 #define EXTENSION_RTC true
 #endif

--- a/firmware/include/config/rtc.h
+++ b/firmware/include/config/rtc.h
@@ -4,13 +4,6 @@
  */
 #include "secrets.h" // please put your custom definitions in the "secrets.h" file
 
-// #define RTC_DS1302
-// #define RTC_DS1307
-// #define RTC_DS3231
-// #define RTC_DS3232
-// #define RTC_DS3234
-// #define RTC_PCF8563
-
 // #define PIN_SCL 1 // I²C SCL
 // #define PIN_SDA 2 // I²C SDA
 

--- a/firmware/src/extensions/RtcExtension.cpp
+++ b/firmware/src/extensions/RtcExtension.cpp
@@ -6,7 +6,6 @@
 
 #include "extensions/BuildExtension.h"
 #include "extensions/HomeAssistantExtension.h"
-#include "extensions/MqttExtension.h"
 #include "extensions/RtcExtension.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"


### PR DESCRIPTION
### Summary

Decouples hardware and software configuration for the RTC feature to improve clarity and maintainability.

### Key Changes

* Moved RTC module type configuration from `rtc.h` to `extensions.h`, separating hardware configuration from the RTC extension (software) settings.

* Updated template configuration lines accordingly.

* Removed an unused `#include` line in the RTC extension.

### Impact

* No functional changes; only commented template configuration lines are affected.

* Improves code organization and makes it clearer where hardware-specific settings should be defined.