### PR TITLE
Shorter startup delay and relocated secrets.h include directive

### DIFF
--- a/firmware/include/config/IkeaFrekvens.h
+++ b/firmware/include/config/IkeaFrekvens.h
@@ -4,6 +4,8 @@
  * https://github.com/VIPnytt/Frekvens/wiki/IKEA-Frekvens
  */
 
+#include "secrets.h"
+
 #define MANUFACTURER "IKEA"
 #define MODEL "Frekvens"
 

--- a/firmware/include/config/IkeaObegransad.h
+++ b/firmware/include/config/IkeaObegransad.h
@@ -4,6 +4,8 @@
  * https://github.com/VIPnytt/Frekvens/wiki/IKEA-Obegransad
  */
 
+#include "secrets.h"
+
 #define MANUFACTURER "IKEA"
 #define MODEL "Obegränsad"
 

--- a/firmware/include/config/constants.h
+++ b/firmware/include/config/constants.h
@@ -4,8 +4,6 @@
  * https://github.com/VIPnytt/Frekvens/wiki
  */
 
-#include "secrets.h"
-
 /**
  * Device
  */

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -22,7 +22,7 @@
 void DeviceService::begin()
 {
     Serial.begin(MONITOR_SPEED);
-    vTaskDelay(UINT8_MAX);
+    vTaskDelay(INT8_MAX);
     ESP_LOGI(name, "Frekvens " VERSION);
     ESP_LOGD(name, MANUFACTURER " " MODEL);
 


### PR DESCRIPTION
Shorten the initial startup delay and relocated `secrets.h` #include directive.

### Changes

- Shortened the startup delay
- Reverted two of the changes from #232

### Impact

No real-world changes expected, except for marginally faster startup times. The `secrets.h` #include directives has no build effect and is soley developer focused.