### PR TITLE
Use std::string_view for service names

### DIFF
--- a/firmware/include/modules/ServiceModule.h
+++ b/firmware/include/modules/ServiceModule.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <ArduinoJson.h> // NOLINT(misc-include-cleaner)
+#include <string_view>
 
 class ServiceModule
 {
 protected:
-    explicit ServiceModule(const char *name) : name(name) {};
+    explicit ServiceModule(std::string_view name) : name(name) {};
 
 public:
     virtual ~ServiceModule() = default;
@@ -15,7 +16,7 @@ public:
     ServiceModule(ServiceModule &&) = delete;
     ServiceModule &operator=(ServiceModule &&) = delete;
 
-    const char *const name;
+    const std::string_view name{};
 
     virtual void onReceive(JsonObjectConst payload, std::string_view source);
 };

--- a/firmware/include/services/ConnectivityService.h
+++ b/firmware/include/services/ConnectivityService.h
@@ -10,9 +10,7 @@
 class ConnectivityService final : public ServiceModule
 {
 private:
-    static constexpr std::string_view name = "Connectivity";
-
-    explicit ConnectivityService() : ServiceModule(name) {};
+    explicit ConnectivityService() : ServiceModule("Connectivity") {};
 
     bool mDNS = false;
     bool pending = false;

--- a/firmware/include/services/ConnectivityService.h
+++ b/firmware/include/services/ConnectivityService.h
@@ -10,9 +10,9 @@
 class ConnectivityService final : public ServiceModule
 {
 private:
-    static constexpr std::string_view _name = "Connectivity";
+    static constexpr std::string_view name = "Connectivity";
 
-    explicit ConnectivityService() : ServiceModule(_name.data()) {};
+    explicit ConnectivityService() : ServiceModule(name) {};
 
     bool mDNS = false;
     bool pending = false;
@@ -20,7 +20,7 @@ private:
 
     unsigned long lastMillis = 0;
 
-    std::unique_ptr<DNSServer> dns = nullptr;
+    std::unique_ptr<DNSServer> dns{};
 
     WiFiMulti multi;
 

--- a/firmware/src/extensions/AlexaExtension.cpp
+++ b/firmware/src/extensions/AlexaExtension.cpp
@@ -72,7 +72,7 @@ void AlexaExtension::onTransmit(JsonObjectConst payload, std::string_view source
 {
     // Display: Brightness
     // Display: Power
-    if (!strcmp(source.data(), Display.name) && (payload["brightness"].is<uint8_t>() || payload["power"].is<bool>()))
+    if (source == Display.name && (payload["brightness"].is<uint8_t>() || payload["power"].is<bool>()))
     {
         fauxmo.setState(NAME,
                         payload["power"].is<bool>() ? payload["power"].as<bool>() : Display.getPower(),

--- a/firmware/src/extensions/HeapExtension.cpp
+++ b/firmware/src/extensions/HeapExtension.cpp
@@ -20,7 +20,7 @@ void HeapExtension::configure()
         component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
         component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
         component[HomeAssistantAbbreviations::icon].set("mdi:memory");
-        component[HomeAssistantAbbreviations::name].set(std::string(Extensions.name).append(" task stack"));
+        component[HomeAssistantAbbreviations::name].set(std::string(Extensions.name.data()).append(" task stack"));
         component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
         component[HomeAssistantAbbreviations::platform].set("sensor");
         component[HomeAssistantAbbreviations::state_class].set("measurement");

--- a/firmware/src/extensions/HomeAssistantExtension.cpp
+++ b/firmware/src/extensions/HomeAssistantExtension.cpp
@@ -118,7 +118,7 @@ void HomeAssistantExtension::transmit()
 void HomeAssistantExtension::onTransmit(JsonObjectConst payload, std::string_view source)
 {
     // Display: Power
-    if (!strcmp(source.data(), Display.name) && payload["power"].is<bool>())
+    if (source == Display.name && payload["power"].is<bool>())
     {
         pending = true;
     }

--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -150,7 +150,7 @@ void PhotocellExtension::onReceive(JsonObjectConst payload,
 void PhotocellExtension::onTransmit(JsonObjectConst payload, std::string_view source)
 {
     // Display: Brightness
-    if (active && !strcmp(source.data(), Display.name) && payload["brightness"].is<uint8_t>())
+    if (active && source == Display.name && payload["brightness"].is<uint8_t>())
     {
         const uint8_t _brightness{payload["brightness"].as<uint8_t>()};
         if (_brightness != brightness)

--- a/firmware/src/extensions/PlaylistExtension.cpp
+++ b/firmware/src/extensions/PlaylistExtension.cpp
@@ -162,7 +162,7 @@ void PlaylistExtension::transmit()
 void PlaylistExtension::onTransmit(JsonObjectConst payload, std::string_view source)
 {
     // Modes: Mode
-    if (active && !strcmp(source.data(), Modes.name) && payload["mode"].is<std::string>() &&
+    if (active && source == Modes.name && payload["mode"].is<std::string>() &&
         payload["mode"].as<std::string>() != playlist[step].mode)
     {
         setActive(false);

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -30,7 +30,7 @@ void ConnectivityService::configure()
     esp_wifi_set_country_code(WIFI_COUNTRY, false);
 #else
     Preferences Storage;
-    Storage.begin(_name.data(), true);
+    Storage.begin(name.data(), true);
     if (Storage.isKey("country"))
     {
         const String country = Storage.getString("country");
@@ -111,7 +111,7 @@ void ConnectivityService::initStation()
 {
     JsonDocument doc; // NOLINT(misc-const-correctness)
     Preferences Storage;
-    Storage.begin(name);
+    Storage.begin(name.data());
     if (Storage.isKey("Wi-Fi"))
     {
         const size_t _length = Storage.getBytesLength("Wi-Fi");
@@ -284,7 +284,7 @@ void ConnectivityService::onScan(WiFiEvent_t event,    // NOLINT(misc-unused-par
             _scan["rssi"].set(WiFi.RSSI(i));
             _scan["ssid"].set(WiFi.SSID(i));
         }
-        Device.transmit(doc.as<JsonObjectConst>(), _name, false);
+        Device.transmit(doc.as<JsonObjectConst>(), name, false);
     }
 }
 
@@ -295,7 +295,7 @@ void ConnectivityService::transmit()
     doc["rssi"].set(WiFi.RSSI());
     {
         Preferences Storage;
-        Storage.begin(name, true);
+        Storage.begin(name.data(), true);
         if (Storage.isKey("saved"))
         {
             const size_t len = Storage.getBytesLength("saved");

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -189,7 +189,7 @@ void ConnectivityService::onConnected(WiFiEvent_t event,    // NOLINT(misc-unuse
     if (esp_wifi_get_country_code(country.data()) == ESP_OK)
     {
         Preferences Storage;
-        Storage.begin(_name.data());
+        Storage.begin(name.data());
         if (strncmp(country.data(), "01", 2) != 0)
         {
             Storage.putString("country", country.data());
@@ -284,7 +284,7 @@ void ConnectivityService::onScan(WiFiEvent_t event,    // NOLINT(misc-unused-par
             _scan["rssi"].set(WiFi.RSSI(i));
             _scan["ssid"].set(WiFi.SSID(i));
         }
-        Device.transmit(doc.as<JsonObjectConst>(), name, false);
+        Device.transmit(doc.as<JsonObjectConst>(), Connectivity.name, false);
     }
 }
 

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -189,7 +189,7 @@ void ConnectivityService::onConnected(WiFiEvent_t event,    // NOLINT(misc-unuse
     if (esp_wifi_get_country_code(country.data()) == ESP_OK)
     {
         Preferences Storage;
-        Storage.begin(name.data());
+        Storage.begin(Connectivity.name.data());
         if (strncmp(country.data(), "01", 2) != 0)
         {
             Storage.putString("country", country.data());

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -39,7 +39,7 @@ void DisplayService::configure()
 #endif // SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
 
     Preferences Storage;
-    Storage.begin(name, true);
+    Storage.begin(name.data(), true);
     const uint8_t _brightness = Storage.isKey("brightness") ? Storage.getUShort("brightness") : UINT8_MAX;
     const Orientation _orientation =
         Storage.isKey("orientation") ? static_cast<Orientation>(Storage.getUShort("orientation")) : orientation;
@@ -176,7 +176,7 @@ void DisplayService::setOrientation(Orientation _orientation)
                                                           : PITCH_VERTICAL / static_cast<float>(PITCH_HORIZONTAL);
 #endif // GRID_COLUMNS == GRID_ROWS && PITCH_HORIZONTAL != PITCH_VERTICAL
     Preferences Storage;
-    Storage.begin(name);
+    Storage.begin(name.data());
     Storage.putUShort("orientation", static_cast<uint8_t>(orientation));
     Storage.end();
     pending = true;
@@ -290,7 +290,7 @@ void DisplayService::setBrightness(uint8_t _brightness)
     }
     brightness = _brightness;
     Preferences Storage;
-    Storage.begin(name);
+    Storage.begin(name.data());
     Storage.putUShort("brightness", brightness);
     Storage.end();
     pending = true;

--- a/firmware/src/services/ExtensionsService.cpp
+++ b/firmware/src/services/ExtensionsService.cpp
@@ -16,7 +16,7 @@ void ExtensionsService::begin()
     {
         extension->begin();
     }
-    xTaskCreate(&onTask, name, stackSize, nullptr, 1, &taskHandle);
+    xTaskCreate(&onTask, name.data(), stackSize, nullptr, 1, &taskHandle);
     transmit();
 }
 

--- a/firmware/src/services/ModesService.cpp
+++ b/firmware/src/services/ModesService.cpp
@@ -54,7 +54,7 @@ void ModesService::begin()
         break;
     default:
         Preferences Storage;
-        Storage.begin(name, true);
+        Storage.begin(name.data(), true);
         if (Storage.isKey("mode"))
         {
             const String _mode = Storage.getString("mode");
@@ -83,7 +83,7 @@ void ModesService::handle()
         setActive(true);
         transmit();
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putString("mode", mode->name);
         Storage.end();
     }
@@ -111,7 +111,7 @@ void ModesService::setActive(bool active)
     }
     else if (taskHandle == nullptr && active && mode != nullptr)
     {
-        xTaskCreate(&onTask, name, stackSize, nullptr, 2, &taskHandle);
+        xTaskCreate(&onTask, name.data(), stackSize, nullptr, 2, &taskHandle);
     }
 }
 


### PR DESCRIPTION
Refactors service name handling to use `std::string_view` instead of owning string types.

This reduces unnecessary allocations and improves overall efficiency, especially in static and compile-time contexts where service names are immutable.

## Changes

- Replace service name storage with `std::string_view`
- Update constructors and interfaces to accept non-owning string references
- Remove redundant string allocations and copies

## Impact

- No functional changes
- Improved performance and memory usage
- Safer and clearer API contracts