### PR TITLE
Remove redundant `secrets.h` include directives

### DIFF
--- a/firmware/include/config/IkeaFrekvens.h
+++ b/firmware/include/config/IkeaFrekvens.h
@@ -4,8 +4,6 @@
  * https://github.com/VIPnytt/Frekvens/wiki/IKEA-Frekvens
  */
 
-#include "secrets.h"
-
 #define MANUFACTURER "IKEA"
 #define MODEL "Frekvens"
 

--- a/firmware/include/config/IkeaObegransad.h
+++ b/firmware/include/config/IkeaObegransad.h
@@ -4,8 +4,6 @@
  * https://github.com/VIPnytt/Frekvens/wiki/IKEA-Obegransad
  */
 
-#include "secrets.h"
-
 #define MANUFACTURER "IKEA"
 #define MODEL "Obegränsad"
 

--- a/firmware/include/config/extensions.h
+++ b/firmware/include/config/extensions.h
@@ -4,8 +4,6 @@
  * https://github.com/VIPnytt/Frekvens/wiki/Extensions
  */
 
-#include "secrets.h"
-
 /**
  * IR
  */

--- a/firmware/include/config/infrared.h
+++ b/firmware/include/config/infrared.h
@@ -4,6 +4,4 @@
  * https://github.com/VIPnytt/Frekvens/wiki/Infrared-receiver
  */
 
-#include "secrets.h"
-
 // #define PIN_IR 1 // Receiver

--- a/firmware/include/config/microphone.h
+++ b/firmware/include/config/microphone.h
@@ -4,6 +4,4 @@
  * https://github.com/VIPnytt/Frekvens/wiki/Microphone
  */
 
-#include "secrets.h"
-
 // #define PIN_MIC 1 // Amplifier

--- a/firmware/include/config/modes.h
+++ b/firmware/include/config/modes.h
@@ -4,8 +4,6 @@
  * https://github.com/VIPnytt/Frekvens/wiki/Modes
  */
 
-#include "secrets.h"
-
 /**
  * Home Assistant weather
  */

--- a/firmware/include/config/photocell.h
+++ b/firmware/include/config/photocell.h
@@ -4,6 +4,4 @@
  * https://github.com/VIPnytt/Frekvens/wiki/Photocell
  */
 
-#include "secrets.h"
-
 // #define PIN_LDR 1 // Bridge

--- a/firmware/include/config/rtc.h
+++ b/firmware/include/config/rtc.h
@@ -4,7 +4,5 @@
  * https://github.com/VIPnytt/Frekvens/wiki/Real-Time-Clock
  */
 
-#include "secrets.h"
-
 // #define PIN_SCL 1 // I²C SCL
 // #define PIN_SDA 2 // I²C SDA

--- a/firmware/include/config/services.h
+++ b/firmware/include/config/services.h
@@ -4,8 +4,6 @@
  * https://github.com/VIPnytt/Frekvens/wiki/Services
  */
 
-#include "secrets.h"
-
 /**
  * Display
  */

--- a/firmware/include/config/version.h
+++ b/firmware/include/config/version.h
@@ -4,6 +4,4 @@
  * https://github.com/VIPnytt/Frekvens/wiki
  */
 
-#include "secrets.h"
-
 #define VERSION "2.0.1-dev0"


### PR DESCRIPTION
### Summary

Remove unnecessary `secrets.h` include directives from multiple configuration header files to streamline the codebase.

### Changes

- Removed `#include "secrets.h"` from various nested firmware config files

### Impact

This change reduces clutter in the code. No compatibility issues are expected as the removed includes were redundant.
