### PR TITLE
Fix manual OTA upload and improve version handling

### DIFF
--- a/firmware/src/extensions/WebAppExtension.cpp
+++ b/firmware/src/extensions/WebAppExtension.cpp
@@ -20,14 +20,14 @@ void WebAppExtension::setup()
 {
 #ifdef F_VERBOSE
 #ifdef BOARD_BUILD__FILESYSTEM__LITTLEFS
-    if (LittleFS.begin() && LittleFS.exists("/webapp/v" VERSION ".html.gz"))
+    if (LittleFS.begin() && LittleFS.exists("/webapp/index.html.gz"))
     {
-        WebServer.http->serveStatic("/", LittleFS, "/webapp/", "max-age=60").setDefaultFile("v" VERSION ".html");
+        WebServer.http->serveStatic("/", LittleFS, "/webapp/", "max-age=60").setDefaultFile("index.html");
     }
 #else
-    if (SPIFFS.begin() && SPIFFS.exists("/webapp/v" VERSION ".html.gz"))
+    if (SPIFFS.begin() && SPIFFS.exists("/webapp/index.html.gz"))
     {
-        WebServer.http->serveStatic("/", SPIFFS, "/webapp/", "max-age=60").setDefaultFile("v" VERSION ".html");
+        WebServer.http->serveStatic("/", SPIFFS, "/webapp/", "max-age=60").setDefaultFile("index.html");
     }
 #endif // BOARD_BUILD__FILESYSTEM__LITTLEFS
     else
@@ -37,10 +37,10 @@ void WebAppExtension::setup()
 #else
 #ifdef BOARD_BUILD__FILESYSTEM__LITTLEFS
     LittleFS.begin();
-    WebServer.http->serveStatic("/", LittleFS, "/webapp/", "max-age=3600").setDefaultFile("v" VERSION ".html");
+    WebServer.http->serveStatic("/", LittleFS, "/webapp/", "max-age=3600").setDefaultFile("index.html");
 #else
     SPIFFS.begin();
-    WebServer.http->serveStatic("/", SPIFFS, "/webapp/", "max-age=3600").setDefaultFile("v" VERSION ".html");
+    WebServer.http->serveStatic("/", SPIFFS, "/webapp/", "max-age=3600").setDefaultFile("index.html");
 #endif // BOARD_BUILD__FILESYSTEM__LITTLEFS
 #endif // F_VERBOSE
     WebServer.http->on("/", WebRequestMethod::HTTP_HEAD, &onHeadRoot);

--- a/scripts/WebApp.py
+++ b/scripts/WebApp.py
@@ -31,7 +31,7 @@ class WebApp:
                     self.env.Execute(f"cd webapp && npm install && npm run build")
             prefix = "data/webapp"
             pathlib.Path(prefix).mkdir(parents=True, exist_ok=True)
-            index = f"{prefix}/v{library['version']}.html.gz"
+            index = f"{prefix}/index.html.gz"
             with open("webapp/dist/index.html", "rb") as html:
                 with gzip.open(index, "wb") as gz:
                     gz.writelines(html)

--- a/webapp/src/extensions/Ota.tsx
+++ b/webapp/src/extensions/Ota.tsx
@@ -13,6 +13,8 @@ const [getAuth, setAuth] = createSignal<boolean>(false);
 const [getFilesystem, setFilesystem] = createSignal<string>('spiffs');
 const [getPlatformioIni, setPlatformioIni] = createSignal<Record<string, string>>({});
 
+export const OtaAuth = getAuth;
+
 export const receiver = (json: any) => {
     json[name]?.filesystem !== undefined && setFilesystem(json[name].filesystem);
     json[name]?.['platformio.ini'] !== undefined && setPlatformioIni(json[name]['platformio.ini']);

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -6,9 +6,11 @@ import { Button } from './components/Button';
 import { Center } from './components/Center';
 import { ToastProvider } from './components/Toast';
 import { Icon } from './components/Vector';
+import { EXTENSION_OTA } from './config/constants';
+import { MainThird as ExtensionOtaThird, OtaAuth } from './extensions/Ota';
 import { MessageProvider, WebSocketState } from './extensions/WebSocket';
 import { MainThird as ConnectivityThird, SidebarSecondary as ConnectivitySecondarySidebar, SidebarThird as ConnectivityThirdSidebar, name as ConnectivityName } from './services/Connectivity';
-import { MainSecondary as DeviceSecondary, SidebarSecondary as DeviceSecondarySidebar, DeviceName } from './services/Device';
+import { MainSecondary as DeviceSecondary, SidebarSecondary as DeviceSecondarySidebar, DeviceName, DeviceVersion } from './services/Device';
 import { Main as DisplayMain, Sidebar as DisplaySidebar, SidebarSecondary as DisplaySecondarySidebar, DisplayPower } from './services/Display';
 import { Footer as ExtensionsFooter, SidebarSecondary as ExtensionsSecondarySidebar, MainThird as ExtensionsThird, SidebarThird as ExtensionsThirdSidebar, name as ExtensionsName } from './services/Extensions';
 import { Main as ModesMain, MainThird as ModesThird, Sidebar as ModesSidebar, SidebarSecondary as ModesSecondarySidebar, SidebarThird as ModesThirdSidebar, name as ModesName } from './services/Modes';
@@ -27,17 +29,21 @@ createEffect(() => {
     }
 });
 
-const Page = () => (
-    <div class="h-full">
-        {WebServerPath() == '/' && location.hostname != '192.168.4.1' && !location.hostname.startsWith('[fe80::') ? (
-            <Primary />
-        ) : (
-            <Secondary />
-        )}
-        {(DisplayPower() || !getSidebar()) && WebSocketState() === 1 && (
-            <Toggle />
-        )}
-    </div>
+const Page: Component = () => (
+    <>
+        {
+            WebServerPath() == '/' && location.hostname != '192.168.4.1' && !location.hostname.startsWith('[fe80::') ? (
+                <Primary />
+            ) : (
+                <Secondary />
+            )
+        }
+        {
+            (DisplayPower() || !getSidebar()) && (
+                <Toggle />
+            )
+        }
+    </>
 );
 
 const Primary: Component = () => (
@@ -120,35 +126,20 @@ const Layout: Component<{
     ref?: any;
     sidebar: JSX.Element;
 }> = (props) => (
-    <div class={`h-full ${getSidebar() && WebSocketState() === 1 ? `grid grid-cols-[320px_1fr]` : ''}`}>
-        {WebSocketState() === 1 ? (
-            <>
-                {getSidebar() && (
-                    <aside class="bg-white p-6 flex flex-col h-full">
-                        {props.sidebar}
-                    </aside>
-                )}
-                <main
-                    class="h-full overflow-auto"
-                    ref={props.ref}
-                >
-                    <div class="grid h-full justify-center items-center">
-                        {props.main}
-                    </div>
-                </main>
-            </>
-        ) : (
-            <main class="h-full overflow-auto">
-                <Center>
-                    <h2 class="text-4xl">
-                        Connecting...
-                    </h2>
-                    <p class="text-xs mt-2 text-gray-300">
-                        {DeviceName()} might be offline.
-                    </p>
-                </Center>
-            </main>
+    <div class={`h-full ${getSidebar() ? `grid grid-cols-[320px_1fr]` : ''}`}>
+        {getSidebar() && (
+            <aside class="bg-white p-6 flex flex-col h-full">
+                {props.sidebar}
+            </aside>
         )}
+        <main
+            class="h-full overflow-auto"
+            ref={props.ref}
+        >
+            <div class="grid h-full justify-center items-center">
+                {props.main}
+            </div>
+        </main>
     </div>
 );
 
@@ -178,11 +169,70 @@ const Toggle: Component = () => (
     </div>
 );
 
+const Incompatible: Component = () => (
+    <>
+        <div class="space-y-3 p-5">
+            <h3 class="text-4xl text-white tracking-wide">Frekvens</h3>
+            <div class="bg-white p-6 rounded-md">
+                <div class="space-y-2">
+                    <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                        Version conflict
+                    </h3>
+                    <p class="text-sm">
+                        Firmware: {DeviceVersion()}<br />
+                        Filesystem: {__VERSION__}
+                    </p>
+                    <p class="text-sm">
+                        Flash or upload matching versions to restore compatibility.
+                    </p>
+                </div>
+            </div>
+            <p class="text-sm text-white tracking-wide">
+                <a
+                    href={REPOSITORY}
+                    target="_blank"
+                >
+                    View project on GitHub
+                </a>
+            </p>
+        </div>
+        {
+            EXTENSION_OTA && !OtaAuth() && (
+                <ExtensionOtaThird />
+            )
+        }
+    </>
+);
+
+const Offline: Component = () => (
+    <Center>
+        <h2 class="text-4xl">
+            Connecting...
+        </h2>
+        <p class="text-xs mt-2 text-gray-300">
+            {DeviceName()} might be offline.
+        </p>
+    </Center>
+);
+
 render(
     () => (
         <ToastProvider>
             <MessageProvider>
-                <Page />
+                <div class="h-full">
+                    <Switch
+                        fallback={
+                            <Page />
+                        }
+                    >
+                        <Match when={WebSocketState() !== 1}>
+                            <Offline />
+                        </Match>
+                        <Match when={__VERSION__ != DeviceVersion()}>
+                            <Incompatible />
+                        </Match>
+                    </Switch>
+                </div>
             </MessageProvider>
         </ToastProvider>
     ),

--- a/webapp/src/services/Device.tsx
+++ b/webapp/src/services/Device.tsx
@@ -16,15 +16,18 @@ export const name = 'Device';
 
 const [getModel, setModel] = createSignal<string>(MODEL || MODEL_FREKVENS);
 const [getName, setName] = createSignal<string>(NAME || MODEL || MODEL_FREKVENS);
+const [getVersion, setVersion] = createSignal<string>(__VERSION__);
 const [getVersionLatest, setVersionLatest] = createSignal<string>(__VERSION__);
 
 export const DeviceModel = getModel;
 export const DeviceName = getName;
+export const DeviceVersion = getVersion;
 
 export const receiver = (json: any) => {
     json[name]?.event !== undefined && event(json[name].event);
     json[name]?.model !== undefined && setModel(json[name].model);
     json[name]?.name !== undefined && setName(json[name].name);
+    json[name]?.version !== undefined && setVersion(json[name].version);
     json[name]?.version_latest !== undefined && setVersionLatest(json[name].version_latest);
 };
 


### PR DESCRIPTION
### Summary

Fixes a bug in the web UI where the manual OTA upload interface could disappear after refreshing the page between `firmware.bin` and `spiffs.bin`/`littlefs.bin` uploads, typically during version migrations.

### Key Changes

* Fixed a bug causing the manual OTA upload interface to disappear during version-to-version migrations.

* Added version checking to the web UI.

* Implemented a fallback minimalistic UI with an error message and manual OTA upload option if a version mismatch is detected.

* Reorganized internal logic related to offline detection for improved maintainability and clarity.

### Impact

Manual OTA uploads now work reliably even across version changes.
Users who previously encountered disappearing upload forms can now complete manual OTA updates without resorting to automatic OTA via `espota` or manual USB flashing.
Overall UI behavior remains unchanged aside from improved resilience and clearer error handling.