### PR TITLE
IR RC5/RC5X Cleanup

### DIFF
--- a/firmware/include/config/global.h
+++ b/firmware/include/config/global.h
@@ -12,9 +12,6 @@
 #ifndef DECODE_RC5
 #define DECODE_RC5 true // Override
 #endif
-#ifndef DECODE_RC5X
-#define DECODE_RC5X true // Override
-#endif
 #ifndef DECODE_SONY
 #define DECODE_SONY true // Override
 #endif

--- a/firmware/include/extensions/InfraredExtension.h
+++ b/firmware/include/extensions/InfraredExtension.h
@@ -68,8 +68,6 @@ private:
                 0x21, // Philips: Title previous
             },
         },
-#endif // DECODE_RC5
-#if DECODE_RC5X
         {
             decode_type_t::RC5X,
             {},
@@ -89,7 +87,7 @@ private:
             {},
             {},
         },
-#endif // DECODE_RC5X
+#endif // DECODE_RC5
 #if DECODE_SONY
         {
             decode_type_t::SONY,

--- a/firmware/src/extensions/InfraredExtension.cpp
+++ b/firmware/src/extensions/InfraredExtension.cpp
@@ -8,7 +8,6 @@
 #include "extensions/HomeAssistantExtension.h"
 #include "extensions/InfraredExtension.h"
 #include "extensions/MicrophoneExtension.h"
-#include "extensions/MqttExtension.h"
 #include "extensions/PhotocellExtension.h"
 #include "extensions/PlaylistExtension.h"
 #include "services/DeviceService.h"
@@ -73,8 +72,6 @@ void InfraredExtension::handle()
             case decode_type_t::RC5:
                 Serial.printf("%s: " D_STR_RC5 " 0x%X\n", name, results.command);
                 break;
-#endif // DECODE_RC5
-#if DECODE_RC5X
             case decode_type_t::RC5X:
                 Serial.printf("%s: " D_STR_RC5X " 0x%X\n", name, results.command);
                 break;


### PR DESCRIPTION
### Summary

Removed the separate `DECODE_RC5X` option and merged it with `DECODE_RC5`, aligning with how the upstream IR decoding library handles RC5X as part of RC5.

### Key Changes

* `DECODE_RC5X` option removed.

* RC5X decoding is now automatically included when `DECODE_RC5` is enabled.

### Impact

* No functional changes expected for end users; RC5X support remains intact through DECODE_RC5.

* Simplifies configuration and reduces potential confusion.