### PR TITLE
Add verbose logging for Wi-Fi and button events

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,7 @@ build_flags =
 	-DF_INFO
 	;-DF_DEBUG
 	;-DF_VERBOSE
+	;-DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_VERBOSE
 ;build_type = debug
 
 ; OTA update


### PR DESCRIPTION
### Summary

This pull request introduces more detailed terminal output to aid in debugging and understanding device behavior during boot and Wi-Fi mode changes.

### Key changes

* Added verbose log message when no saved Wi-Fi configuration is found during startup.

* Added terminal logging for button presses that trigger AP/hotspot mode, including which button was pressed.

* Added an optional build flag in `platformio.ini`:

```ini
-DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_VERBOSE
```

Uncommenting this enables system-wide verbose logging for in-depth debugging.

### Impact

Improves transparency during boot and troubleshooting.
No behavioral changes to normal operation; all additions are limited to debug output.