### PR TITLE
Use std::string_view for mode names

### DIFF
--- a/firmware/include/modes/StreamMode.h
+++ b/firmware/include/modes/StreamMode.h
@@ -10,8 +10,6 @@
 class StreamMode final : public ModeModule
 {
 private:
-    static constexpr std::string_view _name = "Stream";
-
     uint16_t port = 4048;
 
     std::unique_ptr<AsyncUDP> udp{};
@@ -22,7 +20,7 @@ private:
     static void onPacket(AsyncUDPPacket packet);
 
 public:
-    explicit StreamMode() : ModeModule(_name.data()) {};
+    explicit StreamMode() : ModeModule("Stream") {};
 
     void configure() override;
     void begin() override;

--- a/firmware/include/modules/ModeModule.h
+++ b/firmware/include/modules/ModeModule.h
@@ -16,7 +16,7 @@ public:
     ModeModule(ModeModule &&) = delete;
     ModeModule &operator=(ModeModule &&) = delete;
 
-    std::string_view const name;
+    const std::string_view name{};
 
     virtual void configure();
     virtual void begin();

--- a/firmware/include/modules/ModeModule.h
+++ b/firmware/include/modules/ModeModule.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <ArduinoJson.h> // NOLINT(misc-include-cleaner)
+#include <string_view>
 
 class ModeModule
 {
 protected:
-    explicit ModeModule(const char *name) : name(name) {};
+    explicit ModeModule(std::string_view name) : name(name) {};
 
 public:
     virtual ~ModeModule() = default;
@@ -15,7 +16,7 @@ public:
     ModeModule(ModeModule &&) = delete;
     ModeModule &operator=(ModeModule &&) = delete;
 
-    const char *const name;
+    std::string_view const name;
 
     virtual void configure();
     virtual void begin();

--- a/firmware/include/services/ModesService.h
+++ b/firmware/include/services/ModesService.h
@@ -176,7 +176,7 @@ public:
     void begin();
     void handle();
     void setActive(bool active);
-    void setMode(const char *name);
+    void setMode(std::string_view _name);
     void setModeNext();
     void setModePrevious();
     [[nodiscard]] TaskHandle_t getTaskHandle() const;

--- a/firmware/src/extensions/PlaylistExtension.cpp
+++ b/firmware/src/extensions/PlaylistExtension.cpp
@@ -100,7 +100,7 @@ void PlaylistExtension::handle()
         {
             step = 0;
         }
-        Modes.setMode(playlist[step].mode.c_str());
+        Modes.setMode(playlist[step].mode);
         lastMillis = millis();
     }
 }

--- a/firmware/src/modes/AnimationMode.cpp
+++ b/firmware/src/modes/AnimationMode.cpp
@@ -24,7 +24,7 @@ void AnimationMode::handle()
 #endif // EXTENSION_MICROPHONE
     {
         Preferences Storage;
-        Storage.begin(name, true);
+        Storage.begin(name.data(), true);
         if (Storage.isKey(std::to_string(index).c_str()))
         {
             lastMillis = millis();
@@ -52,7 +52,7 @@ void AnimationMode::setFrame(uint8_t _index, std::span<const uint8_t> frame)
 {
     lastMillis = millis() + (frame.size() * 2);
     Preferences Storage;
-    Storage.begin(name);
+    Storage.begin(name.data());
     Storage.putBytes(std::to_string(_index).c_str(), frame.data(), frame.size());
     Storage.end();
     this->index = 0;
@@ -63,7 +63,7 @@ void AnimationMode::setFrame(uint8_t _index, std::span<const uint8_t> frame)
 void AnimationMode::setFrames(uint8_t count)
 {
     Preferences Storage;
-    Storage.begin(name);
+    Storage.begin(name.data());
     for (uint8_t i = count; i >= 2; ++i)
     {
         const std::string key = std::to_string(i);
@@ -82,7 +82,7 @@ void AnimationMode::setInterval(uint16_t _interval)
     {
         interval = _interval;
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putUShort("interval", interval);
         Storage.end();
     }

--- a/firmware/src/modes/ClockMode.cpp
+++ b/firmware/src/modes/ClockMode.cpp
@@ -14,7 +14,7 @@
 void ClockMode::configure()
 {
     Preferences Storage;
-    Storage.begin(name, true);
+    Storage.begin(name.data(), true);
     if (Storage.isKey("font"))
     {
         fontName = Storage.getString("font").c_str();
@@ -157,7 +157,7 @@ void ClockMode::setFont(std::string_view _fontName)
     {
         fontName = _font->name.data();
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putString("font", fontName.c_str());
         Storage.end();
         pending = true;
@@ -171,7 +171,7 @@ void ClockMode::setTicking(bool _ticking)
     {
         ticking = _ticking;
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putBool("ticking", ticking);
         Storage.end();
         pending = true;

--- a/firmware/src/modes/CountdownMode.cpp
+++ b/firmware/src/modes/CountdownMode.cpp
@@ -18,7 +18,7 @@
 void CountdownMode::configure()
 {
     Preferences Storage;
-    Storage.begin(name, true);
+    Storage.begin(name.data(), true);
     if (Storage.isKey("font"))
     {
         fontName = Storage.getString("font").c_str();
@@ -139,7 +139,7 @@ void CountdownMode::save()
 {
     blink = 0;
     Preferences preferences;
-    preferences.begin(name);
+    preferences.begin(name.data());
     preferences.putLong64("epoch", std::chrono::duration_cast<std::chrono::seconds>(epoch.time_since_epoch()).count());
     preferences.end();
     transmit();
@@ -151,7 +151,7 @@ void CountdownMode::setFont(std::string_view _fontName)
     {
         fontName = _font->name.data();
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putString("font", fontName.c_str());
         Storage.end();
         transmit();

--- a/firmware/src/modes/DrawMode.cpp
+++ b/firmware/src/modes/DrawMode.cpp
@@ -43,7 +43,7 @@ void DrawMode::end() { save(true); }
 void DrawMode::load(bool cache)
 {
     Preferences Storage;
-    Storage.begin(name, true);
+    Storage.begin(name.data(), true);
     const char *key = nullptr;
     if (cache && Storage.isKey("cache"))
     {
@@ -67,7 +67,7 @@ void DrawMode::save(bool cache)
     if (std::any_of(frame.begin(), frame.end(), [](uint8_t pixel) { return pixel > 0; }))
     {
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putBytes(cache ? "cache" : "saved", frame.data(), frame.size());
         Storage.end();
         pending = true;

--- a/firmware/src/modes/GameOfLifeMode.cpp
+++ b/firmware/src/modes/GameOfLifeMode.cpp
@@ -39,7 +39,7 @@ void GameOfLifeMode::configure()
     }
 #endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
-    Storage.begin(name, true);
+    Storage.begin(name.data(), true);
     if (Storage.isKey("clock"))
     {
         clock = Storage.getBool("clock");
@@ -117,7 +117,7 @@ void GameOfLifeMode::setClock(bool _clock)
     {
         clock = _clock;
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putBool("clock", clock);
         Storage.end();
         pending = true;

--- a/firmware/src/modes/HomeThermometerMode.cpp
+++ b/firmware/src/modes/HomeThermometerMode.cpp
@@ -24,7 +24,7 @@ void HomeThermometerMode::configure()
                  "outdoor",
              })
         {
-            const std::string id{std::regex_replace(name, std::regex(R"(\s+)"), "").append("_").append(where)};
+            const std::string id{std::regex_replace(name.data(), std::regex(R"(\s+)"), "").append("_").append(where)};
             JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
             component[HomeAssistantAbbreviations::command_template].set(
                 std::string(R"({")").append(where).append(R"(":{{value}}})"));

--- a/firmware/src/modes/PingPongMode.cpp
+++ b/firmware/src/modes/PingPongMode.cpp
@@ -37,7 +37,7 @@ void PingPongMode::configure()
     }
 #endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
-    Storage.begin(name, true);
+    Storage.begin(name.data(), true);
     if (Storage.isKey("clock"))
     {
         clock = Storage.getBool("clock");
@@ -200,7 +200,7 @@ void PingPongMode::setClock(bool _clock)
         }
         Display.clearFrame();
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putBool("clock", clock);
         Storage.end();
         pending = true;

--- a/firmware/src/modes/SnakeMode.cpp
+++ b/firmware/src/modes/SnakeMode.cpp
@@ -40,7 +40,7 @@ void SnakeMode::configure()
     }
 #endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
-    Storage.begin(name, true);
+    Storage.begin(name.data(), true);
     if (Storage.isKey("clock"))
     {
         clock = Storage.getBool("clock");
@@ -264,7 +264,7 @@ void SnakeMode::setClock(bool _clock)
             Display.drawRectangle(0, 0, GRID_COLUMNS - 1, 4, true, 0);
         }
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putBool("clock", clock);
         Storage.end();
         pending = true;

--- a/firmware/src/modes/StreamMode.cpp
+++ b/firmware/src/modes/StreamMode.cpp
@@ -39,7 +39,7 @@ void StreamMode::configure()
     }
 #endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
-    Storage.begin(name, true);
+    Storage.begin(name.data(), true);
     if (Storage.isKey("port"))
     {
         port = Storage.getUShort("port");
@@ -64,7 +64,7 @@ void StreamMode::set(uint16_t _port)
     {
         port = _port;
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putUShort("port", port);
         Storage.end();
         if (udp)

--- a/firmware/src/modes/TickerMode.cpp
+++ b/firmware/src/modes/TickerMode.cpp
@@ -51,7 +51,7 @@ void TickerMode::configure()
     }
 #endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
-    Storage.begin(name, true);
+    Storage.begin(name.data(), true);
     if (Storage.isKey("message"))
     {
         message = Storage.getString("message").c_str();
@@ -109,7 +109,7 @@ void TickerMode::setFont(std::string_view fontName)
     {
         font = std::move(_font);
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putString("font", font->name.data());
         Storage.end();
         pending = true;
@@ -122,7 +122,7 @@ void TickerMode::setMessage(std::string_view _message)
     {
         message = _message.data();
         Preferences Storage;
-        Storage.begin(name);
+        Storage.begin(name.data());
         Storage.putString("message", message.c_str());
         Storage.end();
         pending = true;

--- a/firmware/src/modes/WeatherMode.cpp
+++ b/firmware/src/modes/WeatherMode.cpp
@@ -40,7 +40,7 @@ void WeatherMode::configure()
     }
 #endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
-    Storage.begin(name, true);
+    Storage.begin(name.data(), true);
     if (Storage.isKey("provider"))
     {
         const String _provider = Storage.getString("provider");
@@ -138,7 +138,7 @@ void WeatherMode::setProvider(std::string_view providerName)
         if (provider)
         {
             Preferences Storage;
-            Storage.begin(name);
+            Storage.begin(name.data());
             Storage.putString("provider", provider->name.data());
             Storage.end();
             condition.reset();

--- a/firmware/src/services/ModesService.cpp
+++ b/firmware/src/services/ModesService.cpp
@@ -84,7 +84,7 @@ void ModesService::handle()
         transmit();
         Preferences Storage;
         Storage.begin(name.data());
-        Storage.putString("mode", mode->name);
+        Storage.putString("mode", mode->name.data());
         Storage.end();
     }
 }
@@ -115,13 +115,13 @@ void ModesService::setActive(bool active)
     }
 }
 
-void ModesService::setMode(const char *name) // NOLINT(readability-make-member-function-const)
+void ModesService::setMode(std::string_view _name) // NOLINT(readability-make-member-function-const)
 {
-    if (mode == nullptr || strcmp(mode->name, name) != 0)
+    if (mode == nullptr || mode->name != _name)
     {
         for (ModeModule *_mode : modes)
         {
-            if (!strcmp(_mode->name, name))
+            if (_mode->name == _name)
             {
                 setMode(_mode);
                 return;
@@ -141,7 +141,7 @@ void ModesService::setMode(ModeModule *mode, bool power)
     }
     lastMillis = millis();
     scheduled = mode;
-    const std::string _name = mode->name;
+    const std::string _name = mode->name.data();
     std::vector<std::string> words{""};
     uint8_t _line = 0;
     for (std::size_t i = 0; i < _name.length(); ++i)
@@ -189,9 +189,9 @@ TaskHandle_t ModesService::getTaskHandle() const { return taskHandle; }
 
 void ModesService::setModeNext()
 {
-    const char *const _name = mode == nullptr ? scheduled->name : mode->name;
-    std::vector<ModeModule *>::const_iterator _mode = std::find_if(
-        modes.begin(), modes.end(), [_name](const ModeModule *_mode) { return !strcmp(_mode->name, _name); });
+    const std::string_view _name = mode == nullptr ? scheduled->name : mode->name;
+    std::vector<ModeModule *>::const_iterator _mode =
+        std::find_if(modes.begin(), modes.end(), [_name](const ModeModule *_mode) { return _mode->name == _name; });
     if (!Display.getPower())
     {
         Display.setPower(true);
@@ -209,9 +209,9 @@ void ModesService::setModeNext()
 
 void ModesService::setModePrevious()
 {
-    const char *const _name = mode == nullptr ? scheduled->name : mode->name;
-    std::vector<ModeModule *>::const_iterator _mode = std::find_if(
-        modes.begin(), modes.end(), [_name](const ModeModule *_mode) { return !strcmp(_mode->name, _name); });
+    const std::string_view _name = mode == nullptr ? scheduled->name : mode->name;
+    std::vector<ModeModule *>::const_iterator _mode =
+        std::find_if(modes.begin(), modes.end(), [_name](const ModeModule *_mode) { return _mode->name == _name; });
     if (!Display.getPower())
     {
         Display.setPower(true);
@@ -246,9 +246,9 @@ void ModesService::onReceive(JsonObjectConst payload,
                              std::string_view source) // NOLINT(misc-unused-parameters)
 {
     // Mode
-    if (payload["mode"].is<const char *>())
+    if (payload["mode"].is<std::string_view>())
     {
-        setMode(payload["mode"].as<const char *>());
+        setMode(payload["mode"].as<std::string_view>());
     }
 }
 


### PR DESCRIPTION
Refactors mode name handling to use `std::string_view` instead of owning string types.

This reduces unnecessary allocations and improves overall efficiency, especially in static and compile-time contexts where service names are immutable.

## Changes

- Replace mode name storage with `std::string_view`
- Update constructors and interfaces to accept non-owning string references
- Remove redundant string allocations and copies

## Impact

- No functional changes
- Improved performance and memory usage
- Safer and clearer API contracts