### PR TITLE
Downgrade pioarduino/platform-espressif32 from 55.03.34 to 55.03.31-2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -6,7 +6,9 @@ include_dir = firmware/include
 src_dir = firmware/src
 
 [env]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/archive/b111e6fe9e3c228b22d2900843d64c242a222fe3.tar.gz ; 55.03.31-2+sha.b111e6f
+platform_packages =
+	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32/archive/ef453a58328c5ed2313da0df7b176573ec0e4ba3.tar.gz ; 3.3.1+sha.ef453a5
 framework = arduino
 lib_deps =
 	https://github.com/Arduino-IRremote/Arduino-IRremote/archive/251d34b91f28026d930e22c0c7617806ee42bf36.tar.gz ; v4.5.0+sha.251d34b


### PR DESCRIPTION
Downgrade Arduino from 3.3.4 to 3.3.1 as ESP32 "classic" is affected by an `ledc` bug that got introduced in Arduino 3.3.2.

Downgrade `pioarduino/platform-espressif32` from 55.03.34 to 55.03.31-2+sha.b111e6f (the "original" 55.03.31-2 release from Nov 12, 2025, not the re-release with same tag from Dec 10, 2025).

Pin `framework-arduinoespressif32` to 3.3.1+sha.ef453a5 as 3.3.1 comes bundled with `ArduinoOTA` 3.3.0 and lacks proper `LittleFS` support which got introduced later with `ArduinoOTA` 3.3.1 and `framework-arduinoespressif32` 3.3.2. This commit is just a few patches past the official `framework-arduinoespressif32` 3.3.1 release.

### Changes

- Downgrade `pioarduino/platform-espressif32` from 55.03.34 to 55.03.31-2+sha.b111e6f
- Pin `framework-arduinoespressif32` to 3.3.1+sha.ef453a5

### Impact

ESP32 "classic" users no longer have to manually downgrade to Arduino 3.3.1, which was partially incompatible with the Frekvens OTA extension.
It essentially unifies all ESP32 generations to a single software stack, without any known side-effects of importance.