### PR TITLE
Fix brightness range

### DIFF
--- a/firmware/src/extensions/ButtonExtension.cpp
+++ b/firmware/src/extensions/ButtonExtension.cpp
@@ -79,20 +79,21 @@ void ButtonExtension::handle()
     }
     else if (powerState && millis() - powerMillis > UINT8_MAX)
     {
-        const uint8_t brightness = Display.getBrightness();
+        const uint8_t brightness = Display.getPower() ? Display.getBrightness() : 0;
         if (!powerLong)
         {
             powerLong = true;
             event("power", "long");
-            switch (brightness)
+            if (brightness >= UINT8_MAX)
             {
-            case 0:
-                brightnessIncrease = true;
-                break;
-            case UINT8_MAX:
                 brightnessIncrease = false;
-                break;
-            default:
+            }
+            else if (brightness <= 1)
+            {
+                brightnessIncrease = true;
+            }
+            else
+            {
                 brightnessIncrease = !brightnessIncrease;
             }
         }
@@ -100,7 +101,7 @@ void ButtonExtension::handle()
         {
             Display.setBrightness(brightness + 1);
         }
-        else if (!brightnessIncrease && brightness > 0)
+        else if (!brightnessIncrease && brightness > 1)
         {
             Display.setBrightness(brightness - 1);
         }

--- a/firmware/src/extensions/HomeAssistantExtension.cpp
+++ b/firmware/src/extensions/HomeAssistantExtension.cpp
@@ -27,11 +27,10 @@ void HomeAssistantExtension::configure()
             id = std::regex_replace(name, std::regex("\\s+"), "").append("_main"),
             topicDisplay = std::string("frekvens/" HOSTNAME "/").append(Display.name);
         JsonObject component = (*HomeAssistant->discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>();
-        component[HomeAssistantAbbreviations::brightness_command_template] = "{\"brightness\":{{value-1}}}";
+        component[HomeAssistantAbbreviations::brightness_command_template] = "{\"brightness\":{{value}}}";
         component[HomeAssistantAbbreviations::brightness_command_topic] = topicDisplay + "/set";
-        component[HomeAssistantAbbreviations::brightness_scale] = 1 << 8;
         component[HomeAssistantAbbreviations::brightness_state_topic] = topicDisplay;
-        component[HomeAssistantAbbreviations::brightness_value_template] = "{{value_json.brightness+1}}";
+        component[HomeAssistantAbbreviations::brightness_value_template] = "{{value_json.brightness}}";
         component[HomeAssistantAbbreviations::command_topic] = topicDisplay + "/set";
         component[HomeAssistantAbbreviations::effect_command_template] = "{\"mode\":\"{{value}}\"}";
         component[HomeAssistantAbbreviations::effect_command_topic] = std::string("frekvens/" HOSTNAME "/").append(Modes.name).append("/set");

--- a/firmware/src/extensions/InfraredExtension.cpp
+++ b/firmware/src/extensions/InfraredExtension.cpp
@@ -76,7 +76,7 @@ void InfraredExtension::parse()
         {
             if (t > INT8_MAX && std::find(code.displayBrightnessDecrease.begin(), code.displayBrightnessDecrease.end(), IrReceiver.decodedIRData.command) != code.displayBrightnessDecrease.end())
             {
-                Display.setBrightness(max(0, Display.getBrightness() - 5));
+                Display.setBrightness(max(1, Display.getBrightness() - 5));
                 lastMillis = millis();
                 return;
             }

--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -167,7 +167,7 @@ void PhotocellExtension::onTransmit(const JsonDocument &doc, const char *const s
         const uint8_t _brightness = doc["brightness"].as<uint8_t>();
         if (_brightness != brightness)
         {
-            setGamma(log((_brightness + 1) / (float)((1 << 8) + 1)) / log((raw + 1) / (float)((1 << 12) + 1)));
+            setGamma(log(_brightness / (float)(1 << 8)) / log((raw + 1) / (float)((1 << 12) + 1)));
         }
     }
 }

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -197,13 +197,13 @@ void DisplayService::setPower(bool power)
     if (power)
     {
 #ifdef SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
-        ledcFadeGamma(PIN_OE, 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 3) + 1), (1 << 5) * brightness); // offset -3 instead of -1 due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGamma`.
+        ledcFadeGamma(PIN_OE, 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), (1 << 5) * brightness); // -2 offset due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGamma`.
 #elif CONFIG_IDF_TARGET_ESP32 && ESP_ARDUINO_VERSION > ESP_ARDUINO_VERSION_VAL(3, 3, 1) && ESP_ARDUINO_VERSION <= ESP_ARDUINO_VERSION_VAL(3, 3, 4)
         // Temporary Arduino bugfix mitigation
 #warning "ESP32 classic users: Arduino has a ledcFade crash bug. Downgrade to Arduino 3.3.1 or fading will be disabled."
-        ledcWrite(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 1) + 1));
+        ledcWrite(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * (1 << depth)));
 #else
-        ledcFade(PIN_OE, 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 3) + 1), (1 << 5) * brightness); // offset -3 instead of -1 due to `ledcFade` stability issues.
+        ledcFade(PIN_OE, 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), (1 << 5) * brightness); // -2 offset due to `ledcFade` stability issues.
 #endif // SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
         this->power = true;
         pending = true;
@@ -212,14 +212,14 @@ void DisplayService::setPower(bool power)
     else
     {
 #ifdef SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
-        ledcFadeGammaWithInterrupt(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 3) + 1), 0, (1 << 3) * brightness, &onPowerOff); // offset -3 instead of -1 due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGammaWithInterrupt`.
+        ledcFadeGammaWithInterrupt(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), 0, (1 << 3) * brightness, &onPowerOff); // -2 offset due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGammaWithInterrupt`.
 #elif CONFIG_IDF_TARGET_ESP32 && ESP_ARDUINO_VERSION > ESP_ARDUINO_VERSION_VAL(3, 3, 1) && ESP_ARDUINO_VERSION <= ESP_ARDUINO_VERSION_VAL(3, 3, 4)
         // Temporary Arduino bugfix mitigation
 #warning "ESP32 classic users: Arduino has a ledcFade crash bug. Downgrade to Arduino 3.3.1 or fading will be disabled."
         ledcWrite(PIN_OE, 0);
         onPowerOff();
 #else
-        ledcFadeWithInterrupt(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 3) + 1), 0, (1 << 3) * brightness, &onPowerOff); // offset -3 instead of -1 due to `ledcFade` stability issues.
+        ledcFadeWithInterrupt(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), 0, (1 << 3) * brightness, &onPowerOff); // -2 offset due to `ledcFade` stability issues.
 #endif // SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
     }
 }
@@ -243,15 +243,20 @@ void DisplayService::setBrightness(uint8_t brightness)
     {
         return;
     }
+    else if (!brightness)
+    {
+        setPower(false);
+        return;
+    }
     ESP_LOGI(name, "brightness");
 #ifdef SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
-    ledcFadeGamma(PIN_OE, power ? max<uint16_t>(this->brightness, pow(this->brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 3) + 1) : 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 3) + 1), (1 << 4) * abs(this->brightness - brightness)); // offset -3 instead of -1 due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGamma`.
+    ledcFadeGamma(PIN_OE, power ? max<uint16_t>(this->brightness, pow(this->brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)) : 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), (1 << 4) * abs(this->brightness - brightness)); // -2 offset due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGamma`.
 #elif CONFIG_IDF_TARGET_ESP32 && ESP_ARDUINO_VERSION > ESP_ARDUINO_VERSION_VAL(3, 3, 1) && ESP_ARDUINO_VERSION <= ESP_ARDUINO_VERSION_VAL(3, 3, 4)
     // Temporary Arduino bugfix mitigation
 #warning "ESP32 classic users: Arduino has a ledcFade crash bug. Downgrade to Arduino 3.3.1 or fading will be disabled."
-    ledcWrite(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 1) + 1));
+    ledcWrite(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * (1 << depth)));
 #else
-    ledcFade(PIN_OE, power ? max<uint16_t>(this->brightness, pow(this->brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 3) + 1) : 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 3) + 1), (1 << 4) * abs(this->brightness - brightness)); // offset -3 instead of -1 due to `ledcFade` stability issues.
+    ledcFade(PIN_OE, power ? max<uint16_t>(this->brightness, pow(this->brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)) : 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), (1 << 4) * abs(this->brightness - brightness)); // -2 offset due to `ledcFade` stability issues.
 #endif // SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
     if (!power)
     {

--- a/webapp/src/services/Display.tsx
+++ b/webapp/src/services/Display.tsx
@@ -68,13 +68,11 @@ export const Sidebar: Component = () => {
                     >
                         <Icon path={mdiPower} />
                     </button>
-                    <Tooltip text={`Brightness ${Math.ceil((getBrightness() + 1) / (Math.pow(2, 8)) * 100)} %`}>
+                    <Tooltip text={`Brightness ${Math.ceil(getBrightness() / (Math.pow(2, 8) - 1) * 100)} %`}>
                         <input
                             class="w-full"
-                            type="range"
-                            min="0"
                             max={Math.pow(2, 8) - 1}
-                            value={getBrightness()}
+                            min="1"
                             onInput={(e) =>
                                 handleBrightness(parseFloat(e.currentTarget.value), false)
                             }
@@ -84,6 +82,8 @@ export const Sidebar: Component = () => {
                             onPointerUp={(e) =>
                                 handleBrightness(getBrightness())
                             }
+                            type="range"
+                            value={getBrightness()}
                         />
                     </Tooltip>
                 </div>


### PR DESCRIPTION
### Summary

This PR addresses a bug in the display brightness logic where the 0-255 range did not allow for a true "off" state. Previously, setting the brightness to 0 resulted in the minimum possible PWM duty cycle (still visible), rather than disabling the display output.

### Changes

- Updated Range Logic: Adjusted the brightness mapping to a 1-255 scale for active states.

- True Off State: Implemented a conditional check where a value of 0 now triggers a full display disable (Power Off) instead of minimum brightness.

- Consistency across Extensions: Ensured this logic is respected by all extensions.

### Impact

- Ensures best practices for brightness and power state are followed.
