### PR TITLE
Prepare v1.2.0

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -23,5 +23,6 @@ Earlier releases are no longer supported.
 
 | Version | Supported          |
 |---------|--------------------|
-| 1.1.x   | :white_check_mark: |
+| 1.2.x   | :white_check_mark: |
+| 1.1.x   | :x:                |
 | 1.0.x   | :x:                |

--- a/firmware/include/config/deprecated.h
+++ b/firmware/include/config/deprecated.h
@@ -20,16 +20,23 @@
 /**
  * MODE_OPENMETRO
  *
+ * Deprecated since v1.2.0.
+ * Scheduled for removal in v2.0.0.
+ *
  * MODE_OPENMETRO has been replaced by MODE_OPENMETEO.
  * To ensure forward compatibility, update your configuration:
  * Replace MODE_OPENMETRO with MODE_OPENMETEO.
  */
 #ifdef MODE_OPENMETRO
 #define MODE_OPENMETEO MODE_OPENMETRO
+#warning "'MODE_OPENMETRO' is deprecated since v1.2.0 and will be removed in v2.0.0. Use 'MODE_OPENMETEO' instead."
 #endif
 
 /**
  * OPENMETRO_KEY
+ *
+ * Deprecated since v1.2.0.
+ * Scheduled for removal in v2.0.0.
  *
  * OPENMETRO_KEY has been replaced by OPENMETEO_KEY.
  * To ensure forward compatibility, update your configuration:
@@ -37,10 +44,14 @@
  */
 #ifdef OPENMETRO_KEY
 #define OPENMETEO_KEY OPENMETRO_KEY
+#warning "'OPENMETRO_KEY' is deprecated since v1.2.0 and will be removed in v2.0.0. Use 'OPENMETEO_KEY' instead."
 #endif
 
 /**
  * OPENMETRO_PARAMETERS
+ *
+ * Deprecated since v1.2.0.
+ * Scheduled for removal in v2.0.0.
  *
  * OPENMETRO_PARAMETERS has been replaced by OPENMETEO_PARAMETERS.
  * To ensure forward compatibility, update your configuration:
@@ -48,10 +59,14 @@
  */
 #ifdef OPENMETRO_PARAMETERS
 #define OPENMETEO_PARAMETERS OPENMETRO_PARAMETERS
+#warning "'OPENMETRO_PARAMETERS' is deprecated since v1.2.0 and will be removed in v2.0.0. Use 'OPENMETEO_PARAMETERS' instead."
 #endif
 
 /**
  * PIN_EN
+ *
+ * Deprecated since v1.2.0.
+ * Scheduled for removal in v2.0.0.
  *
  * PIN_EN has been replaced by PIN_OE.
  * To ensure forward compatibility, update your configuration:
@@ -59,4 +74,5 @@
  */
 #ifdef PIN_EN
 #define PIN_OE PIN_EN
+#warning "'PIN_EN' is deprecated since v1.2.0 and will be removed in v2.0.0. Use 'PIN_OE' instead."
 #endif

--- a/firmware/include/config/version.h
+++ b/firmware/include/config/version.h
@@ -4,4 +4,4 @@
  */
 #include "secrets.h" // please put your custom definitions in the "secrets.h" file
 
-#define VERSION "1.1.2-dev"
+#define VERSION "1.2.0"

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "Frekvens",
-    "version": "1.1.2-dev",
+    "version": "1.2.0",
     "homepage": "https://github.com/VIPnytt/Frekvens",
     "license": "MIT",
     "repository": {

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "frekvens"
 description = "Toolbox for the Frekvens ESP32 project."
-version = "1.1.2-dev"
+version = "1.2.0"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "frekvens",
-    "version": "1.1.2-dev",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "frekvens",
-            "version": "1.1.2-dev",
+            "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
                 "@mdi/js": "7.4.47",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "frekvens",
-    "version": "1.1.2-dev",
+    "version": "1.2.0",
     "homepage": "https://github.com/VIPnytt/Frekvens",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Summary

This PR prepares the project for the v1.2.0 release.

### Key Changes

* Bumped internal version to v1.2.0.

* Updated the security policy to reflect supported versions.

* Added deprecation warnings for features scheduled for removal in future releases.

### Impact

This is primarily a versioning and maintenance update, ensuring users and contributors are informed about upcoming deprecations and current support boundaries.