### PR TITLE
Refactored ping-pong modes

### DIFF
--- a/firmware/include/modes/PingPongClockMode.h
+++ b/firmware/include/modes/PingPongClockMode.h
@@ -27,15 +27,12 @@ private:
     uint8_t
         hour,
         minute,
-        targetY = GRID_ROWS / 2,
         x = GRID_COLUMNS - 2,
         y = GRID_ROWS / 2;
 
     uint16_t deg = 180;
 
     unsigned long lastMillis = 0;
-
-    void predict();
 
 public:
     PingPongClockMode() : ModeModule("Ping-Pong clock") {};

--- a/firmware/include/modes/PingPongMode.h
+++ b/firmware/include/modes/PingPongMode.h
@@ -17,19 +17,16 @@ private:
         yDec = GRID_ROWS - 2;
 
     std::deque<uint8_t>
-        paddleT,
-        paddleB;
+        paddleB,
+        paddleT;
 
     uint8_t
-        targetX = GRID_COLUMNS / 2,
         x = GRID_COLUMNS / 2,
         y = GRID_ROWS - 2;
 
     uint16_t deg = 90;
 
     unsigned long lastMillis = 0;
-
-    void predict();
 
 public:
     PingPongMode() : ModeModule("Ping-Pong") {};

--- a/firmware/src/modes/BreakoutClockMode.cpp
+++ b/firmware/src/modes/BreakoutClockMode.cpp
@@ -8,7 +8,7 @@
 
 void BreakoutClockMode::begin()
 {
-    Display.drawRectangle(0, 0, GRID_COLUMNS - 1, 5 - 1);
+    Display.drawRectangle(0, 0, GRID_COLUMNS - 1, GRID_ROWS - 1 - 4);
     paddle.clear();
     const uint8_t paddleX = random(GRID_COLUMNS - 1 - 3);
     for (uint8_t _x = 0; _x < 3; ++_x)
@@ -70,23 +70,22 @@ void BreakoutClockMode::handle()
     x = xDec + .5f;
     y = yDec + .5f;
     Display.setPixel(x, y);
-
-    const float angle = atanf((GRID_ROWS - 2 - yDec) / abs(paddle[1] - xDec)) * RAD_TO_DEG;
-    if (xDec > paddle.back() && angle < 67.5f && paddle.back() < GRID_COLUMNS - 1)
-    {
-        // Right
-        Display.setPixel(paddle.front(), GRID_COLUMNS - 1, 0);
-        paddle.pop_front();
-        paddle.push_back(paddle.back() + 1);
-        Display.setPixel(paddle.back(), GRID_COLUMNS - 1);
-    }
-    else if (xDec < paddle.front() && angle < 67.5f && paddle.front() > 0)
+    const float rad = atanf((GRID_ROWS - 2 - yDec) / abs(paddle[1] - xDec));
+    if (xDec < paddle.front() && rad < 1 && paddle.front() > 0)
     {
         // Left
-        Display.setPixel(paddle.back(), GRID_COLUMNS - 1, 0);
+        Display.setPixel(paddle.back(), GRID_ROWS - 1, 0);
         paddle.pop_back();
         paddle.push_front(paddle.front() - 1);
-        Display.setPixel(paddle.front(), GRID_COLUMNS - 1);
+        Display.setPixel(paddle.front(), GRID_ROWS - 1);
+    }
+    else if (xDec > paddle.back() && rad < 1 && paddle.back() < GRID_COLUMNS - 1)
+    {
+        // Right
+        Display.setPixel(paddle.front(), GRID_ROWS - 1, 0);
+        paddle.pop_front();
+        paddle.push_back(paddle.back() + 1);
+        Display.setPixel(paddle.back(), GRID_ROWS - 1);
     }
 }
 

--- a/firmware/src/modes/PingPongClockMode.cpp
+++ b/firmware/src/modes/PingPongClockMode.cpp
@@ -24,7 +24,6 @@ void PingPongClockMode::begin()
     yDec = y = paddleY + 1;
     deg = random(150, 211); // ±30°
     Display.setPixel(x, y);
-    predict();
 }
 
 void PingPongClockMode::handle()
@@ -44,19 +43,16 @@ void PingPongClockMode::handle()
     {
         // Left
         deg = (random(45, 136) + 270) % 360; // ±45°
-        predict();
     }
     else if (xDec >= GRID_COLUMNS - 2 && (deg < 90 || deg >= 270))
     {
         // Right
         deg = random(135, 226); // ±45°
-        predict();
     }
     if (yDec <= 5 || yDec >= GRID_ROWS - 1)
     {
         // Top/bottom
         deg = 360 - deg; // Invert Y
-        predict();
     }
     Display.setPixel(x, y, 0);
     xDec += cos(deg * DEG_TO_RAD) * speed;
@@ -64,56 +60,41 @@ void PingPongClockMode::handle()
     x = xDec + .5f;
     y = yDec + .5f;
     Display.setPixel(x, y);
-
-    if (deg >= 90 && deg < 270 && targetY - 1 < paddleL.front() && paddleL.front() > 5 && millis() - lastMillis > UINT8_MAX)
-    {
-        // Left up
-        Display.setPixel(0, paddleL.back(), 0);
-        paddleL.pop_back();
-        paddleL.push_front(paddleL.front() - 1);
-        Display.setPixel(0, paddleL.front());
-        lastMillis = millis();
-    }
-    else if (deg >= 90 && deg < 270 && targetY + 1 > paddleL.back() && paddleL.back() < GRID_ROWS - 1 && millis() - lastMillis > UINT8_MAX)
+    const float
+        lRad = atanf((xDec - 1) / abs(paddleL[1] - yDec)),
+        rRad = atanf((GRID_COLUMNS - 2 - xDec) / abs(paddleR[1] - yDec));
+    if (yDec > paddleL.back() && lRad < 1 && paddleL.back() < GRID_ROWS - 1)
     {
         // Left down
         Display.setPixel(0, paddleL.front(), 0);
         paddleL.pop_front();
         paddleL.push_back(paddleL.back() + 1);
         Display.setPixel(0, paddleL.back());
-        lastMillis = millis();
     }
-    else if ((deg < 90 || deg >= 270) && targetY - 1 < paddleR.front() && paddleR.front() > 5 && millis() - lastMillis > UINT8_MAX)
+    else if (yDec < paddleL.front() && lRad < 1 && paddleL.front() > 5)
     {
-        // Right up
-        Display.setPixel(GRID_ROWS - 1, paddleR.back(), 0);
-        paddleR.pop_back();
-        paddleR.push_front(paddleR.front() - 1);
-        Display.setPixel(GRID_ROWS - 1, paddleR.front());
-        lastMillis = millis();
+        // Left up
+        Display.setPixel(0, paddleL.back(), 0);
+        paddleL.pop_back();
+        paddleL.push_front(paddleL.front() - 1);
+        Display.setPixel(0, paddleL.front());
     }
-    else if ((deg < 90 || deg >= 270) && targetY + 1 > paddleR.back() && paddleR.back() < GRID_ROWS - 1 && millis() - lastMillis > UINT8_MAX)
+    else if (yDec > paddleR.back() && rRad < 1 && paddleR.back() < GRID_ROWS - 1)
     {
         // Right down
-        Display.setPixel(GRID_ROWS - 1, paddleR.front(), 0);
+        Display.setPixel(GRID_COLUMNS - 1, paddleR.front(), 0);
         paddleR.pop_front();
         paddleR.push_back(paddleR.back() + 1);
-        Display.setPixel(GRID_ROWS - 1, paddleR.back());
-        lastMillis = millis();
+        Display.setPixel(GRID_COLUMNS - 1, paddleR.back());
     }
-}
-
-void PingPongClockMode::predict()
-{
-    float
-        _x = xDec,
-        _y = yDec;
-    do
+    else if (yDec < paddleR.front() && rRad < 1 && paddleR.front() > 5)
     {
-        _x += cos(deg * DEG_TO_RAD);
-        _y -= sin(deg * DEG_TO_RAD);
-    } while (_x > 1 && _x + .5f < GRID_COLUMNS - 2);
-    targetY = _y + .5f;
+        // Right up
+        Display.setPixel(GRID_COLUMNS - 1, paddleR.back(), 0);
+        paddleR.pop_back();
+        paddleR.push_front(paddleR.front() - 1);
+        Display.setPixel(GRID_COLUMNS - 1, paddleR.front());
+    }
 }
 
 #endif // MODE_PINGPONGCLOCK

--- a/firmware/src/modes/PingPongMode.cpp
+++ b/firmware/src/modes/PingPongMode.cpp
@@ -8,13 +8,13 @@
 void PingPongMode::begin()
 {
     Display.clearFrame();
-    paddleT.clear();
     paddleB.clear();
+    paddleT.clear();
     const uint8_t paddleX = random(GRID_COLUMNS - 3);
     for (uint8_t _x = 0; _x < 3; ++_x)
     {
-        paddleT.push_back(paddleX + _x);
         paddleB.push_back(paddleX + _x);
+        paddleT.push_back(paddleX + _x);
         Display.setPixel(paddleX + _x, 0);
         Display.setPixel(paddleX + _x, GRID_COLUMNS - 1);
     }
@@ -22,7 +22,6 @@ void PingPongMode::begin()
     yDec = y = GRID_ROWS - 2;
     deg = random(60, 121); // ±30°
     Display.setPixel(x, y);
-    predict();
 }
 
 void PingPongMode::handle()
@@ -31,19 +30,16 @@ void PingPongMode::handle()
     {
         // Top
         deg = random(225, 316); // ±45°
-        predict();
     }
     else if (yDec >= GRID_COLUMNS - 2 && deg >= 180)
     {
         // Bottom
         deg = random(45, 136); // ±45°
-        predict();
     }
     if (xDec <= 0 || xDec >= GRID_COLUMNS - 1)
     {
         // Left/right
         deg = deg >= 180 ? 540 - deg : 180 - deg; // Invert X
-        predict();
     }
     Display.setPixel(x, y, 0);
     xDec += cos(deg * DEG_TO_RAD) * speed;
@@ -51,56 +47,41 @@ void PingPongMode::handle()
     x = xDec + .5f;
     y = yDec + .5f;
     Display.setPixel(x, y);
-
-    if (deg < 180 && targetX - 1 < paddleB.front() && paddleB.front() > 0 && millis() - lastMillis > 200)
-    {
-        // Top left
-        Display.setPixel(paddleB.back(), 0, 0);
-        paddleB.pop_back();
-        paddleB.push_front(paddleB.front() - 1);
-        Display.setPixel(paddleB.front(), 0);
-        lastMillis = millis();
-    }
-    else if (deg < 180 && targetX + 1 > paddleB.back() && paddleB.back() < GRID_COLUMNS - 1 && millis() - lastMillis > 200)
-    {
-        // Top right
-        Display.setPixel(paddleB.front(), 0, 0);
-        paddleB.pop_front();
-        paddleB.push_back(paddleB.back() + 1);
-        Display.setPixel(paddleB.back(), 0);
-        lastMillis = millis();
-    }
-    else if (deg >= 180 && targetX - 1 < paddleT.front() && paddleT.front() > 0 && millis() - lastMillis > 200)
+    const float
+        bRad = atanf((GRID_ROWS - 2 - yDec) / abs(paddleB[1] - xDec)),
+        tRad = atanf((yDec - 1) / abs(paddleT[1] - xDec));
+    if (xDec < paddleB.front() && bRad < 1 && paddleB.front() > 0)
     {
         // Bottom left
-        Display.setPixel(paddleT.back(), GRID_ROWS - 1, 0);
-        paddleT.pop_back();
-        paddleT.push_front(paddleT.front() - 1);
-        Display.setPixel(paddleT.front(), GRID_ROWS - 1);
-        lastMillis = millis();
+        Display.setPixel(paddleB.back(), GRID_ROWS - 1, 0);
+        paddleB.pop_back();
+        paddleB.push_front(paddleB.front() - 1);
+        Display.setPixel(paddleB.front(), GRID_ROWS - 1);
     }
-    else if (deg >= 180 && targetX + 1 > paddleT.back() && paddleT.back() < GRID_COLUMNS - 1 && millis() - lastMillis > 200)
+    else if (xDec > paddleB.back() && bRad < 1 && paddleB.back() < GRID_COLUMNS - 1)
     {
         // Bottom right
-        Display.setPixel(paddleT.front(), GRID_ROWS - 1, 0);
+        Display.setPixel(paddleB.front(), GRID_ROWS - 1, 0);
+        paddleB.pop_front();
+        paddleB.push_back(paddleB.back() + 1);
+        Display.setPixel(paddleB.back(), GRID_ROWS - 1);
+    }
+    else if (xDec < paddleT.front() && tRad < 1 && paddleT.front() > 0)
+    {
+        // Top left
+        Display.setPixel(paddleT.back(), 0, 0);
+        paddleT.pop_back();
+        paddleT.push_front(paddleT.front() - 1);
+        Display.setPixel(paddleT.front(), 0);
+    }
+    else if (xDec > paddleT.back() && tRad < 1 && paddleT.back() < GRID_COLUMNS - 1)
+    {
+        // Top right
+        Display.setPixel(paddleT.front(), 0, 0);
         paddleT.pop_front();
         paddleT.push_back(paddleT.back() + 1);
-        Display.setPixel(paddleT.back(), GRID_ROWS - 1);
-        lastMillis = millis();
+        Display.setPixel(paddleT.back(), 0);
     }
-}
-
-void PingPongMode::predict()
-{
-    float
-        _x = xDec,
-        _y = yDec;
-    do
-    {
-        _x += cos(deg * DEG_TO_RAD);
-        _y -= sin(deg * DEG_TO_RAD);
-    } while (_y > 1 && _y + .5f < GRID_ROWS - 2);
-    targetX = _x + .5f;
 }
 
 #endif // MODE_PINGPONG


### PR DESCRIPTION
- Fixed an paddle miss bug in the Ping-Pong and Ping-Pong clock modes
- Fixed an display resolution bug in Breakout clock
- Made the Breakout clock much more lengthy in the beginning by increasing the number of bricks.

### Changes

- Refactored paddles in the Ping-Pong mode
- Refactored paddles in the Ping-Pong clock mode
- Increased the number of bricks and optimized paddle movement in the Breakout clock mode

### Impact

The pong paddles will no longer miss the ball, and will move more human-alike. The breakout challange now has more bricks.