### PR TITLE
Make FontModule::getChar purely virtual

### DIFF
--- a/firmware/include/modules/FontModule.h
+++ b/firmware/include/modules/FontModule.h
@@ -28,5 +28,5 @@ public:
 
     const char *const name;
 
-    virtual Symbol getChar(uint32_t character);
+    virtual Symbol getChar(uint32_t character) = 0;
 };


### PR DESCRIPTION
### Summary

This pull request corrects the `FontModule::getChar()` method definition to make it a truly virtual function, as originally intended.

### Key changes

* Updated the `FontModule` base class so that `getChar()` is now declared as a pure virtual method.

* Fixes occasional compilation errors for font classes missing their own implementation of `getChar()`.

### Impact

No functional differences at runtime.
This change resolves potential build issues and improves code correctness, ensuring that all derived font classes explicitly implement `getChar()` as required.