### PR TITLE
Prepare v1.3.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     labels:
       - "dependencies"
       - "no-changelog"
-    milestone: 6
+    milestone: 7
     schedule:
       interval: "weekly"
 
@@ -20,7 +20,7 @@ updates:
     labels:
       - "dependencies"
       - "webapp"
-    milestone: 6
+    milestone: 7
     schedule:
       interval: "weekly"
     versioning-strategy: "increase"
@@ -36,7 +36,7 @@ updates:
     labels:
       - "dependencies"
       - "tools"
-    milestone: 6
+    milestone: 7
     schedule:
       interval: "weekly"
     versioning-strategy: "increase"

--- a/firmware/include/config/version.h
+++ b/firmware/include/config/version.h
@@ -4,4 +4,4 @@
  */
 #include "secrets.h" // please put your custom definitions in the "secrets.h" file
 
-#define VERSION "1.3.1-dev"
+#define VERSION "1.3.1"

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "Frekvens",
-    "version": "1.3.1-dev",
+    "version": "1.3.1",
     "homepage": "https://github.com/VIPnytt/Frekvens",
     "license": "MIT",
     "repository": {

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "frekvens"
 description = "Toolbox for the Frekvens project."
-version = "1.3.1-dev"
+version = "1.3.1"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "frekvens",
-    "version": "1.3.1-dev",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "frekvens",
-            "version": "1.3.1-dev",
+            "version": "1.3.1",
             "license": "MIT",
             "dependencies": {
                 "@mdi/js": "7.4.47",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "frekvens",
-    "version": "1.3.1-dev",
+    "version": "1.3.1",
     "homepage": "https://github.com/VIPnytt/Frekvens",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Summary

This PR prepares the project for the v1.3.1 release.

### Key changes

- Bumped internal version to v1.3.1.

### Impact

This is primarily a versioning and maintenance update, ensuring users and contributors are informed about upcoming deprecations and current support boundaries.
