### PR TITLE
Skip building the Web App when disabled

### DIFF
--- a/scripts/WebApp.py
+++ b/scripts/WebApp.py
@@ -11,7 +11,6 @@ import sys
 class WebApp:
     def __init__(self, env) -> None:
         self.env = env
-        self.check()
 
     def build(self) -> None:
         with open("library.json") as pio, open("webapp/package.json") as npm, open(
@@ -37,7 +36,20 @@ class WebApp:
                     gz.writelines(html)
                     print(index)
 
-    def check(self) -> None:
+    def check(self) -> bool:
+        env_pio = dotenv.dotenv_values(".env")
+        if (
+            env_pio.get("EXTENSION_WEBAPP", "false") != "false"
+            and env_pio.get("EXTENSION_WEBSOCKET") == "false"
+        ):
+            print("WebSocket is required by the Web app.")
+            print("Please re-enable 'EXTENSION_WEBSOCKET' in .env")
+            sys.exit(1)
+        elif (
+            env_pio.get("EXTENSION_WEBAPP") == "false"
+            or env_pio.get("EXTENSION_WEBSOCKET") == "false"
+        ):
+            return False
         try:
             subprocess.run(
                 ["node", "--version"],
@@ -49,6 +61,7 @@ class WebApp:
             print("Node.js is required but was not found on your system.")
             print("Please install Node.js from https://nodejs.org/")
             sys.exit(1)
+        return True
 
     def clean(self) -> None:
         for path in [

--- a/scripts/preBuild.py
+++ b/scripts/preBuild.py
@@ -41,11 +41,11 @@ if not env.IsCleanTarget() and COMMAND_LINE_TARGETS not in [  # type: ignore
     ["upload"],
 ]:
     webapp = WebApp.WebApp(env)  # type: ignore
-    webapp.check()
-    webapp.version()
-    webapp.evironment()
-    webapp.environment_dev()
-    webapp.build()
+    if webapp.check():
+        webapp.version()
+        webapp.evironment()
+        webapp.environment_dev()
+        webapp.build()
 
 if not env.IsCleanTarget() and COMMAND_LINE_TARGETS not in [  # type: ignore
     ["erase"],


### PR DESCRIPTION
### Summary

Adds logic to skip building the Web App entirely when it is disabled, preventing unnecessary build steps and improving developer experience.

### Key changes

* The Web App is no longer built if disabled in the configuration.

* Builds no longer require Node.js to be installed when the Web App is disabled.

* Added a console error if the Web App is enabled while the WebSocket extension is disabled, as WebSocket is a required dependency.

### Impact

* Simplifies the build process and removes a potential point of confusion for developers who do not use the Web App.

* Reduces unnecessary build dependencies, resulting in faster and more reliable builds.