### PR TITLE
Add support for specifying Wi-Fi country code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build
 
 on:
+  merge_group:
+    types:
+      - checks_requested
+
   pull_request:
     branches:
       - main
@@ -99,6 +103,7 @@ jobs:
           #define SPI_FREQUENCY 10000000
           #define TASK_STACK_EXTENSIONS 8192
           #define TASK_STACK_MODES 8192
+          #define WIFI_COUNTRY "01"
           #define WIFI_KEY "secret"
           #define WIFI_KEY_HOTSPOT "secret"
           #define WIFI_SSID "name"

--- a/docs/wiki/Services.md
+++ b/docs/wiki/Services.md
@@ -79,6 +79,20 @@ The hotspot will be activated automatically if no Wi-Fi credentials is configure
 
 See also [Button](https://github.com/VIPnytt/Frekvens/wiki/Extensions#%EF%B8%8F-button) extension.
 
+**Wi-Fi country:**
+
+Specifies the country code used for applying Wi-Fi regulatory restrictions such as channel availability and transmit power limits.
+
+The expected format is an *ISO 3166-1 alpha-2* code. Only a subset of country codes are [supported by Espressif](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv425esp_wifi_set_country_codePKcb).
+
+Default is `01`, which corresponds to *world safe mode*.
+
+[secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h) example:
+
+```h
+#define WIFI_COUNTRY "01"
+```
+
 ## ☁️ Web server
 
 **Host check:**

--- a/firmware/include/config/services.h
+++ b/firmware/include/config/services.h
@@ -71,3 +71,4 @@
 // #define WIFI_KEY "secret"
 // #define WIFI_SSID_HOTSPOT "name"
 // #define WIFI_KEY_HOTSPOT "secret"
+// #define WIFI_COUNTRY "01"

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -24,6 +24,9 @@ void ConnectivityService::setup()
     WiFi.onEvent(&onScan, WiFiEvent_t::ARDUINO_EVENT_WIFI_SCAN_DONE);
     WiFi.setHostname(HOSTNAME);
     WiFi.mode(wifi_mode_t::WIFI_MODE_STA);
+#ifdef WIFI_COUNTRY
+    esp_wifi_set_country_code(WIFI_COUNTRY, true);
+#endif // WIFI_COUNTRY
     WiFi.enableIpV6();
 #if defined(PIN_SW1) || defined(PIN_SW2)
     if (!vault() || buttonCheck())
@@ -79,6 +82,9 @@ void ConnectivityService::ready()
 #endif // NTP3
 #endif // NTP2
 #endif // NTP1
+#ifdef WIFI_COUNTRY
+    (*Build->config)[Config::h][__STRING(WIFI_COUNTRY)] = WIFI_COUNTRY;
+#endif // WIFI_COUNTRY
 #ifdef WIFI_SSID
     (*Build->config)[Config::h][__STRING(WIFI_SSID)] = WIFI_SSID;
 #ifdef WIFI_KEY


### PR DESCRIPTION
### Summary

This pull request introduces support for specifying a Wi-Fi country code to ensure compliance with regional wireless regulations, including channel restrictions.

### Key changes

* Added firmware support for setting the Wi-Fi country code using `#define WIFI_COUNTRY "XX"`.

* Default remains *world safe mode* (channels 1–11) for universal compatibility.

* Updated documentation to explain the new configuration option.

### Impact

Improves regional Wi-Fi compliance and connectivity reliability, particularly in countries where access point configurations rely on local regulatory channels.
No breaking changes — devices without `WIFI_COUNTRY` defined will continue using the default world safe setting.

### Issues

* Fixes part of #143
