### PR TITLE
Pin PlatformIO dependabot to Python 3.13

### DIFF
--- a/.github/workflows/dependabot-pio.yml
+++ b/.github/workflows/dependabot-pio.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
       - uses: peterus/platformio_dependabot@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

Added Python 3.13 as requirement for the PlatformIO dependabot workflow, as PlatformIO doesn't support 3.14 yet.

### Changes

- Add and pinpoint Python 3.13

### Impact

Fixes an issue where the PlatformIO dependabot workflow fails due to the Python version requirement not being satisfied.