### PR TITLE
Add Support for Adafruit QT Py ESP32-S2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -45,6 +45,12 @@ extra_scripts =
 ; Boards
 ; @see https://registry.platformio.org/platforms/platformio/espressif32/boards
 
+; Adafruit QT Py ESP32-S2
+[env:adafruit_qtpy_esp32s2]
+board = adafruit_qtpy_esp32s2
+board_build.partitions = min_spiffs.csv
+;extends = env:upload_ota
+
 ; Adafruit QT Py ESP32-S3
 [env:adafruit_qtpy_esp32s3_n4r2]
 board = adafruit_qtpy_esp32s3_n4r2


### PR DESCRIPTION
### Summary

Introduces full build and CI support for the Adafruit QT Py ESP32-S2 development board.

### Change

Added the Adafruit QT Py ESP32-S2 board configuration to `platformio.ini`.

### Impact

* Enables seamless compilation and testing for projects using the Adafruit QT Py ESP32-S2.

* Improves platform coverage and CI reliability.