### PR TITLE
Improve Wi-Fi connection reliability

### DIFF
--- a/firmware/include/services/ConnectivityService.h
+++ b/firmware/include/services/ConnectivityService.h
@@ -28,6 +28,8 @@ private:
     std::unique_ptr<DNSServer> dnsServer;
     std::unique_ptr<WiFiMulti> multi;
 
+    static inline bool scanning = false;
+
     bool vault();
     void hotspot();
     void scan();


### PR DESCRIPTION
### Summary

This pull request improves Wi-Fi connection reliability by addressing issues related to how scan results and hidden networks are handled internally.

### Key changes

* Fixed a bug where Wi-Fi scan results were unintentionally cleared when scans were not initiated through the API or frontend, which could prevent connections.

* Improved handling of hidden Wi-Fi networks when `F_DEBUG` is enabled but `F_VERBOSE` is not.

* Removed a verbose log message left over from the old polling-based Wi-Fi scan system.

### Impact

Enhances the robustness of Wi-Fi connectivity, ensuring that stored scan results are preserved and that debug output behaves as intended.
No configuration or behavioral changes are required from users.

### Issues

Fixes #143