### PR TITLE
Use plain Python for dependency-free generate jobs

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -84,12 +84,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
 
       - name: Generate mode
         run: |
@@ -175,12 +173,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
 
       - name: Generate mode
         run: |


### PR DESCRIPTION
Simplify the dependency-free jobs in the `Generate` workflow by replacing the `uv` setup with a plain Python setup.

## Changes

- replace `astral-sh/setup-uv` with `actions/setup-python` in:
  - `mode-dynamic`
  - `mode-static`
- keep the existing `uv` setup for `font-dejavusans`, since that job still installs the `font` extra

## Rationale

`mode-dynamic` and `mode-static` do not install any Python dependencies, so setting up `uv` is unnecessary there. Using a plain Python installation makes those jobs a bit simpler while preserving the existing behavior.

## Impact

- no functional change to the generated output
- reduced setup complexity for the dependency-free jobs
- no change to the font generation job, which still requires dependency installation