### PR TITLE
Remove ESP32 "classic" `ledc` workaround

### DIFF
--- a/firmware/src/extensions/OtaExtension.cpp
+++ b/firmware/src/extensions/OtaExtension.cpp
@@ -1,6 +1,5 @@
 #if EXTENSION_OTA
 
-#include <esp_arduino_version.h> // temporary bugfix mitigation due to ledcFade bug in Arduino 3.3.2 and higher
 #include <ESPmDNS.h>
 #include <HTTPClient.h>
 
@@ -11,11 +10,6 @@
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
 #include "services/ModesService.h"
-
-#if ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 3, 2)
-// Temporary mitigation measure due to ledcFade bug in Arduino 3.3.2 and higher
-#warning "Arduino 3.3.1 and lower: OTA may fail to compile or update. Disable OTA if you need this version."
-#endif
 
 OtaExtension *Ota = nullptr;
 

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -1,4 +1,3 @@
-#include <esp_arduino_version.h> // temporary bugfix mitigation due to ledcFade bug in Arduino 3.3.2 and higher
 #include <Preferences.h>
 #include <SPI.h>
 
@@ -198,10 +197,6 @@ void DisplayService::setPower(bool power)
     {
 #ifdef SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
         ledcFadeGamma(PIN_OE, 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), (1 << 5) * brightness); // -2 offset due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGamma`.
-#elif CONFIG_IDF_TARGET_ESP32 && ESP_ARDUINO_VERSION > ESP_ARDUINO_VERSION_VAL(3, 3, 1) && ESP_ARDUINO_VERSION <= ESP_ARDUINO_VERSION_VAL(3, 3, 4)
-        // Temporary Arduino bugfix mitigation
-#warning "ESP32 classic users: Arduino has a ledcFade crash bug. Downgrade to Arduino 3.3.1 or fading will be disabled."
-        ledcWrite(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * (1 << depth)));
 #else
         ledcFade(PIN_OE, 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), (1 << 5) * brightness); // -2 offset due to `ledcFade` stability issues.
 #endif // SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
@@ -213,11 +208,6 @@ void DisplayService::setPower(bool power)
     {
 #ifdef SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
         ledcFadeGammaWithInterrupt(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), 0, (1 << 3) * brightness, &onPowerOff); // -2 offset due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGammaWithInterrupt`.
-#elif CONFIG_IDF_TARGET_ESP32 && ESP_ARDUINO_VERSION > ESP_ARDUINO_VERSION_VAL(3, 3, 1) && ESP_ARDUINO_VERSION <= ESP_ARDUINO_VERSION_VAL(3, 3, 4)
-        // Temporary Arduino bugfix mitigation
-#warning "ESP32 classic users: Arduino has a ledcFade crash bug. Downgrade to Arduino 3.3.1 or fading will be disabled."
-        ledcWrite(PIN_OE, 0);
-        onPowerOff();
 #else
         ledcFadeWithInterrupt(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), 0, (1 << 3) * brightness, &onPowerOff); // -2 offset due to `ledcFade` stability issues.
 #endif // SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
@@ -251,10 +241,6 @@ void DisplayService::setBrightness(uint8_t brightness)
     ESP_LOGI(name, "brightness");
 #ifdef SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
     ledcFadeGamma(PIN_OE, power ? max<uint16_t>(this->brightness, pow(this->brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)) : 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), (1 << 4) * abs(this->brightness - brightness)); // -2 offset due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGamma`.
-#elif CONFIG_IDF_TARGET_ESP32 && ESP_ARDUINO_VERSION > ESP_ARDUINO_VERSION_VAL(3, 3, 1) && ESP_ARDUINO_VERSION <= ESP_ARDUINO_VERSION_VAL(3, 3, 4)
-    // Temporary Arduino bugfix mitigation
-#warning "ESP32 classic users: Arduino has a ledcFade crash bug. Downgrade to Arduino 3.3.1 or fading will be disabled."
-    ledcWrite(PIN_OE, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * (1 << depth)));
 #else
     ledcFade(PIN_OE, power ? max<uint16_t>(this->brightness, pow(this->brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)) : 0, max<uint16_t>(brightness, pow(brightness / (float)UINT8_MAX, GAMMA) * ((1 << depth) - 2)), (1 << 4) * abs(this->brightness - brightness)); // -2 offset due to `ledcFade` stability issues.
 #endif // SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED


### PR DESCRIPTION
Removes an `ledc` workaround for ESP32 "classic", that was needed due to an `ledc` bug in Arduino 3.3.2 and an `ArduinoOTA` bug in Arduino 3.3.1.
This is now possible thanks to #243 (required), which pins Arduino to an middleground past the official 3.3.1 release and prior to the official 3.3.2 release.

### Changes

- Removed OTA warning for users up until Arduino 3.3.1
- Removed `ledc` workaround for ESP32 "classic" boards targeting Arduino 3.3.2 and onwards.

### Impact

ESP32 "classic" users can now take full advantage of the smooth display dimming capabilities introduced with Frekvens 2.0.0.