### PR TITLE
Add multi-font support to countdown mode

### DIFF
--- a/firmware/include/modes/CountdownMode.h
+++ b/firmware/include/modes/CountdownMode.h
@@ -29,7 +29,7 @@ private:
 #endif
     });
     bool odd = false;
-    
+
     uint8_t blink = 0;
     uint8_t lower = 0;
     uint8_t upper = 0;

--- a/firmware/include/modes/CountdownMode.h
+++ b/firmware/include/modes/CountdownMode.h
@@ -2,6 +2,11 @@
 
 #if MODE_COUNTDOWN
 
+#include "config/constants.h"     // NOLINT(misc-include-cleaner)
+#include "fonts/MediumBoldFont.h" // NOLINT(misc-include-cleaner)
+#include "fonts/MediumFont.h"     // NOLINT(misc-include-cleaner)
+#include "fonts/MediumWideFont.h" // NOLINT(misc-include-cleaner)
+#include "fonts/MiniFont.h"       // NOLINT(misc-include-cleaner)
 #include "modules/ModeModule.h"
 
 #include <chrono>
@@ -9,12 +14,29 @@
 class CountdownMode final : public ModeModule
 {
 private:
-    bool done = false;
-
+    static constexpr auto fontNames = std::to_array<std::string_view>({
+#if FONT_MINI
+        MiniFont::name,
+#endif
+#if FONT_MEDIUM
+        MediumFont::name,
+#endif
+#if FONT_MEDIUMBOLD
+        MediumBoldFont::name,
+#endif
+#if FONT_MEDIUMWIDE
+        MediumWideFont::name,
+#endif
+    });
+    bool odd = false;
+    
+    uint8_t blink = 0;
     uint8_t lower = 0;
     uint8_t upper = 0;
 
     std::chrono::time_point<std::chrono::system_clock> epoch{};
+
+    std::string fontName = fontNames[0].data();
 
     void save();
     void transmit();
@@ -25,6 +47,7 @@ public:
     void configure() override;
     void begin() override;
     void handle() override;
+    void setFont(std::string_view _fontName);
     void onReceive(JsonObjectConst payload, const char *source) override;
 };
 

--- a/firmware/src/modes/CountdownMode.cpp
+++ b/firmware/src/modes/CountdownMode.cpp
@@ -2,12 +2,11 @@
 
 #include "modes/CountdownMode.h"
 
-#include "config/constants.h" // NOLINT(misc-include-cleaner)
 #include "extensions/HomeAssistantExtension.h"
-#include "fonts/MediumFont.h" // NOLINT(misc-include-cleaner)
 #include "handlers/TextHandler.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
+#include "services/FontsService.h"
 
 #include <Preferences.h>
 #include <array>
@@ -17,8 +16,44 @@
 
 void CountdownMode::configure()
 {
+    Preferences Storage;
+    Storage.begin(name, true);
+    if (Storage.isKey("font"))
+    {
+        fontName = Storage.getString("font").c_str();
+    }
+    if (Storage.isKey("epoch"))
+    {
+        const int64_t _epoch = Storage.getLong64("epoch");
+        Storage.end();
+        epoch = std::chrono::system_clock::time_point{std::chrono::seconds{_epoch}};
+    }
+    else
+    {
+        Storage.end();
+    }
 #if EXTENSION_HOMEASSISTANT
     const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
+    {
+        const std::string id{std::string(name).append("_font")};
+        JsonObject component{(*HomeAssistant->discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"font":"{{value}}"})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:format-font");
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" font"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
+        for (const std::string_view _font : fontNames)
+        {
+            options.add(_font);
+        }
+        component[HomeAssistantAbbreviations::platform].set("select");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(HomeAssistant->uniquePrefix + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.font}}");
+    }
     {
         const std::string id{std::string(name).append("_timestamp")};
         JsonObject component{(*HomeAssistant->discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
@@ -36,23 +71,15 @@ void CountdownMode::configure()
         component[HomeAssistantAbbreviations::value_template].set("{{value_json.timestamp}}");
     }
 #endif // EXTENSION_HOMEASSISTANT
-
-    Preferences preferences;
-    preferences.begin(name, true);
-    if (preferences.isKey("epoch"))
-    {
-        const int64_t _epoch = preferences.getLong64("epoch");
-        preferences.end();
-        epoch = std::chrono::system_clock::time_point{std::chrono::seconds{_epoch}};
-        transmit();
-    }
-    else
-    {
-        preferences.end();
-    }
+    transmit();
 }
 
-void CountdownMode::begin() { done = false; }
+void CountdownMode::begin()
+{
+    blink = 0;
+    lower = 0;
+    upper = 0;
+}
 
 void CountdownMode::handle()
 {
@@ -61,8 +88,11 @@ void CountdownMode::handle()
     const std::chrono::minutes _minutes = std::chrono::duration_cast<std::chrono::minutes>(_nanoseconds - _hours);
     const int64_t hours = _hours.count();
     const int64_t minutes = _minutes.count();
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     const int64_t seconds{std::chrono::duration_cast<std::chrono::seconds>(_nanoseconds - _hours - _minutes).count()};
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     const uint8_t _upper{static_cast<uint8_t>(std::clamp<int64_t>(hours > 0 ? hours % 100 : minutes, 0, 99))};
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     const uint8_t _lower{static_cast<uint8_t>(std::clamp<int64_t>(hours > 0 ? minutes : seconds, 0, 99))};
     if (_lower != lower || _upper != upper)
     {
@@ -70,45 +100,42 @@ void CountdownMode::handle()
         lower = _lower;
         if (seconds >= 0 && minutes >= 0 && hours >= 0)
         {
+            const std::unique_ptr<const FontModule> font = Fonts.get(fontName);
+            const TextHandler _tl(std::to_string(_upper / 10), *font);
+            const TextHandler _tr(std::to_string(_upper % 10), *font);
+            const TextHandler _bl(std::to_string(lower / 10), *font);
+            const TextHandler _br(std::to_string(lower % 10), *font);
+            const uint8_t fontWidth{max({_tl.getWidth(), _tr.getWidth(), _bl.getWidth(), _br.getWidth()})};
             Display.clearFrame();
-            const MediumFont font;
-            {
-                TextHandler topLeft{std::to_string(upper / 10), font};
-                topLeft.draw((GRID_COLUMNS / 2) - 1 - ((7 - topLeft.getWidth()) / 2) - topLeft.getWidth(),
-                             (GRID_ROWS / 2) - 1 - ((7 - topLeft.getHeight()) / 2) - topLeft.getHeight());
-            }
-            {
-                TextHandler topRight{std::to_string(upper % 10), font};
-                topRight.draw((GRID_COLUMNS / 2) + 1 + ((7 - topRight.getWidth()) / 2),
-                              (GRID_ROWS / 2) - 1 + ((7 - topRight.getHeight()) / 2) - topRight.getHeight());
-            }
-            {
-                TextHandler bottomLeft{std::to_string(lower / 10), font};
-                bottomLeft.draw((GRID_COLUMNS / 2) - 1 - ((7 - bottomLeft.getWidth()) / 2) - bottomLeft.getWidth(),
-                                (GRID_ROWS / 2) + 1 - ((7 - bottomLeft.getHeight()) / 2));
-            }
-            {
-                TextHandler bottomRight{std::to_string(lower % 10), font};
-                bottomRight.draw((GRID_COLUMNS / 2) + 1 + ((7 - bottomRight.getWidth()) / 2),
-                                 (GRID_ROWS / 2) + 1 + ((7 - bottomRight.getHeight()) / 2));
-            }
+            _tl.draw((GRID_COLUMNS / 2) - 1 - fontWidth + ((fontWidth - _tl.getWidth()) / 2),
+                     (GRID_ROWS / 2) - 1 - _tl.getHeight());
+            _tr.draw((GRID_COLUMNS / 2) + 1 + ((fontWidth - _tr.getWidth()) / 2),
+                     (GRID_ROWS / 2) - 1 - _tr.getHeight());
+            _bl.draw((GRID_COLUMNS / 2) - 1 - fontWidth + ((fontWidth - _bl.getWidth()) / 2),
+                     (GRID_COLUMNS / 2) + static_cast<int8_t>(_bl.getHeight() > 5));
+            _br.draw((GRID_COLUMNS / 2) + 1 + ((fontWidth - _br.getWidth()) / 2),
+                     (GRID_COLUMNS / 2) + static_cast<int8_t>(_br.getHeight() > 5));
             if (seconds == 0 && minutes == 0 && hours == 0)
             {
-                done = true;
+                blink = INT8_MAX;
+                odd = static_cast<bool>(seconds & 1);
                 JsonDocument doc; // NOLINT(misc-const-correctness)
                 doc["event"].set("done");
                 Device.transmit(doc.as<JsonObjectConst>(), name, false);
             }
         }
-        else if (done)
-        {
-            Display.invertFrame();
-        }
+    }
+    else if (blink && odd == static_cast<bool>(seconds & 1))
+    {
+        --blink;
+        odd = !odd;
+        Display.invertFrame();
     }
 }
 
 void CountdownMode::save()
 {
+    blink = 0;
     Preferences preferences;
     preferences.begin(name);
     preferences.putLong64("epoch", std::chrono::duration_cast<std::chrono::seconds>(epoch.time_since_epoch()).count());
@@ -116,13 +143,32 @@ void CountdownMode::save()
     transmit();
 }
 
+void CountdownMode::setFont(std::string_view _fontName)
+{
+    if (const std::unique_ptr<const FontModule> _font = Fonts.get(_fontName))
+    {
+        fontName = _font->name.data();
+        Preferences Storage;
+        Storage.begin(name);
+        Storage.putString("font", fontName.c_str());
+        Storage.end();
+        transmit();
+    }
+}
+
 void CountdownMode::transmit()
 {
     std::array<char, 32> buffer{};
-    time_t timer = std::chrono::system_clock::to_time_t(epoch);
+    time_t timer{std::chrono::system_clock::to_time_t(epoch)};
     tm local = *std::localtime(&timer);
     std::strftime(buffer.data(), buffer.size(), "%FT%T", &local);
     JsonDocument doc; // NOLINT(misc-const-correctness)
+    doc["font"].set(fontName);
+    JsonArray _fonts{doc["fonts"].to<JsonArray>()};
+    for (const std::string_view _font : fontNames)
+    {
+        _fonts.add(_font);
+    }
     doc["timestamp"].set(std::string_view(buffer.data()));
     Device.transmit(doc.as<JsonObjectConst>(), name);
 }
@@ -130,6 +176,12 @@ void CountdownMode::transmit()
 void CountdownMode::onReceive(JsonObjectConst payload,
                               const char *source) // NOLINT(misc-unused-parameters)
 {
+    // Font
+    if (payload["font"].is<std::string_view>())
+    {
+        setFont(payload["font"].as<std::string_view>());
+    }
+    // Time or timestamp
     if (payload["time"].is<uint32_t>())
     {
         epoch = std::chrono::system_clock::now() + std::chrono::seconds(payload["time"].as<uint32_t>());

--- a/webapp/src/modes/Countdown.tsx
+++ b/webapp/src/modes/Countdown.tsx
@@ -1,6 +1,6 @@
 import { mdiTimerSand, mdiTimerSandComplete } from "@mdi/js";
 import Cookies from "js-cookie";
-import { type Component, createSignal } from "solid-js";
+import { type Component, createSignal, For } from "solid-js";
 
 import { Icon } from "../components/Icon";
 import { Toast } from "../components/Toast";
@@ -12,13 +12,17 @@ import { ModesMode, name as ModesName } from "../services/Modes";
 
 export const name = "Countdown";
 
-const [getHours, setHours] = createSignal<number>(parseInt(Cookies.get(`${name}.hours`) || "", 10) || 0);
-const [getMinutes, setMinutes] = createSignal<number>(parseInt(Cookies.get(`${name}.minutes`) || "", 10) || 10);
-const [getSeconds, setSeconds] = createSignal<number>(parseInt(Cookies.get(`${name}.seconds`) || "", 10) || 0);
+const [getFont, setFont] = createSignal<string>("");
+const [getFonts, setFonts] = createSignal<string[]>([]);
+const [getHours, setHours] = createSignal<number>(parseInt(Cookies.get(`${name}.hours`) ?? "0", 10));
+const [getMinutes, setMinutes] = createSignal<number>(parseInt(Cookies.get(`${name}.minutes`) ?? "10", 10));
+const [getSeconds, setSeconds] = createSignal<number>(parseInt(Cookies.get(`${name}.seconds`) ?? "0", 10));
 const [getTimestamp, setTimestamp] = createSignal<string | undefined>(undefined);
 
-export const receiver = (json: { event?: string; timestamp?: string | undefined }) => {
+export const receiver = (json: { event?: string; font?: string; fonts?: string[]; timestamp?: string }) => {
     json?.event !== undefined && event(json.event);
+    json?.font !== undefined && setFont(json.font);
+    json?.fonts !== undefined && setFonts(json.fonts);
     json?.timestamp !== undefined && setTimestamp(json.timestamp);
 };
 
@@ -109,15 +113,37 @@ export const Sidebar: Component = () => {
         );
     };
 
+    const handleFont = (font: string) => {
+        setFont(font);
+        WebSocketWS.send(
+            JSON.stringify({
+                [name]: {
+                    font: getFont(),
+                },
+            }),
+        );
+    };
+
     return (
-        <SidebarSection title="Due">
+        <SidebarSection>
+            <div class="font-semibold uppercase text-content-alt-light dark:text-content-alt-dark text-xs">Due</div>
             <input
-                class="w-full"
+                class="mt-1 w-full"
                 type="datetime-local"
                 min={new Date().toISOString().slice(0, 16)}
                 value={getTimestamp()}
                 onChange={(e) => handleAbsolute(e.currentTarget.value)}
             />
+            <div class="mt-3 font-semibold uppercase text-content-alt-light dark:text-content-alt-dark text-xs">
+                Font
+            </div>
+            <select
+                class="mt-1 w-full"
+                onchange={(e) => handleFont(e.currentTarget.value)}
+                value={getFont()}
+            >
+                <For each={getFonts()}>{(font) => <option>{font}</option>}</For>
+            </select>
         </SidebarSection>
     );
 };


### PR DESCRIPTION
This PR adds multi-font support to Countdown mode across both firmware and the web UI.

Users can now choose which supported font the countdown should use, and the selected font is exposed through the device payload, persisted in preferences, and configurable from the frontend. This also improves how the countdown behaves once it has ended.

## Changes

### Firmware
- Added support for multiple countdown fonts via a static list of available font names
- Persisted the selected countdown font in preferences
- Added `setFont()` handling for validating and applying font changes
- Included the active font and available font list in transmitted Countdown payloads
- Added Home Assistant select discovery for countdown font selection
- Updated countdown rendering to use the selected font dynamically instead of a fixed font
- Reset countdown display state in `begin()` using blink/lower/upper values
- Improved ended countdown handling as part of the mode update flow

### Web UI
- Added Countdown font state handling in the receiver
- Added support for receiving both the active font and the list of available fonts
- Added a font selector dropdown to the Countdown sidebar
- Sent font changes back over WebSocket when a new font is selected
- Adjusted Countdown cookie initialization for hours, minutes, and seconds

## Why

This makes Countdown mode more flexible and consistent with the rest of the project by allowing the display style to be selected instead of being hardcoded. It also improves the configuration experience in both the web UI and Home Assistant.

## Notes
- The default countdown font is initialized from the first available compiled font
- Font changes are validated against the registered font service before being saved
- The web UI font dropdown is populated dynamically from the device-reported font list