### PR TITLE
Add nodejs-wheel-binaries to the end-of-life Node.js matrix

### DIFF
--- a/.github/workflows/end-of-life.yml
+++ b/.github/workflows/end-of-life.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Node.js wheel binaries version
         id: lock
-        run: echo "version=$(yq -p=toml '.package[] | select(.name == \"nodejs-wheel-binaries\") | .version' uv.lock)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(yq -p=toml '.package[] | select(.name == "nodejs-wheel-binaries") | .version' uv.lock)" >> "$GITHUB_OUTPUT"
 
   nodejs:
     name: Node.js

--- a/.github/workflows/end-of-life.yml
+++ b/.github/workflows/end-of-life.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Node.js wheel binaries version
         id: lock
-        run: echo "version=$(yq '.package[] | select(.name == \"nodejs-wheel-binaries\") | .version' uv.lock)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(yq -p=toml '.package[] | select(.name == \"nodejs-wheel-binaries\") | .version' uv.lock)" >> "$GITHUB_OUTPUT"
 
   nodejs:
     name: Node.js
@@ -55,10 +55,10 @@ jobs:
       - idle-check
       - nodejs-wheel
     runs-on: ubuntu-slim
-    continue-on-error: true
     if: ${{ fromJSON(needs.idle-check.outputs.active) }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - ${{ needs.nodejs-wheel.outputs.version }}
@@ -76,10 +76,10 @@ jobs:
     name: Python
     needs: idle-check
     runs-on: ubuntu-slim
-    continue-on-error: true
     if: ${{ fromJSON(needs.idle-check.outputs.active) }}
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: '3.10'

--- a/.github/workflows/end-of-life.yml
+++ b/.github/workflows/end-of-life.yml
@@ -26,23 +26,43 @@ jobs:
             const { data: branch } = await github.rest.repos.getBranch({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              branch: '${{ github.ref_name }}',
+              branch: context.ref.replace('refs/heads/', ''),
             });
             const active = new Date() - new Date(branch.commit.commit.committer.date) <= 90 * 86400000;
             core.info(`Branch active: ${active}`);
             core.setOutput('active', active);
 
-  node:
-    name: Node.js
+  nodejs-wheel:
+    name: Node.js wheel version
     needs: idle-check
+    runs-on: ubuntu-latest
+    if: ${{ fromJSON(needs.idle-check.outputs.active) }}
+  
+    outputs:
+      version: ${{ steps.lock.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Node.js wheel binaries version
+        id: lock
+        run: echo "version=$(yq '.package[] | select(.name == "nodejs-wheel-binaries") | .version' uv.lock)" >> "$GITHUB_OUTPUT"
+
+  nodejs:
+    name: Node.js
+    needs:
+      - idle-check
+      - nodejs-wheel
     runs-on: ubuntu-slim
+    continue-on-error: true
     if: ${{ fromJSON(needs.idle-check.outputs.active) }}
 
     strategy:
-      fail-fast: false
       matrix:
-        include:
-          - node-version: 24
+        node-version:
+          - ${{ needs.nodejs-wheel.outputs.version }}
+          - 24
 
     steps:
       - name: End-of-Life
@@ -56,10 +76,10 @@ jobs:
     name: Python
     needs: idle-check
     runs-on: ubuntu-slim
+    continue-on-error: true
     if: ${{ fromJSON(needs.idle-check.outputs.active) }}
 
     strategy:
-      fail-fast: false
       matrix:
         include:
           - python-version: '3.10'

--- a/.github/workflows/end-of-life.yml
+++ b/.github/workflows/end-of-life.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Node.js wheel binaries version
         id: lock
-        run: echo "version=$(yq -p=toml '.package[] | select(.name == "nodejs-wheel-binaries") | .version' uv.lock)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(yq -o toml -p toml '.package[] | select(.name == "nodejs-wheel-binaries") | .version' uv.lock)" >> "$GITHUB_OUTPUT"
 
   nodejs:
     name: Node.js

--- a/.github/workflows/end-of-life.yml
+++ b/.github/workflows/end-of-life.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Node.js wheel binaries version
         id: lock
-        run: echo "version=$(yq '.package[] | select(.name == "nodejs-wheel-binaries") | .version' uv.lock)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(yq '.package[] | select(.name == \"nodejs-wheel-binaries\") | .version' uv.lock)" >> "$GITHUB_OUTPUT"
 
   nodejs:
     name: Node.js


### PR DESCRIPTION
This PR expands the end-of-life workflow to also check the bundled Node.js version pinned through `nodejs-wheel-binaries` in `uv.lock`.

## Changes

* add a `nodejs-wheel` job that extracts the pinned `nodejs-wheel-binaries` version from `uv.lock`
* include that extracted version in the Node.js end-of-life matrix alongside Node.js 24
* fix branch resolution in the `idle-check` job by using `context.ref`
* disable `fail-fast` for the matrix strategy so one failing version check does not stop the others

## Why

The workflow currently checks the explicitly targeted CI Node.js version, but not the bundled Node.js version used through `nodejs-wheel-binaries`.

By adding the pinned wheel version to the matrix, the end-of-life check covers both:

* the Node.js runtime used in CI
* the bundled Node.js version resolved from `uv.lock`

This makes the workflow more representative of the versions the project actually relies on.

## Notes

* this is a workflow-only change
* labeled `skip-changelog`, so it should not be included in release notes
