### PR TITLE
Add initial repository-wide CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @JanPetterMG


### PR DESCRIPTION
Add an initial `CODEOWNERS` file with a single repository-wide ownership rule.

## Changes

- Add `.github/CODEOWNERS`
- Assign all files to `@JanPetterMG`

## Notes

- This introduces a minimal baseline for code ownership
- The configuration can be expanded later with more specific path-based rules
- No functional changes are included