### PR TITLE
Fix dependabot `/extra/Python` directory path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "pip"
-    directory: "/extra"
+    directory: "/extra/Python"
     cooldown:
       semver-major-days: 90
       semver-minor-days: 21


### PR DESCRIPTION
Fixes an bug where the dependabot wouldn't threat the labels explicitly, as the working directory was in a subdirectory

### Changes

Corrected pip `/extra` to `/extra/Python`

### Impact

Makes sure the correct labels are applied when a new PR is created.