### PR TITLE
Remove the temporary `stdint.h` include directive

### DIFF
--- a/firmware/src/extensions/InfraredExtension.cpp
+++ b/firmware/src/extensions/InfraredExtension.cpp
@@ -1,6 +1,5 @@
 #if EXTENSION_INFRARED
 
-#include <stdint.h> // temporary bugfix for arduino-irremote/IRremote @ 4.5.0
 #include <IRremote.hpp>
 #include <Preferences.h>
 


### PR DESCRIPTION
Removes the `stdint.h` include directive, as it is no longer needed.

### Changes

Removed `#include <stdint.h>` from the Infrared extension.

### Impact

The include directory was previously needed by `IRremote.hpp` from arduino-irremote/IRremote @ 4.5.0, but since this dependency now has been updated in #234, it's no longer needed.