### PR TITLE
Bump vintlabs/fauxmoESP from 3.4.1 to 3.4.1+sha.1b8b91e in /

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ lib_deps =
 	bertmelis/espMqttClient @ 1.7.2
 	ESP32Async/ESPAsyncWebServer @ 3.9.2
 	makuna/RTC @ 2.5.0
-	vintlabs/FauxmoESP @ 3.4.1
+	https://github.com/vintlabs/fauxmoESP/archive/1b8b91e362bc4c2f0891f1160c69f1e399346c02.tar.gz ; 3.4.1+sha.1b8b91e
 extra_scripts =	pre:scripts/extra_script.py
 monitor_speed = 115200
 monitor_filters =


### PR DESCRIPTION
Bumps vintlabs/fauxmoESP from 3.4.1 to /3.4.1+sha.1b8b91e

[Release notes](https://github.com/vintlabs/fauxmoESP/compare/3.4.1...1b8b91e362bc4c2f0891f1160c69f1e399346c02)