### PR TITLE
Optimize MQTT behavior after deep sleep

### DIFF
--- a/firmware/include/extensions/MqttExtension.h
+++ b/firmware/include/extensions/MqttExtension.h
@@ -15,7 +15,7 @@ private:
 
     unsigned long lastMillis = 0;
 
-    static inline bool subscribe = true;
+    static inline bool subscribed = false;
 
     static constexpr size_t
         prefixLength = sizeof("frekvens/" HOSTNAME),


### PR DESCRIPTION
### Summary

This pull request optimizes how the MQTT extension handles subscriptions after waking from deep sleep, reducing unnecessary overhead and improving efficiency.

### Key changes

* Added logic to skip MQTT resubscription on wake from deep sleep if an existing session can be reused.

* Replaced `reinterpret_cast<const uint8_t *>("")` with the cleaner and safer `(const uint8_t[]){0}` for empty payload handling.

### Impact

Reduces redundant MQTT traffic and connection setup time after deep sleep.
No functional behavior changes are expected beyond minor performance improvements.
