### PR TITLE
Remove @solid-primitives/intersection-observer

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@mdi/js": "7.4.47",
                 "@solid-primitives/event-listener": "2.4.3",
-                "@solid-primitives/intersection-observer": "2.2.2",
                 "@solid-primitives/websocket": "1.3.1",
                 "js-cookie": "3.0.5",
                 "solid-js": "1.9.10"
@@ -1166,18 +1165,6 @@
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/@solid-primitives/event-listener/-/event-listener-2.4.3.tgz",
             "integrity": "sha512-h4VqkYFv6Gf+L7SQj+Y6puigL/5DIi7x5q07VZET7AWcS+9/G3WfIE9WheniHWJs51OEkRB43w6lDys5YeFceg==",
-            "license": "MIT",
-            "dependencies": {
-                "@solid-primitives/utils": "^6.3.2"
-            },
-            "peerDependencies": {
-                "solid-js": "^1.6.12"
-            }
-        },
-        "node_modules/@solid-primitives/intersection-observer": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@solid-primitives/intersection-observer/-/intersection-observer-2.2.2.tgz",
-            "integrity": "sha512-5Vak/eRuCKAQis+YaPsP4KysPc+sQGL2ew8kvTOMxKVOTJcICkxznRrlFEBbBk0UsiUQlm9CcVQtJwocKWNXcw==",
             "license": "MIT",
             "dependencies": {
                 "@solid-primitives/utils": "^6.3.2"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -17,7 +17,6 @@
     "dependencies": {
         "@mdi/js": "7.4.47",
         "@solid-primitives/event-listener": "2.4.3",
-        "@solid-primitives/intersection-observer": "2.2.2",
         "@solid-primitives/websocket": "1.3.1",
         "js-cookie": "3.0.5",
         "solid-js": "1.9.10"


### PR DESCRIPTION
Removes the `@solid-primitives/intersection-observer` dependency, as it's no longer in use.

### Changes

- Removed `@solid-primitives/intersection-observer` version 2.2.2 from `package.json` and `package-lock.json`.

### Impact

Reduced bundle size and a cleaner project, as this package is no longer needed.