### PR TITLE
Set version to 1.2.1-dev

### DIFF
--- a/firmware/include/config/version.h
+++ b/firmware/include/config/version.h
@@ -4,4 +4,4 @@
  */
 #include "secrets.h" // please put your custom definitions in the "secrets.h" file
 
-#define VERSION "1.2.0"
+#define VERSION "1.2.1-dev"

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "Frekvens",
-    "version": "1.2.0",
+    "version": "1.2.1-dev",
     "homepage": "https://github.com/VIPnytt/Frekvens",
     "license": "MIT",
     "repository": {

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "frekvens"
 description = "Toolbox for the Frekvens ESP32 project."
-version = "1.2.0"
+version = "1.2.1-dev"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "frekvens",
-    "version": "1.2.0",
+    "version": "1.2.1-dev",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "frekvens",
-            "version": "1.2.0",
+            "version": "1.2.1-dev",
             "license": "MIT",
             "dependencies": {
                 "@mdi/js": "7.4.47",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "frekvens",
-    "version": "1.2.0",
+    "version": "1.2.1-dev",
     "homepage": "https://github.com/VIPnytt/Frekvens",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Summary

This PR bumps the internal version to `1.2.1-dev`, marking the transition from the stable `1.2.0` release to ongoing development on the main branch.

### Key Changes

- Updated project version from `1.2.0` → `1.2.1-dev`.

### Impact

* No functional changes.

* Makes it clear that the main branch now represents a development version rather than a stable release.