### PR TITLE
Pin esp32async/AsyncTCP v3.4.9 to prevent version drifting

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,8 @@ lib_deps =
 	https://github.com/Arduino-IRremote/Arduino-IRremote/archive/251d34b91f28026d930e22c0c7617806ee42bf36.tar.gz ; v4.5.0+sha.251d34b
 	bblanchon/ArduinoJson @ 7.4.2
 	bertmelis/espMqttClient @ 1.7.2
-	ESP32Async/ESPAsyncWebServer @ 3.9.3
+	esp32async/AsyncTCP @ 3.4.9
+	esp32async/ESPAsyncWebServer @ 3.9.3
 	makuna/RTC @ 2.5.0
 	https://github.com/vintlabs/fauxmoESP/archive/1b8b91e362bc4c2f0891f1160c69f1e399346c02.tar.gz ; 3.4.1+sha.1b8b91e
 extra_scripts =	pre:scripts/extra_script.py


### PR DESCRIPTION
This PR explicitly adds `esp32async/AsyncTCP` to the "platformio.ini" file. While this library is already required transitively by two other dependencies, it currently remains unpinned, leading to potential *version drifting* where different builds might pull different versions of the same library.

### Changes

- Added `esp32async/AsyncTCP` [v3.4.9](https://github.com/ESP32Async/AsyncTCP/releases/tag/v3.4.9)
- Use PlatformIO registry canonical name for `esp32async/ESPAsyncWebServer`

### Impact

Prevents potential breaking changes from upstream updates from affecting our network-dependent features.