### PR TITLE
Optimize MQTT subscription handling

### DIFF
--- a/firmware/include/extensions/MqttExtension.h
+++ b/firmware/include/extensions/MqttExtension.h
@@ -14,8 +14,8 @@ private:
     static inline bool subscribed = false;
 
     static constexpr size_t
-        prefixLength = sizeof("frekvens/" HOSTNAME),
-        suffixLength = sizeof("set");
+        prefixLength = sizeof("frekvens/" HOSTNAME "/") - 1,
+        suffixLength = sizeof("/set") - 1;
 
     static void onConnect(bool sessionPresent);
     static void onDisconnect(espMqttClientTypes::DisconnectReason reason);

--- a/firmware/include/services/DeviceService.h
+++ b/firmware/include/services/DeviceService.h
@@ -32,7 +32,6 @@ public:
     void transmit(JsonDocument doc, const char *const source, bool retain = true);
     void receive(const JsonDocument doc, const char *const source, const char *const destination);
 
-    const std::vector<const char *> getNames() const;
     const JsonDocument getTransmits() const;
 
     static DeviceService &getInstance();

--- a/firmware/src/extensions/MqttExtension.cpp
+++ b/firmware/src/extensions/MqttExtension.cpp
@@ -64,10 +64,7 @@ void MqttExtension::onConnect(bool sessionPresent)
     ESP_LOGD(Mqtt->name, "connected");
     if (!sessionPresent || (!subscribed && esp_sleep_get_wakeup_cause() == esp_sleep_source_t::ESP_SLEEP_WAKEUP_UNDEFINED))
     {
-        for (const char *const _name : Device.getNames())
-        {
-            Mqtt->client.subscribe(std::string("frekvens/" HOSTNAME "/").append(_name).append("/set").c_str(), 2);
-        }
+        Mqtt->client.subscribe("frekvens/" HOSTNAME "/+/set", 2);
         subscribed = true;
     }
     Mqtt->client.publish("frekvens/" HOSTNAME "/availability", 1, true, "online");

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -227,28 +227,6 @@ void DeviceService::restore()
     esp_deep_sleep_start();
 }
 
-const std::vector<const char *> DeviceService::getNames() const
-{
-    std::vector<const char *> modules = {
-        Device.name,
-        Display.name,
-        Extensions.name,
-        Fonts.name,
-        Modes.name,
-        Connectivity.name,
-        WebServer.name,
-    };
-    for (const ExtensionModule *extension : Extensions.getAll())
-    {
-        modules.push_back(extension->name);
-    }
-    for (const ModeModule *mode : Modes.getAll())
-    {
-        modules.push_back(mode->name);
-    }
-    return modules;
-}
-
 const JsonDocument DeviceService::getTransmits() const
 {
     return transmits;


### PR DESCRIPTION
Optimize MQTT subscription handling by subscribing to a wildcard topic instead of individual names. Remove the from now on unused `getNames` method from `DeviceService` to streamline the code.

### Changes

- Updated MQTT subscription logic to use a wildcard topic.
- Removed the `getNames` method from `DeviceService`.

### Impact

Reduces complexity in MQTT subscription management and eliminates unnecessary code, improving maintainability. No compatibility issues expected.