### PR TITLE
Switch to platformio_dependabot fork with Python 3.13 fix

### DIFF
--- a/.github/workflows/dependabot-pio.yml
+++ b/.github/workflows/dependabot-pio.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: JanPetterMG/platformio_dependabot@python313
+      - uses: JanPetterMG/platformio_dependabot@d52a00e84a5eac4e52b90ed3b26647496544fae8 # python313
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

Switches to a PlatformIO dependabot fork, with proper Python 3.13 support.

### Changes

Replace `peterus/platformio_dependabot@v1` with `JanPetterMG/platformio_dependabot@python313`

### Impact

Fixes an upstream issue where the PlatformIO dependabot defaults to Python 3.14, which isn't supported by PlatformIO.

### References

Issue: https://github.com/peterus/platformio_dependabot/issues/12
PR: https://github.com/peterus/platformio_dependabot/pull/14