### PR TITLE
CA Certificate retry logic for connection errors

### DIFF
--- a/scripts/src/components/Certificate.py
+++ b/scripts/src/components/Certificate.py
@@ -43,15 +43,10 @@ class Certificate:
                         try:
                             self._add_host(host)
                             break
-                        except TimeoutError as e:
+                        except (ConnectionError, TimeoutError) as e:
                             if attempt >= 3:
                                 raise
-                            logging.warning(
-                                "Timeout fetching certificate for %s (attempt #%d): %s",
-                                host,
-                                attempt,
-                                e,
-                            )
+                            logging.warning("%s (attempt #%d): %s", host, attempt, e)
         bundle_path = pathlib.Path("firmware/certs/bundle")
         bundle_path.mkdir(parents=True, exist_ok=True)
         ca_roots = "ca_roots.pem"


### PR DESCRIPTION
This PR expands the CA certificate retry logic to also handle connection errors.

### Changes

- Now catches both `ConnectionError` (which includes the specific `ConnectionResetError` seen in recent logs) and `TimeoutError`.

### Impact

In CI environments, SSL handshakes or host resolutions can fail due to *"Connection reset by peer"* errors. By allowing up to three attempts, we significantly reduce "false positive" build failures while still ensuring a hard stop if a host is truly unreachable after three tries.
