### PR TITLE
Set version to 2.0.1-dev0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     labels:
       - "dependencies"
       - "no-changelog"
-    milestone: 7
+    milestone: 8
     schedule:
       interval: "weekly"
 
@@ -20,7 +20,7 @@ updates:
     labels:
       - "dependencies"
       - "extra"
-    milestone: 7
+    milestone: 8
     schedule:
       interval: "weekly"
     versioning-strategy: "increase"
@@ -35,7 +35,7 @@ updates:
         - "tzdata"
     labels:
       - "dependencies"
-    milestone: 7
+    milestone: 8
     schedule:
       interval: "weekly"
     versioning-strategy: "increase"
@@ -49,7 +49,7 @@ updates:
     labels:
       - "dependencies"
       - "tools"
-    milestone: 7
+    milestone: 8
     schedule:
       interval: "weekly"
     versioning-strategy: "increase"
@@ -63,7 +63,7 @@ updates:
     labels:
       - "dependencies"
       - "webapp"
-    milestone: 7
+    milestone: 8
     schedule:
       interval: "weekly"
     versioning-strategy: "increase"

--- a/firmware/include/config/version.h
+++ b/firmware/include/config/version.h
@@ -6,4 +6,4 @@
 
 #include "secrets.h"
 
-#define VERSION "2.0.0"
+#define VERSION "2.0.1-dev0"

--- a/scripts/src/config/version.py
+++ b/scripts/src/config/version.py
@@ -1,1 +1,1 @@
-VERSION: str = "2.0.0"
+VERSION: str = "2.0.1-dev0"

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "frekvens"
 description = "Toolbox for the Frekvens project."
-version = "2.0.0"
+version = "2.0.1.dev0"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "frekvens",
-    "version": "2.0.0",
+    "version": "2.0.1-dev0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "frekvens",
-            "version": "2.0.0",
+            "version": "2.0.1-dev0",
             "license": "MIT",
             "dependencies": {
                 "@mdi/js": "7.4.47",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "frekvens",
-    "version": "2.0.0",
+    "version": "2.0.1-dev0",
     "homepage": "https://github.com/VIPnytt/Frekvens",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Summary

This PR bumps the internal version to `2.0.1-dev0`, marking the transition from a stable release to ongoing development on the `main` branch.

### Key changes

- Updated project version to `2.0.1-dev0`.

### Impact

* Makes it clear that the `main` branch now represents a development version rather than a stable release.