### PR TITLE
Add conditional build constants to all mode classes

### DIFF
--- a/firmware/include/modes/AnimationMode.h
+++ b/firmware/include/modes/AnimationMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_ANIMATION
+
 #include <vector>
 
 #include "modules/ModeModule.h"
@@ -22,3 +26,5 @@ public:
     void handle() override;
     void receiverHook(const JsonDocument doc) override;
 };
+
+#endif // MODE_ANIMATION

--- a/firmware/include/modes/ArrowMode.h
+++ b/firmware/include/modes/ArrowMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_ARROW
+
 #include "modules/ModeModule.h"
 
 class ArrowMode : public ModeModule
@@ -86,3 +90,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_ARROW

--- a/firmware/include/modes/ArtNetMode.h
+++ b/firmware/include/modes/ArtNetMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_ARTNET
+
 #include <AsyncUDP.h>
 #include <bits/unique_ptr.h>
 
@@ -20,3 +24,5 @@ public:
 
     static void onPacket(AsyncUDPPacket packet);
 };
+
+#endif // MODE_ARTNET

--- a/firmware/include/modes/BinaryClockMode.h
+++ b/firmware/include/modes/BinaryClockMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_BINARYCLOCK
+
 #include "modules/ModeModule.h"
 
 class BinaryClockMode : public ModeModule
@@ -22,3 +26,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_BINARYCLOCK

--- a/firmware/include/modes/BinaryEpochMode.h
+++ b/firmware/include/modes/BinaryEpochMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_BINARYEPOCH
+
 #include "modules/ModeModule.h"
 
 class BinaryEpochMode : public ModeModule
@@ -12,3 +16,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_BINARYEPOCH

--- a/firmware/include/modes/BlindsMode.h
+++ b/firmware/include/modes/BlindsMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_BLINDS
+
 #include "modules/ModeModule.h"
 
 class BlindsMode : public ModeModule
@@ -18,3 +22,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_BLINDS

--- a/firmware/include/modes/BlinkMode.h
+++ b/firmware/include/modes/BlinkMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_BLINK
+
 #include "modules/ModeModule.h"
 
 class BlinkMode : public ModeModule
@@ -12,3 +16,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_BLINK

--- a/firmware/include/modes/BoldClockMode.h
+++ b/firmware/include/modes/BoldClockMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_BOLDCLOCK
+
 #include "modules/ModeModule.h"
 
 class BoldClockMode : public ModeModule
@@ -19,3 +23,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_BOLDCLOCK

--- a/firmware/include/modes/BreakoutClockMode.h
+++ b/firmware/include/modes/BreakoutClockMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_BREAKOUTCLOCK
+
 #include <deque>
 
 #include "config/constants.h"
@@ -32,3 +36,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_BREAKOUTCLOCK

--- a/firmware/include/modes/BrightMode.h
+++ b/firmware/include/modes/BrightMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_BRIGHT
+
 #include "modules/ModeModule.h"
 
 class BrightMode : public ModeModule
@@ -9,3 +13,5 @@ public:
 
     void wake() override;
 };
+
+#endif // MODE_BRIGHT

--- a/firmware/include/modes/CircleMode.h
+++ b/firmware/include/modes/CircleMode.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include "config/constants.h"
+
+#if MODE_CIRCLE
+
+#include "config/constants.h"
 #include "modules/ModeModule.h"
 
 class CircleMode : public ModeModule
@@ -23,3 +27,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_CIRCLE

--- a/firmware/include/modes/CountdownMode.h
+++ b/firmware/include/modes/CountdownMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_COUNTDOWN
+
 #include <chrono>
 
 #include "modules/ModeModule.h"
@@ -28,3 +32,5 @@ public:
     void handle() override;
     void receiverHook(const JsonDocument doc) override;
 };
+
+#endif // MODE_COUNTDOWN

--- a/firmware/include/modes/DistributedDisplayProtocolMode.h
+++ b/firmware/include/modes/DistributedDisplayProtocolMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_DISTRIBUTEDDISPLAYPROTOCOL
+
 #include <AsyncUDP.h>
 #include <bits/unique_ptr.h>
 
@@ -20,3 +24,5 @@ public:
 
     static void onPacket(AsyncUDPPacket packet);
 };
+
+#endif // MODE_DISTRIBUTEDDISPLAYPROTOCOL

--- a/firmware/include/modes/DrawMode.h
+++ b/firmware/include/modes/DrawMode.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "config/constants.h"
+
+#if MODE_DRAW
+
 #include "modules/ModeModule.h"
 
 class DrawMode : public ModeModule
@@ -23,3 +26,5 @@ public:
     void sleep() override;
     void receiverHook(const JsonDocument doc) override;
 };
+
+#endif // MODE_DRAW

--- a/firmware/include/modes/E131Mode.h
+++ b/firmware/include/modes/E131Mode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_E131
+
 #include <AsyncUDP.h>
 #include <bits/unique_ptr.h>
 
@@ -20,3 +24,5 @@ public:
 
     static void onPacket(AsyncUDPPacket packet);
 };
+
+#endif // MODE_E131

--- a/firmware/include/modes/EqualizerMode.h
+++ b/firmware/include/modes/EqualizerMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_EQUALIZER
+
 #include "modules/ModeModule.h"
 
 class EqualizerMode : public ModeModule
@@ -17,3 +21,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_EQUALIZER

--- a/firmware/include/modes/FireworkMode.h
+++ b/firmware/include/modes/FireworkMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_FIREWORK
+
 #include "modules/ModeModule.h"
 
 class FireworkMode : public ModeModule
@@ -25,3 +29,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_FIREWORK

--- a/firmware/include/modes/FliesMode.h
+++ b/firmware/include/modes/FliesMode.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_FLIES
+
 #include <unordered_map>
 #include <vector>
 
-#include "config/constants.h"
 #include "modules/ModeModule.h"
 
 class FliesMode : public ModeModule
@@ -28,3 +31,5 @@ public:
     void handle() override;
     void receiverHook(const JsonDocument doc) override;
 };
+
+#endif // MODE_FLIES

--- a/firmware/include/modes/GameOfLifeClockMode.h
+++ b/firmware/include/modes/GameOfLifeClockMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_GAMEOFLIFECLOCK
+
 #include "modules/ModeModule.h"
 
 class GameOfLifeClockMode : public ModeModule
@@ -22,3 +26,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_GAMEOFLIFECLOCK

--- a/firmware/include/modes/GameOfLifeMode.h
+++ b/firmware/include/modes/GameOfLifeMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_GAMEOFLIFE
+
 #include "modules/ModeModule.h"
 
 class GameOfLifeMode : public ModeModule
@@ -14,3 +18,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_GAMEOFLIFE

--- a/firmware/include/modes/GlitterMode.h
+++ b/firmware/include/modes/GlitterMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_GLITTER
+
 #include "modules/ModeModule.h"
 
 class GlitterMode : public ModeModule
@@ -9,3 +13,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_GLITTER

--- a/firmware/include/modes/HomeThermometerMode.h
+++ b/firmware/include/modes/HomeThermometerMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_HOMETHERMOMETER
+
 #include "modules/ModeModule.h"
 
 class HomeThermometerMode : public ModeModule
@@ -19,3 +23,5 @@ public:
     void handle() override;
     void receiverHook(const JsonDocument doc) override;
 };
+
+#endif // MODE_HOMETHERMOMETER

--- a/firmware/include/modes/JaggedWaveformMode.h
+++ b/firmware/include/modes/JaggedWaveformMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_JAGGEDWAVEFORM
+
 #include "modules/ModeModule.h"
 
 class JaggedWaveformMode : public ModeModule
@@ -72,3 +76,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_JAGGEDWAVEFORM

--- a/firmware/include/modes/LeafFallMode.h
+++ b/firmware/include/modes/LeafFallMode.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "config/constants.h"
+
+#if MODE_LEAFFALL
+
 #include "modules/ModeModule.h"
 
 class LeafFallMode : public ModeModule
@@ -24,3 +27,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_LEAFFALL

--- a/firmware/include/modes/LinesMode.h
+++ b/firmware/include/modes/LinesMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_LINES
+
 #include "modules/ModeModule.h"
 
 class LinesMode : public ModeModule
@@ -14,3 +18,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_LINES

--- a/firmware/include/modes/MetaballsMode.h
+++ b/firmware/include/modes/MetaballsMode.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "config/constants.h"
+
+#if MODE_METABALLS
+
 #include "modules/ModeModule.h"
 
 class MetaballsMode : public ModeModule
@@ -34,3 +37,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_METABALLS

--- a/firmware/include/modes/NoiseMode.h
+++ b/firmware/include/modes/NoiseMode.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "config/constants.h"
+
+#if MODE_NOISE
+
 #include "modules/ModeModule.h"
 
 class NoiseMode : public ModeModule
@@ -22,3 +25,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_NOISE

--- a/firmware/include/modes/OpenMeteoMode.h
+++ b/firmware/include/modes/OpenMeteoMode.h
@@ -2,7 +2,7 @@
 
 #include "config/constants.h"
 
-#if defined(LATITUDE) && defined(LONGITUDE)
+#if MODE_OPENMETEO && defined(LATITUDE) && defined(LONGITUDE)
 
 #include <vector>
 
@@ -72,4 +72,4 @@ public:
     void handle() override;
 };
 
-#endif // defined(LATITUDE) && defined(LONGITUDE)
+#endif // MODE_OPENMETEO && defined(LATITUDE) && defined(LONGITUDE)

--- a/firmware/include/modes/OpenWeatherMode.h
+++ b/firmware/include/modes/OpenWeatherMode.h
@@ -2,7 +2,7 @@
 
 #include "config/constants.h"
 
-#if defined(OPENWEATHER_KEY) && defined(LATITUDE) && defined(LONGITUDE)
+#if MODE_OPENWEATHER && defined(OPENWEATHER_KEY) && defined(LATITUDE) && defined(LONGITUDE)
 
 #include <vector>
 
@@ -69,4 +69,4 @@ public:
     void handle() override;
 };
 
-#endif // defined(LATITUDE) && defined(LONGITUDE) && defined(OPENWEATHER_KEY)
+#endif // MODE_OPENWEATHER && defined(LATITUDE) && defined(LONGITUDE) && defined(OPENWEATHER_KEY)

--- a/firmware/include/modes/PingPongClockMode.h
+++ b/firmware/include/modes/PingPongClockMode.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_PINGPONGCLOCK
+
 #include <deque>
 
-#include "config/constants.h"
 #include "modules/ModeModule.h"
 
 class PingPongClockMode : public ModeModule
@@ -41,3 +44,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_PINGPONGCLOCK

--- a/firmware/include/modes/PingPongMode.h
+++ b/firmware/include/modes/PingPongMode.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_PINGPONG
+
 #include <deque>
 
-#include "config/constants.h"
 #include "modules/ModeModule.h"
 
 class PingPongMode : public ModeModule
@@ -35,3 +38,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_PINGPONG

--- a/firmware/include/modes/PixelSequenceMode.h
+++ b/firmware/include/modes/PixelSequenceMode.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "config/constants.h"
+
+#if MODE_PIXELSEQUENCE
+
 #include "modules/ModeModule.h"
 
 class PixelSequenceMode : public ModeModule
@@ -19,3 +22,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_PIXELSEQUENCE

--- a/firmware/include/modes/RainMode.h
+++ b/firmware/include/modes/RainMode.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "config/constants.h"
+
+#if MODE_RAIN
+
 #include "modules/ModeModule.h"
 
 // Ikea Obegränsad stock rain animation:
@@ -27,3 +30,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_RAIN

--- a/firmware/include/modes/RingMode.h
+++ b/firmware/include/modes/RingMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_RING
+
 #include "modules/ModeModule.h"
 
 class RingMode : public ModeModule
@@ -127,3 +131,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_RING

--- a/firmware/include/modes/ScanMode.h
+++ b/firmware/include/modes/ScanMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_SCAN
+
 #include "modules/ModeModule.h"
 
 class ScanMode : public ModeModule
@@ -14,3 +18,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_SCAN

--- a/firmware/include/modes/SmallClockMode.h
+++ b/firmware/include/modes/SmallClockMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_SMALLCLOCK
+
 #include "modules/ModeModule.h"
 
 class SmallClockMode : public ModeModule
@@ -19,3 +23,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_SMALLCLOCK

--- a/firmware/include/modes/SmoothWaveformMode.h
+++ b/firmware/include/modes/SmoothWaveformMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_SMOOTHWAVEFORM
+
 #include "modules/ModeModule.h"
 
 class SmoothWaveformMode : public ModeModule
@@ -60,3 +64,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_SMOOTHWAVEFORM

--- a/firmware/include/modes/SnakeClockMode.h
+++ b/firmware/include/modes/SnakeClockMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_SNAKECLOCK
+
 #include <deque>
 
 #include "modules/ModeModule.h"
@@ -53,3 +57,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_SNAKECLOCK

--- a/firmware/include/modes/SnakeMode.h
+++ b/firmware/include/modes/SnakeMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_SNAKE
+
 #include "modules/ModeModule.h"
 
 class SnakeMode : public ModeModule
@@ -45,3 +49,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_SNAKE

--- a/firmware/include/modes/StarsMode.h
+++ b/firmware/include/modes/StarsMode.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "config/constants.h"
+
+#if MODE_STARS
+
 #include "modules/ModeModule.h"
 
 class StarsMode : public ModeModule
@@ -25,3 +28,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_STARS

--- a/firmware/include/modes/TickerMode.h
+++ b/firmware/include/modes/TickerMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_TICKER
+
 #include <bits/unique_ptr.h>
 
 #include "handlers/TextHandler.h"
@@ -41,3 +45,5 @@ public:
 
     void receiverHook(const JsonDocument doc) override;
 };
+
+#endif // MODE_TICKER

--- a/firmware/include/modes/TickingClockMode.h
+++ b/firmware/include/modes/TickingClockMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_TICKINGCLOCK
+
 #include "modules/ModeModule.h"
 
 class TickingClockMode : public ModeModule
@@ -20,3 +24,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_TICKINGCLOCK

--- a/firmware/include/modes/WaveformMode.h
+++ b/firmware/include/modes/WaveformMode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_WAVEFORM
+
 #include "modules/ModeModule.h"
 
 class WaveformMode : public ModeModule
@@ -117,3 +121,5 @@ public:
 
     void handle() override;
 };
+
+#endif // MODE_WAVEFORM

--- a/firmware/include/modes/WorldWeatherOnlineMode.h
+++ b/firmware/include/modes/WorldWeatherOnlineMode.h
@@ -2,7 +2,7 @@
 
 #include "config/constants.h"
 
-#if defined(WORLDWEATHERONLINE_KEY) && ((defined(LATITUDE) && defined(LONGITUDE)) || defined(LOCATION))
+#if MODE_WORLDWEATHERONLINE && defined(WORLDWEATHERONLINE_KEY) && ((defined(LATITUDE) && defined(LONGITUDE)) || defined(LOCATION))
 
 #include <vector>
 
@@ -74,4 +74,4 @@ public:
     void handle() override;
 };
 
-#endif // defined(WORLDWEATHERONLINE_KEY) && ((defined(LATITUDE) && defined(LONGITUDE)) || defined(LOCATION))
+#endif // MODE_WORLDWEATHERONLINE && defined(WORLDWEATHERONLINE_KEY) && ((defined(LATITUDE) && defined(LONGITUDE)) || defined(LOCATION))

--- a/firmware/include/modes/WttrInMode.h
+++ b/firmware/include/modes/WttrInMode.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if MODE_WTTRIN
+
 #include <vector>
 
-#include "config/constants.h"
 #include "handlers/WeatherHandler.h"
 #include "modules/ModeModule.h"
 
@@ -75,3 +78,5 @@ public:
     void wake() override;
     void handle() override;
 };
+
+#endif // MODE_WTTRIN

--- a/firmware/include/modes/YrMode.h
+++ b/firmware/include/modes/YrMode.h
@@ -2,7 +2,7 @@
 
 #include "config/constants.h"
 
-#if defined(LATITUDE) && defined(LONGITUDE)
+#if MODE_YR && defined(LATITUDE) && defined(LONGITUDE)
 
 #include <vector>
 
@@ -165,4 +165,4 @@ public:
     void handle();
 };
 
-#endif // defined(LATITUDE) && defined(LONGITUDE)
+#endif // MODE_YR && defined(LATITUDE) && defined(LONGITUDE)

--- a/firmware/src/modes/AnimationMode.cpp
+++ b/firmware/src/modes/AnimationMode.cpp
@@ -1,6 +1,9 @@
+#include "config/constants.h"
+
+#if MODE_ANIMATION
+
 #include <Preferences.h>
 
-#include "config/constants.h"
 #include "extensions/MicrophoneExtension.h"
 #include "handlers/BitmapHandler.h"
 #include "modes/AnimationMode.h"
@@ -129,3 +132,5 @@ void AnimationMode::receiverHook(const JsonDocument doc)
         Storage.end();
     }
 }
+
+#endif // MODE_ANIMATION

--- a/firmware/src/modes/ArrowMode.cpp
+++ b/firmware/src/modes/ArrowMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_ARROW
+
 #include "extensions/MicrophoneExtension.h"
 #include "handlers/BitmapHandler.h"
 #include "modes/ArrowMode.h"
@@ -25,3 +28,5 @@ void ArrowMode::handle()
         }
     }
 }
+
+#endif // MODE_ARROW

--- a/firmware/src/modes/ArtNetMode.cpp
+++ b/firmware/src/modes/ArtNetMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_ARTNET
+
 #include "modes/ArtNetMode.h"
 #include "services/ConnectivityService.h"
 #include "services/DisplayService.h"
@@ -33,3 +36,5 @@ void ArtNetMode::sleep()
 {
     udp.reset();
 }
+
+#endif // MODE_ARTNET

--- a/firmware/src/modes/BinaryClockMode.cpp
+++ b/firmware/src/modes/BinaryClockMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_BINARYCLOCK
+
 #include "modes/BinaryClockMode.h"
 #include "services/DisplayService.h"
 
@@ -37,3 +41,5 @@ void BinaryClockMode::draw(uint8_t y, uint8_t value)
         Display.drawRectangle(x, y, x + 1, y + 3, true, value & (1U << i) ? UINT8_MAX : 0);
     }
 }
+
+#endif // MODE_BINARYCLOCK

--- a/firmware/src/modes/BinaryEpochMode.cpp
+++ b/firmware/src/modes/BinaryEpochMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_BINARYEPOCH
+
 #include "modes/BinaryEpochMode.h"
 #include "services/DisplayService.h"
 
@@ -16,3 +20,5 @@ void BinaryEpochMode::handle()
         }
     }
 }
+
+#endif // MODE_BINARYEPOCH

--- a/firmware/src/modes/BlindsMode.cpp
+++ b/firmware/src/modes/BlindsMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_BLINDS
+
 #include "extensions/MicrophoneExtension.h"
 #include "modes/BlindsMode.h"
 #include "services/DisplayService.h"
@@ -27,3 +30,5 @@ void BlindsMode::handle()
         direction ? ++modulo : --modulo;
     }
 }
+
+#endif // MODE_BLINDS

--- a/firmware/src/modes/BlinkMode.cpp
+++ b/firmware/src/modes/BlinkMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_BLINK
+
 #include "extensions/MicrophoneExtension.h"
 #include "modes/BlinkMode.h"
 #include "services/DisplayService.h"
@@ -15,3 +18,5 @@ void BlinkMode::handle()
         Display.clear(Display.getPixel(0, 0) ? 0 : UINT8_MAX);
     }
 }
+
+#endif // MODE_BLINK

--- a/firmware/src/modes/BoldClockMode.cpp
+++ b/firmware/src/modes/BoldClockMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_BOLDCLOCK
+
 #include "fonts/MediumBoldFont.h"
 #include "handlers/TextHandler.h"
 #include "modes/BoldClockMode.h"
@@ -28,3 +31,5 @@ void BoldClockMode::handle()
         pending = false;
     }
 }
+
+#endif // MODE_BOLDCLOCK

--- a/firmware/src/modes/BreakoutClockMode.cpp
+++ b/firmware/src/modes/BreakoutClockMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_BREAKOUTCLOCK
+
 #include "fonts/MiniFont.h"
 #include "handlers/TextHandler.h"
 #include "modes/BreakoutClockMode.h"
@@ -87,3 +91,5 @@ void BreakoutClockMode::handle()
         Display.setPixel(paddle.front(), COLUMNS - 1);
     }
 }
+
+#endif // MODE_BREAKOUTCLOCK

--- a/firmware/src/modes/BrightMode.cpp
+++ b/firmware/src/modes/BrightMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_BRIGHT
+
 #include "modes/BrightMode.h"
 #include "services/DisplayService.h"
 
@@ -5,3 +9,5 @@ void BrightMode::wake()
 {
     Display.clear(UINT8_MAX);
 }
+
+#endif // MODE_BRIGHT

--- a/firmware/src/modes/CircleMode.cpp
+++ b/firmware/src/modes/CircleMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_CIRCLE
+
 #include "extensions/MicrophoneExtension.h"
 #include "modes/CircleMode.h"
 #include "services/DisplayService.h"
@@ -27,3 +31,5 @@ void CircleMode::handle()
         }
     }
 }
+
+#endif // MODE_CIRCLE

--- a/firmware/src/modes/CountdownMode.cpp
+++ b/firmware/src/modes/CountdownMode.cpp
@@ -1,8 +1,11 @@
+#include "config/constants.h"
+
+#if MODE_COUNTDOWN
+
 #include <iomanip>
 #include <Preferences.h>
 #include <sstream>
 
-#include "config/constants.h"
 #include "extensions/HomeAssistantExtension.h"
 #include "fonts/MediumFont.h"
 #include "handlers/TextHandler.h"
@@ -141,3 +144,5 @@ void CountdownMode::save()
     Storage.end();
     transmit();
 }
+
+#endif // MODE_COUNTDOWN

--- a/firmware/src/modes/DistributedDisplayProtocolMode.cpp
+++ b/firmware/src/modes/DistributedDisplayProtocolMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_DISTRIBUTEDDISPLAYPROTOCOL
+
 #include "modes/DistributedDisplayProtocolMode.h"
 #include "services/ConnectivityService.h"
 #include "services/DisplayService.h"
@@ -34,3 +37,5 @@ void DistributedDisplayProtocolMode::sleep()
 {
     udp.reset();
 }
+
+#endif // MODE_DISTRIBUTEDDISPLAYPROTOCOL

--- a/firmware/src/modes/DrawMode.cpp
+++ b/firmware/src/modes/DrawMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_DRAW
+
 #include <Preferences.h>
 
 #include "handlers/BitmapHandler.h"
@@ -149,3 +153,5 @@ void DrawMode::save(bool cache)
     }
     transmit();
 }
+
+#endif // MODE_DRAW

--- a/firmware/src/modes/E131Mode.cpp
+++ b/firmware/src/modes/E131Mode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_E131
+
 #include "modes/E131Mode.h"
 #include "services/ConnectivityService.h"
 #include "services/DisplayService.h"
@@ -33,3 +36,5 @@ void E131Mode::sleep()
 {
     udp.reset();
 }
+
+#endif // MODE_E131

--- a/firmware/src/modes/EqualizerMode.cpp
+++ b/firmware/src/modes/EqualizerMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_EQUALIZER
+
 #include "extensions/MicrophoneExtension.h"
 #include "modes/EqualizerMode.h"
 #include "services/DisplayService.h"
@@ -30,3 +33,5 @@ void EqualizerMode::handle()
         }
     }
 }
+
+#endif // MODE_EQUALIZER

--- a/firmware/src/modes/FireworkMode.cpp
+++ b/firmware/src/modes/FireworkMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_FIREWORK
+
 #include "extensions/MicrophoneExtension.h"
 #include "modes/FireworkMode.h"
 #include "services/DisplayService.h"
@@ -89,3 +92,5 @@ void FireworkMode::fading()
         Display.clear();
     }
 }
+
+#endif // MODE_FIREWORK

--- a/firmware/src/modes/FliesMode.cpp
+++ b/firmware/src/modes/FliesMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_FLIES
+
 #include "modes/FliesMode.h"
 #include "services/DisplayService.h"
 
@@ -22,3 +26,5 @@ void FliesMode::receiverHook(const JsonDocument doc)
         pending = true;
     }
 }
+
+#endif // MODE_FLIES

--- a/firmware/src/modes/GameOfLifeClockMode.cpp
+++ b/firmware/src/modes/GameOfLifeClockMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_GAMEOFLIFECLOCK
+
 #include "fonts/MiniFont.h"
 #include "handlers/TextHandler.h"
 #include "modes/GameOfLifeClockMode.h"
@@ -71,3 +74,5 @@ void GameOfLifeClockMode::handle()
         }
     }
 }
+
+#endif // MODE_GAMEOFLIFECLOCK

--- a/firmware/src/modes/GameOfLifeMode.cpp
+++ b/firmware/src/modes/GameOfLifeMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_GAMEOFLIFE
+
 #include "modes/GameOfLifeMode.h"
 #include "services/DisplayService.h"
 
@@ -52,3 +55,5 @@ void GameOfLifeMode::handle()
         }
     }
 }
+
+#endif // MODE_GAMEOFLIFE

--- a/firmware/src/modes/GlitterMode.cpp
+++ b/firmware/src/modes/GlitterMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_GLITTER
+
 #include "modes/GlitterMode.h"
 #include "services/DisplayService.h"
 
@@ -6,3 +9,5 @@ void GlitterMode::handle()
 {
     Display.setPixel(random(COLUMNS), random(ROWS), random(1, 1U << 8));
 }
+
+#endif // MODE_GLITTER

--- a/firmware/src/modes/HomeThermometerMode.cpp
+++ b/firmware/src/modes/HomeThermometerMode.cpp
@@ -1,8 +1,11 @@
+#include "config/constants.h"
+
+#if MODE_HOMETHERMOMETER
+
 #include <nvs.h>
 #include <Preferences.h>
 #include <regex>
 
-#include "config/constants.h"
 #include "extensions/BuildExtension.h"
 #include "extensions/HomeAssistantExtension.h"
 #include "fonts/MiniFont.h"
@@ -148,3 +151,5 @@ void HomeThermometerMode::set(const char *const where, const int16_t temperature
     Serial.printf("%s: %s %d\n", name, where, temperature);
 #endif
 }
+
+#endif // MODE_HOMETHERMOMETER

--- a/firmware/src/modes/JaggedWaveformMode.cpp
+++ b/firmware/src/modes/JaggedWaveformMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_JAGGEDWAVEFORM
+
 #include "extensions/MicrophoneExtension.h"
 #include "handlers/BitmapHandler.h"
 #include "modes/JaggedWaveformMode.h"
@@ -19,3 +22,5 @@ void JaggedWaveformMode::handle()
         bitmap.draw((COLUMNS - bitmap.getWidth()) / 2, (ROWS - bitmap.getHeight()) / 2);
     }
 }
+
+#endif // MODE_JAGGEDWAVEFORM

--- a/firmware/src/modes/LeafFallMode.cpp
+++ b/firmware/src/modes/LeafFallMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_LEAFFALL
+
 #include "modes/LeafFallMode.h"
 #include "services/DisplayService.h"
 
@@ -48,3 +52,5 @@ void LeafFallMode::handle()
         }
     }
 }
+
+#endif // MODE_LEAFFALL

--- a/firmware/src/modes/LinesMode.cpp
+++ b/firmware/src/modes/LinesMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_LINES
+
 #include "extensions/MicrophoneExtension.h"
 #include "modes/LinesMode.h"
 #include "services/DisplayService.h"
@@ -33,3 +36,5 @@ void LinesMode::handle()
         }
     }
 }
+
+#endif // MODE_LINES

--- a/firmware/src/modes/MetaballsMode.cpp
+++ b/firmware/src/modes/MetaballsMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_METABALLS
+
 #include "extensions/MicrophoneExtension.h"
 #include "modes/MetaballsMode.h"
 #include "services/DisplayService.h"
@@ -87,3 +91,5 @@ void MetaballsMode::handle()
         }
     }
 }
+
+#endif // MODE_METABALLS

--- a/firmware/src/modes/NoiseMode.cpp
+++ b/firmware/src/modes/NoiseMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_NOISE
+
 #include "modes/NoiseMode.h"
 #include "services/DisplayService.h"
 
@@ -16,3 +20,5 @@ void NoiseMode::handle()
         }
     }
 }
+
+#endif // MODE_NOISE

--- a/firmware/src/modes/OpenMeteoMode.cpp
+++ b/firmware/src/modes/OpenMeteoMode.cpp
@@ -1,6 +1,6 @@
 #include "config/constants.h"
 
-#if defined(LATITUDE) && defined(LONGITUDE)
+#if MODE_OPENMETEO && defined(LATITUDE) && defined(LONGITUDE)
 
 #include <HTTPClient.h>
 
@@ -89,4 +89,4 @@ void OpenMeteoMode::update()
     }
 }
 
-#endif // defined(LATITUDE) && defined(LONGITUDE)
+#endif // MODE_OPENMETEO && defined(LATITUDE) && defined(LONGITUDE)

--- a/firmware/src/modes/OpenWeatherMode.cpp
+++ b/firmware/src/modes/OpenWeatherMode.cpp
@@ -1,6 +1,6 @@
 #include "config/constants.h"
 
-#if defined(OPENWEATHER_KEY) && defined(LATITUDE) && defined(LONGITUDE)
+#if MODE_OPENWEATHER && defined(OPENWEATHER_KEY) && defined(LATITUDE) && defined(LONGITUDE)
 
 #include <HTTPClient.h>
 
@@ -99,4 +99,4 @@ void OpenWeatherMode::update()
     }
 }
 
-#endif // defined(LATITUDE) && defined(LONGITUDE) && defined(OPENWEATHER_KEY)
+#endif // MODE_OPENWEATHER && defined(OPENWEATHER_KEY) && defined(LATITUDE) && defined(LONGITUDE)

--- a/firmware/src/modes/PingPongClockMode.cpp
+++ b/firmware/src/modes/PingPongClockMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_PINGPONGCLOCK
+
 #include "fonts/MiniFont.h"
 #include "handlers/TextHandler.h"
 #include "modes/PingPongClockMode.h"
@@ -113,3 +117,5 @@ void PingPongClockMode::predict()
     } while (_x > 1 && _x + .5 < COLUMNS - 2);
     targetY = _y + .5;
 }
+
+#endif // MODE_PINGPONGCLOCK

--- a/firmware/src/modes/PingPongMode.cpp
+++ b/firmware/src/modes/PingPongMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_PINGPONG
+
 #include "modes/PingPongMode.h"
 #include "services/DisplayService.h"
 
@@ -98,3 +102,5 @@ void PingPongMode::predict()
     } while (_y > 1 && _y + .5 < ROWS - 2);
     targetX = _x + .5;
 }
+
+#endif // MODE_PINGPONG

--- a/firmware/src/modes/PixelSequenceMode.cpp
+++ b/firmware/src/modes/PixelSequenceMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_PIXELSEQUENCE
+
 #include "extensions/MicrophoneExtension.h"
 #include "modes/PixelSequenceMode.h"
 #include "services/DisplayService.h"
@@ -27,3 +31,5 @@ void PixelSequenceMode::handle()
         lastMillis = millis();
     }
 }
+
+#endif // MODE_PIXELSEQUENCE

--- a/firmware/src/modes/RainMode.cpp
+++ b/firmware/src/modes/RainMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_RAIN
+
 #include "modes/RainMode.h"
 #include "services/DisplayService.h"
 
@@ -57,3 +61,5 @@ void RainMode::handle()
         }
     }
 }
+
+#endif // MODE_RAIN

--- a/firmware/src/modes/RingMode.cpp
+++ b/firmware/src/modes/RingMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_RING
+
 #include "extensions/MicrophoneExtension.h"
 #include "handlers/BitmapHandler.h"
 #include "modes/RingMode.h"
@@ -24,3 +27,5 @@ void RingMode::handle()
         }
     }
 }
+
+#endif // MODE_RING

--- a/firmware/src/modes/ScanMode.cpp
+++ b/firmware/src/modes/ScanMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_SCAN
+
 #include "extensions/MicrophoneExtension.h"
 #include "modes/ScanMode.h"
 #include "services/DisplayService.h"
@@ -30,3 +33,5 @@ void ScanMode::handle()
         }
     }
 }
+
+#endif // MODE_SCAN

--- a/firmware/src/modes/SmallClockMode.cpp
+++ b/firmware/src/modes/SmallClockMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_SMALLCLOCK
+
 #include "fonts/MiniFont.h"
 #include "handlers/TextHandler.h"
 #include "modes/SmallClockMode.h"
@@ -23,3 +27,5 @@ void SmallClockMode::handle()
         pending = false;
     }
 }
+
+#endif // MODE_SMALLCLOCK

--- a/firmware/src/modes/SmoothWaveformMode.cpp
+++ b/firmware/src/modes/SmoothWaveformMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_SMOOTHWAVEFORM
+
 #include "extensions/MicrophoneExtension.h"
 #include "handlers/BitmapHandler.h"
 #include "modes/SmoothWaveformMode.h"
@@ -19,3 +22,5 @@ void SmoothWaveformMode::handle()
         bitmap.draw((COLUMNS - bitmap.getWidth()) / 2, (ROWS - bitmap.getHeight()) / 2);
     }
 }
+
+#endif // MODE_SMOOTHWAVEFORM

--- a/firmware/src/modes/SnakeClockMode.cpp
+++ b/firmware/src/modes/SnakeClockMode.cpp
@@ -1,7 +1,10 @@
+#include "config/constants.h"
+
+#if MODE_SNAKECLOCK
+
 #include <map>
 #include <queue>
 
-#include "config/constants.h"
 #include "fonts/MiniFont.h"
 #include "handlers/TextHandler.h"
 #include "modes/SnakeClockMode.h"
@@ -210,3 +213,5 @@ bool SnakeClockMode::findPath(Pixel start, Pixel goal, Pixel &next)
     }
     return false;
 }
+
+#endif // MODE_SNAKECLOCK

--- a/firmware/src/modes/SnakeMode.cpp
+++ b/firmware/src/modes/SnakeMode.cpp
@@ -1,7 +1,10 @@
+#include "config/constants.h"
+
+#if MODE_SNAKE
+
 #include <map>
 #include <queue>
 
-#include "config/constants.h"
 #include "modes/SnakeMode.h"
 #include "services/DisplayService.h"
 
@@ -196,3 +199,5 @@ bool SnakeMode::findPath(Pixel start, Pixel goal, Pixel &next)
     }
     return false;
 }
+
+#endif // MODE_SNAKE

--- a/firmware/src/modes/StarsMode.cpp
+++ b/firmware/src/modes/StarsMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_STARS
+
 #include "modes/StarsMode.h"
 #include "services/DisplayService.h"
 
@@ -37,3 +41,5 @@ void StarsMode::handle()
         }
     }
 }
+
+#endif // MODE_STARS

--- a/firmware/src/modes/TickerMode.cpp
+++ b/firmware/src/modes/TickerMode.cpp
@@ -1,6 +1,9 @@
+#include "config/constants.h"
+
+#if MODE_TICKER
+
 #include <Preferences.h>
 
-#include "config/constants.h"
 #include "extensions/HomeAssistantExtension.h"
 #include "fonts/MiniFont.h"
 #include "fonts/SmallFont.h"
@@ -159,3 +162,5 @@ void TickerMode::sleep()
 {
     text.reset();
 }
+
+#endif // MODE_TICKER

--- a/firmware/src/modes/TickingClockMode.cpp
+++ b/firmware/src/modes/TickingClockMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_TICKINGCLOCK
+
 #include "fonts/MediumFont.h"
 #include "handlers/TextHandler.h"
 #include "modes/TickingClockMode.h"
@@ -37,3 +40,5 @@ void TickingClockMode::handle()
         }
     }
 }
+
+#endif // MODE_TICKINGCLOCK

--- a/firmware/src/modes/WaveformMode.cpp
+++ b/firmware/src/modes/WaveformMode.cpp
@@ -1,4 +1,7 @@
 #include "config/constants.h"
+
+#if MODE_WAVEFORM
+
 #include "extensions/MicrophoneExtension.h"
 #include "handlers/BitmapHandler.h"
 #include "modes/WaveformMode.h"
@@ -19,3 +22,5 @@ void WaveformMode::handle()
         bitmap.draw((COLUMNS - bitmap.getWidth()) / 2, (ROWS - bitmap.getHeight()) / 2);
     }
 }
+
+#endif // MODE_WAVEFORM

--- a/firmware/src/modes/WorldWeatherOnlineMode.cpp
+++ b/firmware/src/modes/WorldWeatherOnlineMode.cpp
@@ -1,6 +1,6 @@
 #include "config/constants.h"
 
-#if defined(WORLDWEATHERONLINE_KEY) && ((defined(LATITUDE) && defined(LONGITUDE)) || defined(LOCATION))
+#if MODE_WORLDWEATHERONLINE && defined(WORLDWEATHERONLINE_KEY) && ((defined(LATITUDE) && defined(LONGITUDE)) || defined(LOCATION))
 
 #include <HTTPClient.h>
 
@@ -100,4 +100,4 @@ void WorldWeatherOnlineMode::update()
     }
 }
 
-#endif // defined(WORLDWEATHERONLINE_KEY) && ((defined(LATITUDE) && defined(LONGITUDE)) || defined(LOCATION))
+#endif // MODE_WORLDWEATHERONLINE && defined(WORLDWEATHERONLINE_KEY) && ((defined(LATITUDE) && defined(LONGITUDE)) || defined(LOCATION))

--- a/firmware/src/modes/WttrInMode.cpp
+++ b/firmware/src/modes/WttrInMode.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if MODE_WTTRIN
+
 #include <HTTPClient.h>
 
 #include "extensions/BuildExtension.h"
@@ -79,3 +83,5 @@ void WttrInMode::update()
 #endif
     }
 }
+
+#endif // MODE_WTTRIN

--- a/firmware/src/modes/YrMode.cpp
+++ b/firmware/src/modes/YrMode.cpp
@@ -1,6 +1,6 @@
 #include "config/constants.h"
 
-#if defined(LATITUDE) && defined(LONGITUDE)
+#if MODE_YR && defined(LATITUDE) && defined(LONGITUDE)
 
 #include <HTTPClient.h>
 
@@ -84,4 +84,4 @@ void YrMode::update()
     }
 }
 
-#endif // defined(LATITUDE) && defined(LONGITUDE)
+#endif // MODE_YR && defined(LATITUDE) && defined(LONGITUDE)


### PR DESCRIPTION
### Summary

This pull request introduces conditional build constants (`#if MODE_*` / `#endif`) to all mode classes that previously lacked them, aligning with the existing pattern used across extensions and certain modes.

### Key changes

* Added conditional build constants to all mode classes for consistency.

* Extended the existing conditional compilation logic to cover all modes.

* Ensures the project can be built even with selective mode or extension exclusion.

### Impact

This change is developer-focused and does not alter the build output.
It improves portability, simplifies experimentation with different libraries or platforms, and makes it possible to compile the project core independently of extensions or modes — leading to slightly faster builds when optional components are disabled.