### PR TITLE
Fix race condition during startup

### DIFF
--- a/firmware/include/services/DeviceService.h
+++ b/firmware/include/services/DeviceService.h
@@ -24,6 +24,8 @@ private:
         reset_watchdog = "Watchdog";
 #endif // F_DEBUG
 
+    bool operational = false;
+
     unsigned long lastMillis = 0;
 
 #ifdef F_DEBUG


### PR DESCRIPTION
### Summary

This pull request addresses a rare startup issue that could lead to a task stack overflow under specific timing conditions.

### Key changes

* Added safeguards to prevent outgoing messages from being processed before the relevant API extensions are fully initialized.

* Ensures correct initialization order and synchronization during startup.

### Impact

Resolves a potential stack overflow condition caused by early event triggering.
Improves system stability and reliability during startup, with no functional changes to normal runtime behavior.