### PR TITLE
Add conditional build flags for optional fonts

### DIFF
--- a/firmware/include/fonts/BrailleFont.h
+++ b/firmware/include/fonts/BrailleFont.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if FONT_BRAILLE
+
 #include "modules/FontModule.h"
 
 class BrailleFont : public FontModule
@@ -346,3 +350,5 @@ public:
 };
 
 extern BrailleFont *FontBraille;
+
+#endif // FONT_BRAILLE

--- a/firmware/include/fonts/SmallFont.h
+++ b/firmware/include/fonts/SmallFont.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/constants.h"
+
+#if !defined(FONT_SMALL) || FONT_SMALL
+
 #include "modules/FontModule.h"
 
 //
@@ -1462,3 +1466,5 @@ public:
 };
 
 extern SmallFont *FontSmall;
+
+#endif // !defined(FONT_SMALL) || FONT_SMALL

--- a/firmware/src/fonts/BrailleFont.cpp
+++ b/firmware/src/fonts/BrailleFont.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if FONT_BRAILLE
+
 #include "fonts/BrailleFont.h"
 
 BrailleFont *FontBraille = nullptr;
@@ -19,3 +23,5 @@ FontModule::Symbol BrailleFont::getChar(uint32_t character)
     }
     return {};
 }
+
+#endif // FONT_BRAILLE

--- a/firmware/src/fonts/SmallFont.cpp
+++ b/firmware/src/fonts/SmallFont.cpp
@@ -1,3 +1,7 @@
+#include "config/constants.h"
+
+#if !defined(FONT_SMALL) || FONT_SMALL
+
 #include "fonts/SmallFont.h"
 
 SmallFont *FontSmall = nullptr;
@@ -25,3 +29,5 @@ FontModule::Symbol SmallFont::getChar(uint32_t character)
     }
     return {};
 }
+
+#endif // !defined(FONT_SMALL) || FONT_SMALL


### PR DESCRIPTION
### Summary

This pull request extends the conditional build flag system introduced for mode classes to also include fonts.

### Key changes

* Added `#if FONT_*` / `#endif` conditional build flags to the optional font classes.

* Only two fonts are affected, as the remaining ones are considered core and always included.

* Maintains consistency with the existing pattern used for modes and extensions.

### Impact

No functional differences are expected.
This change improves maintainability and flexibility for developers, allowing optional fonts to be excluded from builds when not needed, reducing compile time and resource usage in experimental or lightweight configurations.