### PR TITLE
Fix Automatic Enabling of the RTC Extension

### DIFF
--- a/firmware/include/config/extensions.h
+++ b/firmware/include/config/extensions.h
@@ -99,7 +99,7 @@
 // #define RTC_DS3232
 // #define RTC_DS3234
 // #define RTC_PCF8563
-#if !defined(EXTENSION_RTC) && (defined(RTC_TYPE_DS1307) || defined(RTC_TYPE_DS3231) || defined(RTC_TYPE_PCF8523) || defined(RTC_TYPE_PCF8563))
+#if !defined(EXTENSION_RTC) && (defined(RTC_DS1302) || defined(RTC_DS1307) || defined(RTC_DS3231) || defined(RTC_DS3232) || defined(RTC_DS3234) || defined(RTC_PCF8563))
 #define EXTENSION_RTC true
 #endif
 


### PR DESCRIPTION
### Summary

Resolves an issue where the RTC extension was not automatically enabled when an RTC module were defined.

### Changes

* Corrected the logic so that the RTC extension is enabled whenever a compatible module are configured.

### Impact

* Removes the need for manual activation when an RTC module is present.

* No other functional changes expected.