### PR TITLE
Bump Arduino-IRremote/Arduino-IRremote from 4.5.0 to 4.5.0+sha.251d34b in /

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@ src_dir = firmware/src
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
 framework = arduino
 lib_deps =
-	arduino-irremote/IRremote @ 4.5.0
+	https://github.com/Arduino-IRremote/Arduino-IRremote/archive/251d34b91f28026d930e22c0c7617806ee42bf36.tar.gz ; v4.5.0+sha.251d34b
 	bblanchon/ArduinoJson @ 7.4.2
 	bertmelis/espMqttClient @ 1.7.2
 	ESP32Async/ESPAsyncWebServer @ 3.9.2


### PR DESCRIPTION
Bumps Arduino-IRremote/Arduino-IRremote from 4.5.0 to 4.5.0+sha.251d34b

[Release notes](https://github.com/Arduino-IRremote/Arduino-IRremote/compare/v4.5.0...251d34b91f28026d930e22c0c7617806ee42bf36)