### PR TITLE
Refactor Home Assistant integration structure

### DIFF
--- a/firmware/include/extensions/ButtonExtension.h
+++ b/firmware/include/extensions/ButtonExtension.h
@@ -43,6 +43,10 @@ public:
 
     void configure() override;
     void handle() override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // EXTENSION_BUTTON

--- a/firmware/include/extensions/HeapExtension.h
+++ b/firmware/include/extensions/HeapExtension.h
@@ -14,12 +14,12 @@ private:
 public:
     explicit HeapExtension() : ExtensionModule(name) {};
 
-#if EXTENSION_HOMEASSISTANT
-    void configure() override;
-#endif // EXTENSION_HOMEASSISTANT
-
     void handle() override;
     void transmit();
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // EXTENSION_HEAP

--- a/firmware/include/extensions/HomeAssistantExtension.h
+++ b/firmware/include/extensions/HomeAssistantExtension.h
@@ -24,17 +24,12 @@ private:
 public:
     explicit HomeAssistantExtension() : ExtensionModule(name) {};
 
-    inline static const std::string uniquePrefix = std::format("0x{:x}_", ESP.getEfuseMac());
-
-    JsonDocument *discovery = new JsonDocument();
-
-    void configure() override;
     void begin() override;
     void handle() override;
-
     void undiscover();
 
     void onTransmit(JsonObjectConst payload, std::string_view source) override;
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
 };
 
 namespace HomeAssistantAbbreviations

--- a/firmware/include/extensions/InfraredExtension.h
+++ b/firmware/include/extensions/InfraredExtension.h
@@ -150,6 +150,10 @@ public:
     void parse();
 
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // EXTENSION_INFRARED

--- a/firmware/include/extensions/MessageExtension.h
+++ b/firmware/include/extensions/MessageExtension.h
@@ -50,13 +50,13 @@ private:
 public:
     explicit MessageExtension() : ExtensionModule(name) {};
 
-#if EXTENSION_HOMEASSISTANT
-    void configure() override;
-#endif
-
     void begin() override;
     void handle() override;
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // EXTENSION_MESSAGE

--- a/firmware/include/extensions/MicrophoneExtension.h
+++ b/firmware/include/extensions/MicrophoneExtension.h
@@ -35,6 +35,10 @@ public:
     [[nodiscard]] bool isTriggered() const;
 
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // EXTENSION_MICROPHONE

--- a/firmware/include/extensions/PhotocellExtension.h
+++ b/firmware/include/extensions/PhotocellExtension.h
@@ -40,6 +40,10 @@ public:
 
     void onReceive(JsonObjectConst payload, std::string_view source) override;
     void onTransmit(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // EXTENSION_PHOTOCELL

--- a/firmware/include/extensions/PlaylistExtension.h
+++ b/firmware/include/extensions/PlaylistExtension.h
@@ -27,6 +27,10 @@ public:
     void onReceive(JsonObjectConst payload, std::string_view source) override;
     void onTransmit(JsonObjectConst payload, std::string_view source) override;
 
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
+
 private:
     static constexpr std::string_view name{"Playlist"};
 

--- a/firmware/include/extensions/RtcExtension.h
+++ b/firmware/include/extensions/RtcExtension.h
@@ -51,6 +51,10 @@ public:
 #if defined(RTC_DS3231) || defined(RTC_DS3232) || defined(RTC_PCF8563)
     void handle() override;
 #endif
+
+#if EXTENSION_HOMEASSISTANT && (defined(RTC_DS3231) || defined(RTC_DS3232))
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif // EXTENSION_HOMEASSISTANT && (defined(RTC_DS3231) || defined(RTC_DS3232))
 };
 
 #endif // EXTENSION_RTC

--- a/firmware/include/modes/ClockMode.h
+++ b/firmware/include/modes/ClockMode.h
@@ -57,6 +57,10 @@ public:
     void begin() override;
     void handle() override;
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // MODE_CLOCK

--- a/firmware/include/modes/CountdownMode.h
+++ b/firmware/include/modes/CountdownMode.h
@@ -50,7 +50,12 @@ public:
     void begin() override;
     void handle() override;
     void setFont(std::string_view _fontName);
+
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // MODE_COUNTDOWN

--- a/firmware/include/modes/GameOfLifeMode.h
+++ b/firmware/include/modes/GameOfLifeMode.h
@@ -30,7 +30,12 @@ public:
     void configure() override;
     void begin() override;
     void handle() override;
+
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // MODE_GAMEOFLIFE

--- a/firmware/include/modes/HomeThermometerMode.h
+++ b/firmware/include/modes/HomeThermometerMode.h
@@ -21,7 +21,12 @@ public:
     void configure() override;
     void begin() override;
     void handle() override;
+
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // MODE_HOMETHERMOMETER

--- a/firmware/include/modes/PingPongMode.h
+++ b/firmware/include/modes/PingPongMode.h
@@ -44,7 +44,12 @@ public:
     void configure() override;
     void begin() override;
     void handle() override;
+
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // MODE_PINGPONG

--- a/firmware/include/modes/SnakeMode.h
+++ b/firmware/include/modes/SnakeMode.h
@@ -54,7 +54,12 @@ public:
     void configure() override;
     void begin() override;
     void handle() override;
+
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // MODE_SNAKE

--- a/firmware/include/modes/StreamMode.h
+++ b/firmware/include/modes/StreamMode.h
@@ -29,6 +29,10 @@ public:
     void end() override;
 
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // MODE_STREAM

--- a/firmware/include/modes/TickerMode.h
+++ b/firmware/include/modes/TickerMode.h
@@ -42,6 +42,10 @@ public:
     void end() override;
 
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // MODE_TICKER

--- a/firmware/include/modes/WeatherMode.h
+++ b/firmware/include/modes/WeatherMode.h
@@ -79,6 +79,10 @@ public:
     void end() override;
 
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 };
 
 #endif // MODE_WEATHER

--- a/firmware/include/modules/ExtensionModule.h
+++ b/firmware/include/modules/ExtensionModule.h
@@ -24,4 +24,8 @@ public:
 
     virtual void onReceive(JsonObjectConst payload, std::string_view source);
     virtual void onTransmit(JsonObjectConst payload, std::string_view source);
+
+#if EXTENSION_HOMEASSISTANT
+    virtual void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique);
+#endif
 };

--- a/firmware/include/modules/ModeModule.h
+++ b/firmware/include/modules/ModeModule.h
@@ -24,4 +24,8 @@ public:
     virtual void end();
 
     virtual void onReceive(JsonObjectConst payload, std::string_view source);
+
+#if EXTENSION_HOMEASSISTANT
+    virtual void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique);
+#endif
 };

--- a/firmware/include/modules/ServiceModule.h
+++ b/firmware/include/modules/ServiceModule.h
@@ -19,4 +19,8 @@ public:
     const std::string_view name{};
 
     virtual void onReceive(JsonObjectConst payload, std::string_view source);
+
+#if EXTENSION_HOMEASSISTANT
+    virtual void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique);
+#endif
 };

--- a/firmware/include/services/ConnectivityService.h
+++ b/firmware/include/services/ConnectivityService.h
@@ -38,9 +38,13 @@ public:
     static constexpr std::string_view userAgent = "Frekvens/" VERSION " (ESP32; +https://github.com/VIPnytt/Frekvens)";
 
     void configure();
-    void begin();
     void handle();
+
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 
     static ConnectivityService &getInstance();
 };

--- a/firmware/include/services/DeviceService.h
+++ b/firmware/include/services/DeviceService.h
@@ -33,6 +33,10 @@ public:
 
     [[nodiscard]] JsonObjectConst getTransmits() const;
 
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
+
     static DeviceService &getInstance();
 };
 

--- a/firmware/include/services/DisplayService.h
+++ b/firmware/include/services/DisplayService.h
@@ -5,7 +5,6 @@
 
 #include <array>
 #include <span>
-#include <vector>
 
 class DisplayService final : public ServiceModule
 {
@@ -104,6 +103,10 @@ public:
     void flush();
 
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 
     static DisplayService &getInstance();
 };

--- a/firmware/include/services/ModesService.h
+++ b/firmware/include/services/ModesService.h
@@ -181,7 +181,12 @@ public:
     void setModeNext();
     void setModePrevious();
     [[nodiscard]] TaskHandle_t getTaskHandle() const;
+
     void onReceive(JsonObjectConst payload, std::string_view source) override;
+
+#if EXTENSION_HOMEASSISTANT
+    void onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) override;
+#endif
 
     static ModesService &getInstance();
 };

--- a/firmware/src/extensions/AlexaExtension.cpp
+++ b/firmware/src/extensions/AlexaExtension.cpp
@@ -3,7 +3,6 @@
 #include "extensions/AlexaExtension.h"
 
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
 #include "services/WebServerService.h"
 
 #include <HTTPClient.h>

--- a/firmware/src/extensions/ButtonExtension.cpp
+++ b/firmware/src/extensions/ButtonExtension.cpp
@@ -4,7 +4,7 @@
 
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 #include "services/ModesService.h"
 
 void ButtonExtension::configure()
@@ -132,6 +132,7 @@ void ButtonExtension::event(const char *key, const char *value) // NOLINT(bugpro
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ButtonExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/extensions/ButtonExtension.cpp
+++ b/firmware/src/extensions/ButtonExtension.cpp
@@ -15,50 +15,12 @@ void ButtonExtension::configure()
 #ifdef PIN_SW2
     pinMode(PIN_SW2, INPUT_PULLUP);
 #endif
-
 #ifdef PIN_SW1
     attachInterrupt(PIN_SW1, &onInterrupt, CHANGE);
 #endif
 #ifdef PIN_SW2
     attachInterrupt(PIN_SW2, &onInterrupt, CHANGE);
 #endif
-
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    for (const char *const payload : {
-             "long",
-             "short",
-         })
-    {
-#ifdef PIN_SW1
-        {
-            const std::string id{std::string(name).append("_power_").append(payload)};
-            JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-            component[HomeAssistantAbbreviations::automation_type].set("trigger");
-            component[HomeAssistantAbbreviations::payload].set(payload);
-            component[HomeAssistantAbbreviations::platform].set("device_automation");
-            component[HomeAssistantAbbreviations::subtype].set("Power button");
-            component[HomeAssistantAbbreviations::topic].set(topic);
-            component[HomeAssistantAbbreviations::type].set(std::string("button_").append(payload).append("_press"));
-            component[HomeAssistantAbbreviations::value_template].set("{{value_json.event.power}}");
-        }
-#endif // PIN_SW1
-#ifdef PIN_SW2
-        {
-            const std::string id{std::string(name).append("_mode_").append(payload)};
-            JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-            component[HomeAssistantAbbreviations::automation_type].set("trigger");
-            component[HomeAssistantAbbreviations::payload].set(payload);
-            component[HomeAssistantAbbreviations::platform].set("device_automation");
-            component[HomeAssistantAbbreviations::subtype].set("Mode button");
-            component[HomeAssistantAbbreviations::topic].set(topic);
-            component[HomeAssistantAbbreviations::type].set(std::string("button_").append(payload).append("_press"));
-            component[HomeAssistantAbbreviations::value_template].set("{{value_json.event.mode}}");
-        }
-#endif // PIN_SW2
-    }
-#endif // EXTENSION_HOMEASSISTANT
 }
 
 void ButtonExtension::handle()
@@ -168,5 +130,44 @@ void ButtonExtension::event(const char *key, const char *value) // NOLINT(bugpro
     doc["event"][key] = value;
     Device.transmit(doc.as<JsonObjectConst>(), name, false);
 }
+
+#if EXTENSION_HOMEASSISTANT
+void ButtonExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    for (const std::string_view payload : {
+             "long",
+             "short",
+         })
+    {
+#ifdef PIN_SW1
+        {
+            const std::string id{std::string(name).append("_power_").append(payload)};
+            JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+            component[HomeAssistantAbbreviations::automation_type].set("trigger");
+            component[HomeAssistantAbbreviations::payload].set(payload);
+            component[HomeAssistantAbbreviations::platform].set("device_automation");
+            component[HomeAssistantAbbreviations::subtype].set("Power button");
+            component[HomeAssistantAbbreviations::topic].set(topic);
+            component[HomeAssistantAbbreviations::type].set(std::string("button_").append(payload).append("_press"));
+            component[HomeAssistantAbbreviations::value_template].set("{{value_json.event.power}}");
+        }
+#endif // PIN_SW1
+#ifdef PIN_SW2
+        {
+            const std::string id{std::string(name).append("_mode_").append(payload)};
+            JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+            component[HomeAssistantAbbreviations::automation_type].set("trigger");
+            component[HomeAssistantAbbreviations::payload].set(payload);
+            component[HomeAssistantAbbreviations::platform].set("device_automation");
+            component[HomeAssistantAbbreviations::subtype].set("Mode button");
+            component[HomeAssistantAbbreviations::topic].set(topic);
+            component[HomeAssistantAbbreviations::type].set(std::string("button_").append(payload).append("_press"));
+            component[HomeAssistantAbbreviations::value_template].set("{{value_json.event.mode}}");
+        }
+#endif // PIN_SW2
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // EXTENSION_BUTTON

--- a/firmware/src/extensions/HeapExtension.cpp
+++ b/firmware/src/extensions/HeapExtension.cpp
@@ -7,81 +7,6 @@
 #include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 #include "services/ModesService.h"
 
-#if EXTENSION_HOMEASSISTANT
-void HeapExtension::configure()
-{
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_extensions")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::device_class].set("data_size");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
-        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
-        component[HomeAssistantAbbreviations::icon].set("mdi:memory");
-        component[HomeAssistantAbbreviations::name].set(std::string(Extensions.name.data()).append(" task stack"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("sensor");
-        component[HomeAssistantAbbreviations::state_class].set("measurement");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::unit_of_measurement].set("kB");
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.extensions/2**10}}");
-    }
-    {
-        const std::string id{std::string(name).append("_heap")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::device_class].set("data_size");
-        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
-        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
-        component[HomeAssistantAbbreviations::icon].set("mdi:memory");
-        component[HomeAssistantAbbreviations::name].set(name);
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("sensor");
-        component[HomeAssistantAbbreviations::state_class].set("measurement");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::unit_of_measurement].set("kB");
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.heap/2**10}}");
-    }
-    {
-        const std::string id{std::string(name).append("_main")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::device_class].set("data_size");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
-        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
-        component[HomeAssistantAbbreviations::icon].set("mdi:memory");
-        component[HomeAssistantAbbreviations::name].set("Main task stack");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("sensor");
-        component[HomeAssistantAbbreviations::state_class].set("measurement");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::unit_of_measurement].set("kB");
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.main/2**10}}");
-    }
-    {
-        const std::string id{std::string(name).append("_modes")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::device_class].set("data_size");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
-        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
-        component[HomeAssistantAbbreviations::icon].set("mdi:memory");
-        component[HomeAssistantAbbreviations::name].set(std::string(Modes.name).append(" task stack"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("sensor");
-        component[HomeAssistantAbbreviations::state_class].set("measurement");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::unit_of_measurement].set("kB");
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.modes/2**10}}");
-    }
-}
-#endif // EXTENSION_HOMEASSISTANT
-
 void HeapExtension::handle()
 {
     if (millis() - lastMillis > UINT16_MAX)
@@ -103,5 +28,79 @@ void HeapExtension::transmit()
     }
     Device.transmit(doc.as<JsonObjectConst>(), name);
 }
+
+#if EXTENSION_HOMEASSISTANT
+void HeapExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_extensions")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::device_class].set("data_size");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
+        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
+        component[HomeAssistantAbbreviations::icon].set("mdi:memory");
+        component[HomeAssistantAbbreviations::name].set(std::string(Extensions.name.data()).append(" task stack"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::platform].set("sensor");
+        component[HomeAssistantAbbreviations::state_class].set("measurement");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::unit_of_measurement].set("kB");
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.extensions/2**10}}");
+    }
+    {
+        const std::string id{std::string(name).append("_heap")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::device_class].set("data_size");
+        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
+        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
+        component[HomeAssistantAbbreviations::icon].set("mdi:memory");
+        component[HomeAssistantAbbreviations::name].set(name);
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::platform].set("sensor");
+        component[HomeAssistantAbbreviations::state_class].set("measurement");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::unit_of_measurement].set("kB");
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.heap/2**10}}");
+    }
+    {
+        const std::string id{std::string(name).append("_main")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::device_class].set("data_size");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
+        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
+        component[HomeAssistantAbbreviations::icon].set("mdi:memory");
+        component[HomeAssistantAbbreviations::name].set("Main task stack");
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::platform].set("sensor");
+        component[HomeAssistantAbbreviations::state_class].set("measurement");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::unit_of_measurement].set("kB");
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.main/2**10}}");
+    }
+    {
+        const std::string id{std::string(name).append("_modes")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::device_class].set("data_size");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
+        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
+        component[HomeAssistantAbbreviations::icon].set("mdi:memory");
+        component[HomeAssistantAbbreviations::name].set(std::string(Modes.name).append(" task stack"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::platform].set("sensor");
+        component[HomeAssistantAbbreviations::state_class].set("measurement");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::unit_of_measurement].set("kB");
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.modes/2**10}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // EXTENSION_HEAP

--- a/firmware/src/extensions/HeapExtension.cpp
+++ b/firmware/src/extensions/HeapExtension.cpp
@@ -2,7 +2,6 @@
 
 #include "extensions/HeapExtension.h"
 
-#include "extensions/HomeAssistantExtension.h"
 #include "services/DeviceService.h"
 #include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 #include "services/ModesService.h"
@@ -30,6 +29,7 @@ void HeapExtension::transmit()
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void HeapExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/extensions/HomeAssistantExtension.cpp
+++ b/firmware/src/extensions/HomeAssistantExtension.cpp
@@ -3,7 +3,6 @@
 #include "extensions/HomeAssistantExtension.h"
 
 #include "config/constants.h" // NOLINT(misc-include-cleaner)
-#include "extensions/MqttExtension.h"
 #include "services/ConnectivityService.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h" // NOLINT(misc-include-cleaner)
@@ -111,6 +110,7 @@ void HomeAssistantExtension::onTransmit(JsonObjectConst payload, std::string_vie
     }
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void HomeAssistantExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/extensions/HomeAssistantExtension.cpp
+++ b/firmware/src/extensions/HomeAssistantExtension.cpp
@@ -4,6 +4,7 @@
 
 #include "config/constants.h" // NOLINT(misc-include-cleaner)
 #include "extensions/MqttExtension.h"
+#include "services/ConnectivityService.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h" // NOLINT(misc-include-cleaner)
 #include "services/ExtensionsService.h"
@@ -13,53 +14,36 @@
 #include <array>
 #include <regex>
 
-void HomeAssistantExtension::configure()
-{
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::regex_replace(name.data(), std::regex(R"(\s+)"), "").append("_main")};
-        const std::string topicDisplay{std::string("frekvens/" HOSTNAME "/").append(Display.name)};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::brightness_command_template].set(R"({"brightness":{{value}}})");
-        component[HomeAssistantAbbreviations::brightness_command_topic].set(topicDisplay + "/set");
-        component[HomeAssistantAbbreviations::brightness_state_topic].set(topicDisplay);
-        component[HomeAssistantAbbreviations::brightness_value_template].set("{{value_json.brightness}}");
-        component[HomeAssistantAbbreviations::command_topic].set(topicDisplay + "/set");
-        component[HomeAssistantAbbreviations::effect_command_template].set(R"({"mode":"{{value}}"})");
-        component[HomeAssistantAbbreviations::effect_command_topic].set(
-            std::string("frekvens/" HOSTNAME "/").append(Modes.name).append("/set"));
-        JsonArray effectList{component[HomeAssistantAbbreviations::effect_list].to<JsonArray>()};
-        for (const std::string_view _mode : Modes.names)
-        {
-            effectList.add(_mode);
-        }
-        component[HomeAssistantAbbreviations::effect_state_topic].set(
-            std::string("frekvens/" HOSTNAME "/").append(Modes.name));
-        component[HomeAssistantAbbreviations::effect_value_template].set("{{value_json.mode}}");
-        component[HomeAssistantAbbreviations::icon].set("mdi:dots-grid");
-        component[HomeAssistantAbbreviations::name].set("");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::on_command_type].set("brightness");
-        component[HomeAssistantAbbreviations::payload_off].set(payloadOff);
-        component[HomeAssistantAbbreviations::payload_on].set(payloadOn);
-        component[HomeAssistantAbbreviations::platform].set("light");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::state_value_template].set(
-            std::string("{{value_json.").append(Display.name).append(".power}}"));
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-    }
-}
-
 void HomeAssistantExtension::begin()
 {
+    const std::string topic = std::string("frekvens/" HOSTNAME "/");
+    const std::string unique = std::format("0x{:x}_", ESP.getEfuseMac());
+    JsonDocument discovery;
+    const std::array<ServiceModule *, 4> services{
+        &Connectivity,
+        &Device,
+        &Display,
+        &Modes,
+    };
+    for (ServiceModule *service : services)
     {
-        JsonObject availability{(*discovery)[HomeAssistantAbbreviations::availability].to<JsonObject>()};
+        service->onHomeAssistant(discovery, topic, unique);
+    }
+    for (ExtensionModule *extension : Extensions.getAll())
+    {
+        extension->onHomeAssistant(discovery, topic, unique);
+    }
+    for (const std::string_view _mode : Modes.names)
+    {
+        Modes.getMode(_mode)->onHomeAssistant(discovery, topic, unique);
+    }
+    {
+        JsonObject availability{discovery[HomeAssistantAbbreviations::availability].to<JsonObject>()};
         availability[HomeAssistantAbbreviations::payload_not_available].set("");
         availability[HomeAssistantAbbreviations::topic].set("frekvens/" HOSTNAME "/availability");
     }
     {
-        JsonObject device{(*discovery)[HomeAssistantAbbreviations::device].to<JsonObject>()};
+        JsonObject device{discovery[HomeAssistantAbbreviations::device].to<JsonObject>()};
 #if EXTENSION_WEBAPP
         device[HomeAssistantAbbreviations::configuration_url].set("http://" HOSTNAME ".local");
 #endif // EXTENSION_WEBAPP
@@ -78,18 +62,16 @@ void HomeAssistantExtension::begin()
         device[HomeAssistantAbbreviations::name].set(NAME);
         device[HomeAssistantAbbreviations::sw_version].set("Frekvens " VERSION);
         {
-            JsonObject origin{(*discovery)[HomeAssistantAbbreviations::origin].to<JsonObject>()};
+            JsonObject origin{discovery[HomeAssistantAbbreviations::origin].to<JsonObject>()};
             origin[HomeAssistantAbbreviations::name].set("Frekvens");
             origin[HomeAssistantAbbreviations::support_url].set(
                 "https://github.com/VIPnytt/Frekvens/blob/main/docs/SUPPORT.md");
             origin[HomeAssistantAbbreviations::sw_version].set(VERSION);
         }
     }
-    const size_t length{measureJson(*discovery)};
+    const size_t length{measureJson(discovery)};
     std::vector<uint8_t> payload(length + 1);
-    serializeJson(*discovery, payload.data(), length + 1);
-    delete discovery;
-    discovery = nullptr;
+    serializeJson(discovery, payload.data(), length + 1);
     Extensions.MQTT().client.publish(discoveryTopic.c_str(), 0, true, payload.data(), length);
 }
 
@@ -126,6 +108,43 @@ void HomeAssistantExtension::onTransmit(JsonObjectConst payload, std::string_vie
     else if (payload["action"].is<const char *>() && !strcmp(payload["action"].as<const char *>(), "remove"))
     {
         undiscover();
+    }
+}
+
+void HomeAssistantExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::regex_replace(name.data(), std::regex(R"(\s+)"), "").append("_main")};
+        const std::string topicDisplay{std::string("frekvens/" HOSTNAME "/").append(Display.name)};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::brightness_command_template].set(R"({"brightness":{{value}}})");
+        component[HomeAssistantAbbreviations::brightness_command_topic].set(topicDisplay + "/set");
+        component[HomeAssistantAbbreviations::brightness_state_topic].set(topicDisplay);
+        component[HomeAssistantAbbreviations::brightness_value_template].set("{{value_json.brightness}}");
+        component[HomeAssistantAbbreviations::command_topic].set(topicDisplay + "/set");
+        component[HomeAssistantAbbreviations::effect_command_template].set(R"({"mode":"{{value}}"})");
+        component[HomeAssistantAbbreviations::effect_command_topic].set(
+            std::string("frekvens/" HOSTNAME "/").append(Modes.name).append("/set"));
+        JsonArray effectList{component[HomeAssistantAbbreviations::effect_list].to<JsonArray>()};
+        for (const std::string_view _mode : Modes.names)
+        {
+            effectList.add(_mode);
+        }
+        component[HomeAssistantAbbreviations::effect_state_topic].set(
+            std::string("frekvens/" HOSTNAME "/").append(Modes.name));
+        component[HomeAssistantAbbreviations::effect_value_template].set("{{value_json.mode}}");
+        component[HomeAssistantAbbreviations::icon].set("mdi:dots-grid");
+        component[HomeAssistantAbbreviations::name].set("");
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::on_command_type].set("brightness");
+        component[HomeAssistantAbbreviations::payload_off].set(payloadOff);
+        component[HomeAssistantAbbreviations::payload_on].set(payloadOn);
+        component[HomeAssistantAbbreviations::platform].set("light");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::state_value_template].set(
+            std::string("{{value_json.").append(Display.name).append(".power}}"));
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
     }
 }
 

--- a/firmware/src/extensions/InfraredExtension.cpp
+++ b/firmware/src/extensions/InfraredExtension.cpp
@@ -15,29 +15,6 @@ void InfraredExtension::configure()
 {
     pinMode(PIN_IR, INPUT);
     IrReceiver.setReceivePin(PIN_IR);
-
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_active")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"active":{{value}}})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:remote-tv");
-        component[HomeAssistantAbbreviations::name].set(name);
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::payload_off].set("false");
-        component[HomeAssistantAbbreviations::payload_on].set("true");
-        component[HomeAssistantAbbreviations::platform].set("switch");
-        component[HomeAssistantAbbreviations::state_off].set("False");
-        component[HomeAssistantAbbreviations::state_on].set("True");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.active}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
 }
 
 void InfraredExtension::begin()
@@ -193,5 +170,30 @@ void InfraredExtension::onReceive(JsonObjectConst payload,
         setActive(payload["active"].as<bool>());
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void InfraredExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_active")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"active":{{value}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:remote-tv");
+        component[HomeAssistantAbbreviations::name].set(name);
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_off].set("false");
+        component[HomeAssistantAbbreviations::payload_on].set("true");
+        component[HomeAssistantAbbreviations::platform].set("switch");
+        component[HomeAssistantAbbreviations::state_off].set("False");
+        component[HomeAssistantAbbreviations::state_on].set("True");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.active}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // EXTENSION_INFRARED

--- a/firmware/src/extensions/InfraredExtension.cpp
+++ b/firmware/src/extensions/InfraredExtension.cpp
@@ -4,9 +4,9 @@
 
 #include "config/constants.h" // NOLINT(misc-include-cleaner)
 #include "services/DeviceService.h"
-#include "services/DisplayService.h" // NOLINT(misc-include-cleaner)
-#include "services/ExtensionsService.h"
-#include "services/ModesService.h" // NOLINT(misc-include-cleaner)
+#include "services/DisplayService.h"    // NOLINT(misc-include-cleaner)
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
+#include "services/ModesService.h"      // NOLINT(misc-include-cleaner)
 
 #include <IRremote.hpp> // NOLINT(misc-include-cleaner)
 #include <Preferences.h>
@@ -172,6 +172,7 @@ void InfraredExtension::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void InfraredExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/extensions/MessageExtension.cpp
+++ b/firmware/src/extensions/MessageExtension.cpp
@@ -11,61 +11,6 @@
 
 #include <Preferences.h>
 
-#if EXTENSION_HOMEASSISTANT
-void MessageExtension::configure()
-{
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_font")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"font":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:format-font");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" font"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
-        for (const std::string_view _font : Fonts.names)
-        {
-            options.add(_font);
-        }
-        component[HomeAssistantAbbreviations::platform].set("select");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.font}}");
-    }
-    {
-        const std::string id{std::string(name).append("_notify")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"message":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::name].set("");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("notify");
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-    }
-    {
-        const std::string id{std::string(name).append("_repeat")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template] = R"({"repeat":"{{value}}"})";
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:counter");
-        component[HomeAssistantAbbreviations::max].set(UINT8_MAX);
-        component[HomeAssistantAbbreviations::mode].set("box");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" repeat"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("number");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.repeat}}");
-    }
-}
-#endif // EXTENSION_HOMEASSISTANT
-
 void MessageExtension::begin()
 {
     Preferences Storage;
@@ -198,5 +143,30 @@ void MessageExtension::onReceive(JsonObjectConst payload,
         addMessage(payload["message"].as<std::string>());
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void MessageExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_active")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"active":{{value}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:remote-tv");
+        component[HomeAssistantAbbreviations::name].set(name);
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_off].set("false");
+        component[HomeAssistantAbbreviations::payload_on].set("true");
+        component[HomeAssistantAbbreviations::platform].set("switch");
+        component[HomeAssistantAbbreviations::state_off].set("False");
+        component[HomeAssistantAbbreviations::state_on].set("True");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.active}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // EXTENSION_MESSAGE

--- a/firmware/src/extensions/MessageExtension.cpp
+++ b/firmware/src/extensions/MessageExtension.cpp
@@ -2,11 +2,10 @@
 
 #include "extensions/MessageExtension.h"
 
-#include "extensions/HomeAssistantExtension.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
-#include "services/FontsService.h" // NOLINT(misc-include-cleaner)
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
+#include "services/FontsService.h"      // NOLINT(misc-include-cleaner)
 #include "services/ModesService.h"
 
 #include <Preferences.h>
@@ -145,6 +144,7 @@ void MessageExtension::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void MessageExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/extensions/MicrophoneExtension.cpp
+++ b/firmware/src/extensions/MicrophoneExtension.cpp
@@ -3,10 +3,9 @@
 #include "extensions/MicrophoneExtension.h"
 
 #include "config/constants.h" // NOLINT(misc-include-cleaner)
-#include "extensions/HomeAssistantExtension.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <Preferences.h>
 
@@ -141,6 +140,7 @@ void MicrophoneExtension::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void MicrophoneExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/extensions/MicrophoneExtension.cpp
+++ b/firmware/src/extensions/MicrophoneExtension.cpp
@@ -21,57 +21,6 @@ void MicrophoneExtension::configure()
         levelMax = Storage.getUShort("max");
     }
     Storage.end();
-
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_active")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"active":{{value}}})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::icon].set("mdi:microphone");
-        component[HomeAssistantAbbreviations::name].set(name);
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::payload_off].set("false");
-        component[HomeAssistantAbbreviations::payload_on].set("true");
-        component[HomeAssistantAbbreviations::platform].set("switch");
-        component[HomeAssistantAbbreviations::state_off].set("False");
-        component[HomeAssistantAbbreviations::state_on].set("True");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.active}}");
-    }
-    {
-        const std::string id{std::string(name).append("_sound")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::automation_type].set("trigger");
-        component[HomeAssistantAbbreviations::payload].set("sound");
-        component[HomeAssistantAbbreviations::platform].set("device_automation");
-        component[HomeAssistantAbbreviations::subtype].set(name);
-        component[HomeAssistantAbbreviations::topic].set(topic);
-        component[HomeAssistantAbbreviations::type].set("sound detected");
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.event}}");
-    }
-    {
-        const std::string id{std::string(name).append("_threshold")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template] = R"({"threshold":{{value}}})";
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:microphone");
-        component[HomeAssistantAbbreviations::max].set(levelMax);
-        component[HomeAssistantAbbreviations::min].set(1);
-        component[HomeAssistantAbbreviations::mode].set("slider");
-        component[HomeAssistantAbbreviations::name].set("Threshold");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("number");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.threshold}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
 }
 
 void MicrophoneExtension::begin()
@@ -190,5 +139,58 @@ void MicrophoneExtension::onReceive(JsonObjectConst payload,
         setThreshold(payload["threshold"].as<uint16_t>());
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void MicrophoneExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_active")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"active":{{value}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::icon].set("mdi:microphone");
+        component[HomeAssistantAbbreviations::name].set(name);
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_off].set("false");
+        component[HomeAssistantAbbreviations::payload_on].set("true");
+        component[HomeAssistantAbbreviations::platform].set("switch");
+        component[HomeAssistantAbbreviations::state_off].set("False");
+        component[HomeAssistantAbbreviations::state_on].set("True");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.active}}");
+    }
+    {
+        const std::string id{std::string(name).append("_sound")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::automation_type].set("trigger");
+        component[HomeAssistantAbbreviations::payload].set("sound");
+        component[HomeAssistantAbbreviations::platform].set("device_automation");
+        component[HomeAssistantAbbreviations::subtype].set(name);
+        component[HomeAssistantAbbreviations::topic].set(topic);
+        component[HomeAssistantAbbreviations::type].set("sound detected");
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.event}}");
+    }
+    {
+        const std::string id{std::string(name).append("_threshold")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template] = R"({"threshold":{{value}}})";
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:microphone");
+        component[HomeAssistantAbbreviations::max].set(levelMax);
+        component[HomeAssistantAbbreviations::min].set(1);
+        component[HomeAssistantAbbreviations::mode].set("slider");
+        component[HomeAssistantAbbreviations::name].set("Threshold");
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::platform].set("number");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.threshold}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // EXTENSION_MICROPHONE

--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -10,45 +10,7 @@
 
 #include <Preferences.h>
 
-void PhotocellExtension::configure()
-{
-    pinMode(PIN_LDR, ANALOG);
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_active")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"active":{{value}}})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::icon].set("mdi:brightness-auto");
-        component[HomeAssistantAbbreviations::name].set(name);
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::payload_off].set("false");
-        component[HomeAssistantAbbreviations::payload_on].set("true");
-        component[HomeAssistantAbbreviations::platform].set("switch");
-        component[HomeAssistantAbbreviations::state_off].set("False");
-        component[HomeAssistantAbbreviations::state_on].set("True");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.active}}");
-    }
-    {
-        const std::string id{std::string(name).append("_illuminance")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
-        component[HomeAssistantAbbreviations::icon].set("mdi:brightness-5");
-        component[HomeAssistantAbbreviations::name].set("Illuminance");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("sensor");
-        component[HomeAssistantAbbreviations::state_class].set("measurement");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.illuminance}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
-}
+void PhotocellExtension::configure() { pinMode(PIN_LDR, ANALOG); }
 
 void PhotocellExtension::begin()
 {
@@ -160,5 +122,43 @@ void PhotocellExtension::onTransmit(JsonObjectConst payload, std::string_view so
         }
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void PhotocellExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_active")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"active":{{value}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::icon].set("mdi:brightness-auto");
+        component[HomeAssistantAbbreviations::name].set(name);
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_off].set("false");
+        component[HomeAssistantAbbreviations::payload_on].set("true");
+        component[HomeAssistantAbbreviations::platform].set("switch");
+        component[HomeAssistantAbbreviations::state_off].set("False");
+        component[HomeAssistantAbbreviations::state_on].set("True");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.active}}");
+    }
+    {
+        const std::string id{std::string(name).append("_illuminance")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
+        component[HomeAssistantAbbreviations::icon].set("mdi:brightness-5");
+        component[HomeAssistantAbbreviations::name].set("Illuminance");
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::platform].set("sensor");
+        component[HomeAssistantAbbreviations::state_class].set("measurement");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.illuminance}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // EXTENSION_PHOTOCELL

--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -3,10 +3,9 @@
 #include "extensions/PhotocellExtension.h"
 
 #include "config/constants.h" // NOLINT(misc-include-cleaner)
-#include "extensions/HomeAssistantExtension.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <Preferences.h>
 
@@ -124,6 +123,7 @@ void PhotocellExtension::onTransmit(JsonObjectConst payload, std::string_view so
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void PhotocellExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/extensions/PlaylistExtension.cpp
+++ b/firmware/src/extensions/PlaylistExtension.cpp
@@ -2,10 +2,9 @@
 
 #include "extensions/PlaylistExtension.h"
 
-#include "extensions/HomeAssistantExtension.h"
 #include "services/DeviceService.h"
-#include "services/DisplayService.h" // NOLINT(misc-include-cleaner)
-#include "services/ExtensionsService.h"
+#include "services/DisplayService.h"    // NOLINT(misc-include-cleaner)
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 #include "services/ModesService.h"
 
 #include <Preferences.h>
@@ -172,6 +171,7 @@ void PlaylistExtension::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void PlaylistExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/extensions/PlaylistExtension.cpp
+++ b/firmware/src/extensions/PlaylistExtension.cpp
@@ -38,30 +38,6 @@ void PlaylistExtension::configure()
     {
         Storage.end();
     }
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_active")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"active":{{value}}})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::icon].set("mdi:format-list-bulleted");
-        component[HomeAssistantAbbreviations::json_attributes_template].set(
-            "{%set ns=namespace(d={})%}{%for i in value_json.playlist%}{%set ns.d=ns.d|combine({i.mode:i.duration})%}{%endfor%}{{ns.d}}");
-        component[HomeAssistantAbbreviations::json_attributes_topic].set(topic);
-        component[HomeAssistantAbbreviations::name].set(name);
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::payload_off].set("false");
-        component[HomeAssistantAbbreviations::payload_on].set("true");
-        component[HomeAssistantAbbreviations::platform].set("switch");
-        component[HomeAssistantAbbreviations::state_off].set("False");
-        component[HomeAssistantAbbreviations::state_on].set("True");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.active}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
 }
 
 void PlaylistExtension::begin()
@@ -194,5 +170,32 @@ void PlaylistExtension::onReceive(JsonObjectConst payload,
         setActive(payload["active"].as<bool>());
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void PlaylistExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_active")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"active":{{value}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::icon].set("mdi:format-list-bulleted");
+        component[HomeAssistantAbbreviations::json_attributes_template].set(
+            "{%set ns=namespace(d={})%}{%for i in value_json.playlist%}{%set ns.d=ns.d|combine({i.mode:i.duration})%}{%endfor%}{{ns.d}}");
+        component[HomeAssistantAbbreviations::json_attributes_topic].set(topic);
+        component[HomeAssistantAbbreviations::name].set(name);
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_off].set("false");
+        component[HomeAssistantAbbreviations::payload_on].set("true");
+        component[HomeAssistantAbbreviations::platform].set("switch");
+        component[HomeAssistantAbbreviations::state_off].set("False");
+        component[HomeAssistantAbbreviations::state_on].set("True");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.active}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // EXTENSION_PLAYLIST

--- a/firmware/src/extensions/RtcExtension.cpp
+++ b/firmware/src/extensions/RtcExtension.cpp
@@ -2,10 +2,9 @@
 
 #include "extensions/RtcExtension.h"
 
-#include "extensions/HomeAssistantExtension.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <esp_sntp.h>
 
@@ -91,6 +90,7 @@ void RtcExtension::sntpSetTimeSyncNotificationCallback(struct timeval *tv)
 }
 
 #if EXTENSION_HOMEASSISTANT && (defined(RTC_DS3231) || defined(RTC_DS3232))
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void RtcExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/extensions/RtcExtension.cpp
+++ b/firmware/src/extensions/RtcExtension.cpp
@@ -37,27 +37,6 @@ void RtcExtension::configure()
 #ifdef PIN_INT
     attachInterrupt(PIN_INT, onInterrupt, CHANGE);
 #endif
-
-#if EXTENSION_HOMEASSISTANT && (defined(RTC_DS3231) || defined(RTC_DS3232))
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_temperature")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::device_class].set("temperature");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
-        component[HomeAssistantAbbreviations::force_update].set(true);
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" temperature"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("sensor");
-        component[HomeAssistantAbbreviations::state_class].set("measurement");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::unit_of_measurement].set("°C");
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.temperature}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT && (defined(RTC_DS3231) || defined(RTC_DS3232))
 }
 
 #if defined(RTC_DS3231) || defined(RTC_DS3232) || defined(RTC_PCF8563)
@@ -110,5 +89,28 @@ void RtcExtension::sntpSetTimeSyncNotificationCallback(struct timeval *tv)
         local->tm_year + 1900, local->tm_mon + 1, local->tm_mday, local->tm_hour, local->tm_min, local->tm_sec));
     ESP_LOGV(name, "NTP sync"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 }
+
+#if EXTENSION_HOMEASSISTANT && (defined(RTC_DS3231) || defined(RTC_DS3232))
+void RtcExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_temperature")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::device_class].set("temperature");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
+        component[HomeAssistantAbbreviations::force_update].set(true);
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" temperature"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::platform].set("sensor");
+        component[HomeAssistantAbbreviations::state_class].set("measurement");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::unit_of_measurement].set("°C");
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.temperature}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT && (defined(RTC_DS3231) || defined(RTC_DS3232))
 
 #endif // EXTENSION_RTC

--- a/firmware/src/modes/AnimationMode.cpp
+++ b/firmware/src/modes/AnimationMode.cpp
@@ -4,7 +4,7 @@
 
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <Preferences.h>
 #include <array>

--- a/firmware/src/modes/ClockMode.cpp
+++ b/firmware/src/modes/ClockMode.cpp
@@ -24,49 +24,6 @@ void ClockMode::configure()
         ticking = Storage.getBool("ticking");
     }
     Storage.end();
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_font")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"font":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:format-font");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" font"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
-        for (const std::string_view _font : fontNames)
-        {
-            options.add(_font);
-        }
-        component[HomeAssistantAbbreviations::platform].set("select");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.font}}");
-    }
-    {
-        const std::string id{std::string(name).append("_ticking")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"ticking":{{value}}})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:progress-clock");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" ticking"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::payload_off].set("false");
-        component[HomeAssistantAbbreviations::payload_on].set("true");
-        component[HomeAssistantAbbreviations::platform].set("switch");
-        component[HomeAssistantAbbreviations::state_off].set("False");
-        component[HomeAssistantAbbreviations::state_on].set("True");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.ticking}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
     transmit();
 }
 
@@ -206,5 +163,51 @@ void ClockMode::onReceive(JsonObjectConst payload,
         setTicking(payload["ticking"].as<bool>());
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void ClockMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_font")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"font":"{{value}}"})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:format-font");
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" font"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
+        for (const std::string_view _font : fontNames)
+        {
+            options.add(_font);
+        }
+        component[HomeAssistantAbbreviations::platform].set("select");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.font}}");
+    }
+    {
+        const std::string id{std::string(name).append("_ticking")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"ticking":{{value}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:progress-clock");
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" ticking"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_off].set("false");
+        component[HomeAssistantAbbreviations::payload_on].set("true");
+        component[HomeAssistantAbbreviations::platform].set("switch");
+        component[HomeAssistantAbbreviations::state_off].set("False");
+        component[HomeAssistantAbbreviations::state_on].set("True");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.ticking}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // MODE_CLOCK

--- a/firmware/src/modes/CountdownMode.cpp
+++ b/firmware/src/modes/CountdownMode.cpp
@@ -33,46 +33,6 @@ void CountdownMode::configure()
     {
         Storage.end();
     }
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_font")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"font":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:format-font");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" font"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
-        for (const std::string_view _font : fontNames)
-        {
-            options.add(_font);
-        }
-        component[HomeAssistantAbbreviations::platform].set("select");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.font}}");
-    }
-    {
-        const std::string id{std::string(name).append("_timestamp")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"timestamp":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:timer-sand-full");
-        component[HomeAssistantAbbreviations::name].set(name);
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::pattern].set(
-            R"(^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):[0-5]\d:[0-5]\d$)");
-        component[HomeAssistantAbbreviations::platform].set("text");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.timestamp}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
     transmit();
 }
 
@@ -198,5 +158,48 @@ void CountdownMode::onReceive(JsonObjectConst payload,
         save();
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void CountdownMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_font")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"font":"{{value}}"})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:format-font");
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" font"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
+        for (const std::string_view _font : fontNames)
+        {
+            options.add(_font);
+        }
+        component[HomeAssistantAbbreviations::platform].set("select");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.font}}");
+    }
+    {
+        const std::string id{std::string(name).append("_timestamp")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"timestamp":"{{value}}"})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:timer-sand-full");
+        component[HomeAssistantAbbreviations::name].set(name);
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::pattern].set(
+            R"(^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):[0-5]\d:[0-5]\d$)");
+        component[HomeAssistantAbbreviations::platform].set("text");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.timestamp}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // MODE_COUNTDOWN

--- a/firmware/src/modes/CountdownMode.cpp
+++ b/firmware/src/modes/CountdownMode.cpp
@@ -2,11 +2,10 @@
 
 #include "modes/CountdownMode.h"
 
-#include "extensions/HomeAssistantExtension.h"
 #include "handlers/TextHandler.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 #include "services/FontsService.h"
 
 #include <Preferences.h>
@@ -160,6 +159,7 @@ void CountdownMode::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void CountdownMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/modes/GameOfLifeMode.cpp
+++ b/firmware/src/modes/GameOfLifeMode.cpp
@@ -15,29 +15,6 @@
 
 void GameOfLifeMode::configure()
 {
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_clock")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"clock":{{value}}})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:one-up");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" clock"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::payload_off].set("false");
-        component[HomeAssistantAbbreviations::payload_on].set("true");
-        component[HomeAssistantAbbreviations::platform].set("switch");
-        component[HomeAssistantAbbreviations::state_off].set("False");
-        component[HomeAssistantAbbreviations::state_on].set("True");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.clock}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
     Storage.begin(name.data(), true);
     if (Storage.isKey("clock"))
@@ -141,5 +118,31 @@ void GameOfLifeMode::onReceive(JsonObjectConst payload,
         setClock(payload["clock"].as<bool>());
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void GameOfLifeMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_clock")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"clock":{{value}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:one-up");
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" clock"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_off].set("false");
+        component[HomeAssistantAbbreviations::payload_on].set("true");
+        component[HomeAssistantAbbreviations::platform].set("switch");
+        component[HomeAssistantAbbreviations::state_off].set("False");
+        component[HomeAssistantAbbreviations::state_on].set("True");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.clock}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // MODE_GAMEOFLIFE

--- a/firmware/src/modes/GameOfLifeMode.cpp
+++ b/firmware/src/modes/GameOfLifeMode.cpp
@@ -2,13 +2,12 @@
 
 #include "modes/GameOfLifeMode.h"
 
-#include "config/constants.h" // NOLINT(misc-include-cleaner)
-#include "extensions/HomeAssistantExtension.h"
+#include "config/constants.h"     // NOLINT(misc-include-cleaner)
 #include "fonts/MiniFont.h"       // NOLINT(misc-include-cleaner)
 #include "handlers/TextHandler.h" // NOLINT(misc-include-cleaner)
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <Preferences.h>
 #include <vector>
@@ -120,6 +119,7 @@ void GameOfLifeMode::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void GameOfLifeMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/modes/HomeThermometerMode.cpp
+++ b/firmware/src/modes/HomeThermometerMode.cpp
@@ -7,7 +7,7 @@
 #include "handlers/TextHandler.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <Preferences.h>
 #include <nvs.h>
@@ -98,6 +98,7 @@ void HomeThermometerMode::setTemperature(const char *where, int16_t temperature)
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void HomeThermometerMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/modes/HomeThermometerMode.cpp
+++ b/firmware/src/modes/HomeThermometerMode.cpp
@@ -13,54 +13,7 @@
 #include <nvs.h>
 #include <regex>
 
-void HomeThermometerMode::configure()
-{
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        for (const char *const where : {
-                 "indoor",
-                 "outdoor",
-             })
-        {
-            const std::string id{std::regex_replace(name.data(), std::regex(R"(\s+)"), "").append("_").append(where)};
-            JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-            component[HomeAssistantAbbreviations::command_template].set(
-                std::string(R"({")").append(where).append(R"(":{{value}}})"));
-            component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-            component[HomeAssistantAbbreviations::device_class].set("temperature");
-            component[HomeAssistantAbbreviations::entity_category].set("config");
-            component[HomeAssistantAbbreviations::icon].set("mdi:thermometer");
-#if GRID_COLUMNS < 18
-            component[HomeAssistantAbbreviations::max].set(999);
-            component[HomeAssistantAbbreviations::min].set(-99);
-#elif GRID_COLUMNS < 22
-            component[HomeAssistantAbbreviations::max].set(9999);
-            component[HomeAssistantAbbreviations::min].set(-999);
-#elif GRID_COLUMNS < 26
-            component[HomeAssistantAbbreviations::max].set(INT16_MAX);
-            component[HomeAssistantAbbreviations::min].set(-9999);
-#else
-            component[HomeAssistantAbbreviations::max].set(INT16_MAX);
-            component[HomeAssistantAbbreviations::min].set(INT16_MIN);
-#endif // GRID_COLUMNS < 18
-            component[HomeAssistantAbbreviations::mode].set("box");
-            component[HomeAssistantAbbreviations::name].set((char)std::toupper(*where) + std::string(where + 1));
-            component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-            component[HomeAssistantAbbreviations::platform].set("number");
-            component[HomeAssistantAbbreviations::state_topic].set(topic);
-            component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-#ifdef TEMPERATURE_UNIT
-            component[HomeAssistantAbbreviations::unit_of_measurement].set(TEMPERATURE_UNIT);
-#endif // TEMPERATURE_UNIT
-            component[HomeAssistantAbbreviations::value_template].set(
-                std::string("{{value_json.").append(where).append("}}"));
-        }
-    }
-#endif // EXTENSION_HOMEASSISTANT
-    transmit();
-}
+void HomeThermometerMode::configure() { transmit(); }
 
 void HomeThermometerMode::begin() { pending = true; }
 
@@ -143,5 +96,52 @@ void HomeThermometerMode::setTemperature(const char *where, int16_t temperature)
     ESP_LOGD(name, "%s %d°", where, temperature); // NOLINT(cppcoreguidelines-avoid-do-while)
 #endif // TEMPERATURE_UNIT
 }
+
+#if EXTENSION_HOMEASSISTANT
+void HomeThermometerMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        for (const char *const where : {
+                 "indoor",
+                 "outdoor",
+             })
+        {
+            const std::string id{std::regex_replace(name.data(), std::regex(R"(\s+)"), "").append("_").append(where)};
+            JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+            component[HomeAssistantAbbreviations::command_template].set(
+                std::string(R"({")").append(where).append(R"(":{{value}}})"));
+            component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+            component[HomeAssistantAbbreviations::device_class].set("temperature");
+            component[HomeAssistantAbbreviations::entity_category].set("config");
+            component[HomeAssistantAbbreviations::icon].set("mdi:thermometer");
+#if GRID_COLUMNS < 18
+            component[HomeAssistantAbbreviations::max].set(999);
+            component[HomeAssistantAbbreviations::min].set(-99);
+#elif GRID_COLUMNS < 22
+            component[HomeAssistantAbbreviations::max].set(9999);
+            component[HomeAssistantAbbreviations::min].set(-999);
+#elif GRID_COLUMNS < 26
+            component[HomeAssistantAbbreviations::max].set(INT16_MAX);
+            component[HomeAssistantAbbreviations::min].set(-9999);
+#else
+            component[HomeAssistantAbbreviations::max].set(INT16_MAX);
+            component[HomeAssistantAbbreviations::min].set(INT16_MIN);
+#endif // GRID_COLUMNS < 18
+            component[HomeAssistantAbbreviations::mode].set("box");
+            component[HomeAssistantAbbreviations::name].set((char)std::toupper(*where) + std::string(where + 1));
+            component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+            component[HomeAssistantAbbreviations::platform].set("number");
+            component[HomeAssistantAbbreviations::state_topic].set(topic);
+            component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+#ifdef TEMPERATURE_UNIT
+            component[HomeAssistantAbbreviations::unit_of_measurement].set(TEMPERATURE_UNIT);
+#endif // TEMPERATURE_UNIT
+            component[HomeAssistantAbbreviations::value_template].set(
+                std::string("{{value_json.").append(where).append("}}"));
+        }
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // MODE_HOMETHERMOMETER

--- a/firmware/src/modes/PingPongMode.cpp
+++ b/firmware/src/modes/PingPongMode.cpp
@@ -2,12 +2,11 @@
 
 #include "modes/PingPongMode.h"
 
-#include "extensions/HomeAssistantExtension.h"
 #include "fonts/MiniFont.h"       // NOLINT(misc-include-cleaner)
 #include "handlers/TextHandler.h" // NOLINT(misc-include-cleaner)
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <Preferences.h>
 
@@ -203,6 +202,7 @@ void PingPongMode::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void PingPongMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/modes/PingPongMode.cpp
+++ b/firmware/src/modes/PingPongMode.cpp
@@ -13,29 +13,6 @@
 
 void PingPongMode::configure()
 {
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_clock")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"clock":{{value}}})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:table-tennis");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" clock"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::payload_off].set("false");
-        component[HomeAssistantAbbreviations::payload_on].set("true");
-        component[HomeAssistantAbbreviations::platform].set("switch");
-        component[HomeAssistantAbbreviations::state_off].set("False");
-        component[HomeAssistantAbbreviations::state_on].set("True");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.clock}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
     Storage.begin(name.data(), true);
     if (Storage.isKey("clock"))
@@ -224,5 +201,31 @@ void PingPongMode::onReceive(JsonObjectConst payload,
         setClock(payload["clock"].as<bool>());
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void PingPongMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_clock")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"clock":{{value}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:table-tennis");
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" clock"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_off].set("false");
+        component[HomeAssistantAbbreviations::payload_on].set("true");
+        component[HomeAssistantAbbreviations::platform].set("switch");
+        component[HomeAssistantAbbreviations::state_off].set("False");
+        component[HomeAssistantAbbreviations::state_on].set("True");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.clock}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // MODE_PINGPONG

--- a/firmware/src/modes/SnakeMode.cpp
+++ b/firmware/src/modes/SnakeMode.cpp
@@ -16,29 +16,6 @@
 
 void SnakeMode::configure()
 {
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_clock")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"clock":{{value}}})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:snake");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" clock"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::payload_off].set("false");
-        component[HomeAssistantAbbreviations::payload_on].set("true");
-        component[HomeAssistantAbbreviations::platform].set("switch");
-        component[HomeAssistantAbbreviations::state_off].set("False");
-        component[HomeAssistantAbbreviations::state_on].set("True");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.clock}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
     Storage.begin(name.data(), true);
     if (Storage.isKey("clock"))
@@ -288,5 +265,31 @@ void SnakeMode::onReceive(JsonObjectConst payload,
         setClock(payload["clock"].as<bool>());
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void SnakeMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_clock")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"clock":{{value}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:snake");
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" clock"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_off].set("false");
+        component[HomeAssistantAbbreviations::payload_on].set("true");
+        component[HomeAssistantAbbreviations::platform].set("switch");
+        component[HomeAssistantAbbreviations::state_off].set("False");
+        component[HomeAssistantAbbreviations::state_on].set("True");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.clock}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // MODE_SNAKE

--- a/firmware/src/modes/SnakeMode.cpp
+++ b/firmware/src/modes/SnakeMode.cpp
@@ -2,13 +2,12 @@
 
 #include "modes/SnakeMode.h"
 
-#include "config/constants.h" // NOLINT(misc-include-cleaner)
-#include "extensions/HomeAssistantExtension.h"
+#include "config/constants.h"     // NOLINT(misc-include-cleaner)
 #include "fonts/MiniFont.h"       // NOLINT(misc-include-cleaner)
 #include "handlers/TextHandler.h" // NOLINT(misc-include-cleaner)
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <Preferences.h>
 #include <map>
@@ -267,6 +266,7 @@ void SnakeMode::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void SnakeMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/modes/StreamMode.cpp
+++ b/firmware/src/modes/StreamMode.cpp
@@ -13,31 +13,6 @@
 
 void StreamMode::configure()
 {
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_protocol")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(
-            R"({"port":{{{"Art-Net":6454,"Distributed Display Protocol":4048,"E1.31":5568}.get(value)}}})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:protocol");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" protocol"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
-        options.add("Art-Net");
-        options.add("Distributed Display Protocol");
-        options.add("E1.31");
-        component[HomeAssistantAbbreviations::platform].set("select");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set(
-            R"({{{4048:"Distributed Display Protocol",5568:"E1.31",6454:"Art-Net"}.get(value_json.port)}})");
-    }
-#endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
     Storage.begin(name.data(), true);
     if (Storage.isKey("port"))
@@ -106,5 +81,33 @@ void StreamMode::onPacket(AsyncUDPPacket packet)
 }
 
 void StreamMode::end() { udp.reset(); }
+
+#if EXTENSION_HOMEASSISTANT
+void StreamMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_protocol")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(
+            R"({"port":{{{"Art-Net":6454,"Distributed Display Protocol":4048,"E1.31":5568}.get(value)}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:protocol");
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" protocol"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
+        options.add("Art-Net");
+        options.add("Distributed Display Protocol");
+        options.add("E1.31");
+        component[HomeAssistantAbbreviations::platform].set("select");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set(
+            R"({{{4048:"Distributed Display Protocol",5568:"E1.31",6454:"Art-Net"}.get(value_json.port)}})");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // MODE_STREAM

--- a/firmware/src/modes/StreamMode.cpp
+++ b/firmware/src/modes/StreamMode.cpp
@@ -3,10 +3,9 @@
 #include "modes/StreamMode.h"
 
 #include "config/constants.h" // NOLINT(misc-include-cleaner)
-#include "extensions/HomeAssistantExtension.h"
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <Preferences.h>
 #include <span>
@@ -83,6 +82,7 @@ void StreamMode::onPacket(AsyncUDPPacket packet)
 void StreamMode::end() { udp.reset(); }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void StreamMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/modes/TickerMode.cpp
+++ b/firmware/src/modes/TickerMode.cpp
@@ -13,43 +13,6 @@
 
 void TickerMode::configure()
 {
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_font")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"font":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:format-font");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" font"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
-        for (const std::string_view _font : Fonts.names)
-        {
-            options.add(_font);
-        }
-        component[HomeAssistantAbbreviations::platform].set("select");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.font}}");
-    }
-    {
-        const std::string id{std::string(name).append("_message")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"message":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::icon].set("mdi:message");
-        component[HomeAssistantAbbreviations::name].set(name);
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("text");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.message}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
     Storage.begin(name.data(), true);
     if (Storage.isKey("message"))
@@ -153,5 +116,45 @@ void TickerMode::onReceive(JsonObjectConst payload,
 }
 
 void TickerMode::end() { text.reset(); }
+
+#if EXTENSION_HOMEASSISTANT
+void TickerMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_font")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"font":"{{value}}"})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:format-font");
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" font"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
+        for (const std::string_view _font : Fonts.names)
+        {
+            options.add(_font);
+        }
+        component[HomeAssistantAbbreviations::platform].set("select");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.font}}");
+    }
+    {
+        const std::string id{std::string(name).append("_message")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"message":"{{value}}"})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::icon].set("mdi:message");
+        component[HomeAssistantAbbreviations::name].set(name);
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::platform].set("text");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.message}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // MODE_TICKER

--- a/firmware/src/modes/TickerMode.cpp
+++ b/firmware/src/modes/TickerMode.cpp
@@ -2,12 +2,11 @@
 
 #include "modes/TickerMode.h"
 
-#include "extensions/HomeAssistantExtension.h"
 #include "fonts/SmallFont.h" // NOLINT(misc-include-cleaner)
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
-#include "services/FontsService.h" // NOLINT(misc-include-cleaner)
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
+#include "services/FontsService.h"      // NOLINT(misc-include-cleaner)
 
 #include <Preferences.h>
 
@@ -118,6 +117,7 @@ void TickerMode::onReceive(JsonObjectConst payload,
 void TickerMode::end() { text.reset(); }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void TickerMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/modes/WeatherMode.cpp
+++ b/firmware/src/modes/WeatherMode.cpp
@@ -2,7 +2,6 @@
 
 #include "modes/WeatherMode.h"
 
-#include "extensions/HomeAssistantExtension.h"
 #include "fonts/MiniFont.h"         // NOLINT(misc-include-cleaner)
 #include "handlers/BitmapHandler.h" // NOLINT(misc-include-cleaner)
 #include "handlers/TextHandler.h"   // NOLINT(misc-include-cleaner)
@@ -163,6 +162,7 @@ void WeatherMode::end()
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void WeatherMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/modes/WeatherMode.cpp
+++ b/firmware/src/modes/WeatherMode.cpp
@@ -15,30 +15,6 @@
 
 void WeatherMode::configure()
 {
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_protocol")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"provider":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:weather-partly-cloudy");
-        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" provider"));
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
-        for (const std::string_view _provider : providerNames)
-        {
-            options.add(_provider);
-        }
-        component[HomeAssistantAbbreviations::platform].set("select");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.provider}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
     Preferences Storage;
     Storage.begin(name.data(), true);
     if (Storage.isKey("provider"))
@@ -185,5 +161,32 @@ void WeatherMode::end()
     temperature.reset();
     transmit();
 }
+
+#if EXTENSION_HOMEASSISTANT
+void WeatherMode::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_protocol")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"provider":"{{value}}"})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:weather-partly-cloudy");
+        component[HomeAssistantAbbreviations::name].set(std::string(name).append(" provider"));
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
+        for (const std::string_view _provider : providerNames)
+        {
+            options.add(_provider);
+        }
+        component[HomeAssistantAbbreviations::platform].set("select");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.provider}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 #endif // MODE_WEATHER

--- a/firmware/src/modules/ExtensionModule.cpp
+++ b/firmware/src/modules/ExtensionModule.cpp
@@ -6,3 +6,7 @@ void ExtensionModule::handle() {}
 
 void ExtensionModule::onReceive(JsonObjectConst payload, std::string_view source) {}
 void ExtensionModule::onTransmit(JsonObjectConst payload, std::string_view source) {}
+
+#if EXTENSION_HOMEASSISTANT
+void ExtensionModule::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) {}
+#endif

--- a/firmware/src/modules/ExtensionModule.cpp
+++ b/firmware/src/modules/ExtensionModule.cpp
@@ -8,5 +8,6 @@ void ExtensionModule::onReceive(JsonObjectConst payload, std::string_view source
 void ExtensionModule::onTransmit(JsonObjectConst payload, std::string_view source) {}
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ExtensionModule::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) {}
 #endif

--- a/firmware/src/modules/ModeModule.cpp
+++ b/firmware/src/modules/ModeModule.cpp
@@ -8,5 +8,6 @@ void ModeModule::end() {}
 void ModeModule::onReceive(JsonObjectConst payload, std::string_view source) {}
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ModeModule::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) {}
 #endif

--- a/firmware/src/modules/ModeModule.cpp
+++ b/firmware/src/modules/ModeModule.cpp
@@ -6,3 +6,7 @@ void ModeModule::handle() {}
 void ModeModule::end() {}
 
 void ModeModule::onReceive(JsonObjectConst payload, std::string_view source) {}
+
+#if EXTENSION_HOMEASSISTANT
+void ModeModule::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) {}
+#endif

--- a/firmware/src/modules/ServiceModule.cpp
+++ b/firmware/src/modules/ServiceModule.cpp
@@ -3,5 +3,6 @@
 void ServiceModule::onReceive(JsonObjectConst payload, std::string_view source) {}
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ServiceModule::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) {}
 #endif

--- a/firmware/src/modules/ServiceModule.cpp
+++ b/firmware/src/modules/ServiceModule.cpp
@@ -1,3 +1,7 @@
 #include "modules/ServiceModule.h"
 
 void ServiceModule::onReceive(JsonObjectConst payload, std::string_view source) {}
+
+#if EXTENSION_HOMEASSISTANT
+void ServiceModule::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique) {}
+#endif

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -63,30 +63,6 @@ void ConnectivityService::configure()
     configTzTime(TIME_ZONE, "pool.ntp.org", "time.cloudflare.com", "time.nist.gov");
 }
 
-void ConnectivityService::begin()
-{
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_rssi")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::device_class].set("signal_strength");
-        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
-        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
-        component[HomeAssistantAbbreviations::force_update].set(true);
-        component[HomeAssistantAbbreviations::name].set("Wi-Fi signal");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("sensor");
-        component[HomeAssistantAbbreviations::state_class].set("measurement");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::unit_of_measurement].set("dBm");
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.rssi}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
-}
-
 void ConnectivityService::handle()
 {
     if (dns && WiFi.getMode() != wifi_mode_t::WIFI_MODE_STA)
@@ -337,6 +313,29 @@ void ConnectivityService::onReceive(JsonObjectConst payload,
         WiFi.scanNetworks(true);
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void ConnectivityService::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_rssi")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::device_class].set("signal_strength");
+        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
+        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
+        component[HomeAssistantAbbreviations::force_update].set(true);
+        component[HomeAssistantAbbreviations::name].set("Wi-Fi signal");
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::platform].set("sensor");
+        component[HomeAssistantAbbreviations::state_class].set("measurement");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::unit_of_measurement].set("dBm");
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.rssi}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 ConnectivityService &ConnectivityService::getInstance()
 {

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -2,7 +2,6 @@
 
 #include "extensions/HomeAssistantExtension.h"
 #include "services/DeviceService.h"
-#include "services/ExtensionsService.h"
 
 #include <ESPmDNS.h>
 #include <Preferences.h>
@@ -315,6 +314,7 @@ void ConnectivityService::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ConnectivityService::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -18,7 +18,6 @@ void DeviceService::begin()
     vTaskDelay(INT8_MAX);
     ESP_LOGI(name, "Frekvens " VERSION);    // NOLINT(cppcoreguidelines-avoid-do-while)
     ESP_LOGD(name, MANUFACTURER " " MODEL); // NOLINT(cppcoreguidelines-avoid-do-while)
-
 #if SOC_PM_SUPPORT_EXT_WAKEUP || SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
 #if SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
     gpio_deep_sleep_hold_dis();
@@ -91,76 +90,19 @@ void DeviceService::begin()
 #elif SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP && defined(PIN_SW2)
     esp_deep_sleep_enable_gpio_wakeup(1ULL << static_cast<unsigned>(PIN_SW2), ESP_GPIO_WAKEUP_GPIO_LOW);
 #endif // SOC_PM_SUPPORT_EXT_WAKEUP && CONFIG_IDF_TARGET_ESP32 && defined(PIN_INT) && defined(PIN_SW1)
-
     taskHandle = xTaskGetCurrentTaskHandle();
-
     Display.configure();
     Connectivity.configure();
     WebServer.configure();
     Extensions.configure();
     Modes.configure();
-
     operational = true;
     ESP_LOGV(name, "operational"); // NOLINT(cppcoreguidelines-avoid-do-while)
-
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_reboot")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"action":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::device_class].set("restart");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::name].set("Reboot");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::payload_press].set("reboot");
-        component[HomeAssistantAbbreviations::platform].set("button");
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-    }
-    {
-        const std::string id{std::string(name).append("_power")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"action":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:power");
-        component[HomeAssistantAbbreviations::name].set("Power off");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::payload_press].set("power");
-        component[HomeAssistantAbbreviations::platform].set("button");
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-    }
-    {
-        const std::string id{std::string(name).append("_temperature")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::device_class].set("temperature");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
-        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
-        component[HomeAssistantAbbreviations::force_update].set(true);
-        component[HomeAssistantAbbreviations::name].set("Internal temperature");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        component[HomeAssistantAbbreviations::platform].set("sensor");
-        component[HomeAssistantAbbreviations::state_class].set("measurement");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::unit_of_measurement].set("°C");
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.temperature}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
-
-    Display.begin();
-    Connectivity.begin();
     WebServer.begin();
     Fonts.begin();
     Extensions.begin();
     Modes.begin();
-
     transmit();
-
     ESP_LOGD(name, "ready"); // NOLINT(cppcoreguidelines-avoid-do-while)
 }
 
@@ -322,6 +264,57 @@ void DeviceService::onReceive(JsonObjectConst payload,
         }
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void DeviceService::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_reboot")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"action":"{{value}}"})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::device_class].set("restart");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::name].set("Reboot");
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_press].set("reboot");
+        component[HomeAssistantAbbreviations::platform].set("button");
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+    }
+    {
+        const std::string id{std::string(name).append("_power")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"action":"{{value}}"})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:power");
+        component[HomeAssistantAbbreviations::name].set("Power off");
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::payload_press].set("power");
+        component[HomeAssistantAbbreviations::platform].set("button");
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+    }
+    {
+        const std::string id{std::string(name).append("_temperature")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::device_class].set("temperature");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("diagnostic");
+        component[HomeAssistantAbbreviations::expire_after].set(UINT8_MAX);
+        component[HomeAssistantAbbreviations::force_update].set(true);
+        component[HomeAssistantAbbreviations::name].set("Internal temperature");
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        component[HomeAssistantAbbreviations::platform].set("sensor");
+        component[HomeAssistantAbbreviations::state_class].set("measurement");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::unit_of_measurement].set("°C");
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.temperature}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 DeviceService &DeviceService::getInstance()
 {

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -266,6 +266,7 @@ void DeviceService::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void DeviceService::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -51,38 +51,6 @@ void DisplayService::configure()
     flush();
 }
 
-void DisplayService::begin()
-{
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_orientation")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"orientation":{{value.replace('°','')}}})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
-        component[HomeAssistantAbbreviations::entity_category].set("config");
-        component[HomeAssistantAbbreviations::icon].set("mdi:rotate-right-variant");
-        component[HomeAssistantAbbreviations::name].set("Orientation");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
-        options.add("0°");
-#if GRID_COLUMNS == GRID_ROWS
-        options.add("90°");
-#endif // GRID_COLUMNS == GRID_ROWS
-        options.add("180°");
-#if GRID_COLUMNS == GRID_ROWS
-        options.add("270°");
-#endif // GRID_COLUMNS == GRID_ROWS
-        component[HomeAssistantAbbreviations::platform].set("select");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.orientation}}°");
-    }
-#endif // EXTENSION_HOMEASSISTANT
-}
-
 void DisplayService::handle()
 {
     if (pending)
@@ -450,6 +418,37 @@ void DisplayService::onReceive(JsonObjectConst payload,
         setPower(payload["power"].as<bool>());
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void DisplayService::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_orientation")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"orientation":{{value.replace('°','')}}})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::enabled_by_default].set(false);
+        component[HomeAssistantAbbreviations::entity_category].set("config");
+        component[HomeAssistantAbbreviations::icon].set("mdi:rotate-right-variant");
+        component[HomeAssistantAbbreviations::name].set("Orientation");
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
+        options.add("0°");
+#if GRID_COLUMNS == GRID_ROWS
+        options.add("90°");
+#endif // GRID_COLUMNS == GRID_ROWS
+        options.add("180°");
+#if GRID_COLUMNS == GRID_ROWS
+        options.add("270°");
+#endif // GRID_COLUMNS == GRID_ROWS
+        component[HomeAssistantAbbreviations::platform].set("select");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.orientation}}°");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 DisplayService &DisplayService::getInstance()
 {

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -1,9 +1,8 @@
 #include "services/DisplayService.h"
 
-#include "extensions/HomeAssistantExtension.h"
 #include "handlers/BitmapHandler.h" // NOLINT(misc-include-cleaner)
 #include "services/DeviceService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 #include "services/ModesService.h"
 
 #include <Preferences.h>
@@ -420,6 +419,7 @@ void DisplayService::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void DisplayService::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/services/ModesService.cpp
+++ b/firmware/src/services/ModesService.cpp
@@ -1,11 +1,10 @@
 #include "services/ModesService.h"
 
-#include "extensions/HomeAssistantExtension.h"
 #include "fonts/MicroFont.h"      // NOLINT(misc-include-cleaner)
 #include "handlers/TextHandler.h" // NOLINT(misc-include-cleaner)
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h"
+#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <Preferences.h>
 #include <vector>
@@ -428,6 +427,7 @@ void ModesService::onReceive(JsonObjectConst payload,
 }
 
 #if EXTENSION_HOMEASSISTANT
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ModesService::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
 {
     topic.append(name);

--- a/firmware/src/services/ModesService.cpp
+++ b/firmware/src/services/ModesService.cpp
@@ -12,29 +12,6 @@
 
 void ModesService::configure()
 {
-#if EXTENSION_HOMEASSISTANT
-    const std::string topic{std::string("frekvens/" HOSTNAME "/").append(name)};
-    const HomeAssistantExtension &_ha = Extensions.HomeAssistant();
-    {
-        const std::string id{std::string(name).append("_mode")};
-        JsonObject component{(*_ha.discovery)[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
-        component[HomeAssistantAbbreviations::command_template].set(R"({"mode":"{{value}}"})");
-        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
-        component[HomeAssistantAbbreviations::icon].set("mdi:format-list-bulleted");
-        component[HomeAssistantAbbreviations::name].set("Mode");
-        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
-        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
-        for (const std::string_view _name : names)
-        {
-            options.add(_name);
-        }
-        component[HomeAssistantAbbreviations::platform].set("select");
-        component[HomeAssistantAbbreviations::state_topic].set(topic);
-        component[HomeAssistantAbbreviations::unique_id].set(_ha.uniquePrefix + id);
-        component[HomeAssistantAbbreviations::value_template].set("{{value_json.mode}}");
-    }
-#endif // EXTENSION_HOMEASSISTANT
-
     for (const std::string_view _name : names)
     {
         getMode(_name)->configure();
@@ -449,6 +426,31 @@ void ModesService::onReceive(JsonObjectConst payload,
         setMode(payload["mode"].as<std::string_view>());
     }
 }
+
+#if EXTENSION_HOMEASSISTANT
+void ModesService::onHomeAssistant(JsonDocument &discovery, std::string topic, std::string unique)
+{
+    topic.append(name);
+    {
+        const std::string id{std::string(name).append("_mode")};
+        JsonObject component{discovery[HomeAssistantAbbreviations::components][id].to<JsonObject>()};
+        component[HomeAssistantAbbreviations::command_template].set(R"({"mode":"{{value}}"})");
+        component[HomeAssistantAbbreviations::command_topic].set(topic + "/set");
+        component[HomeAssistantAbbreviations::icon].set("mdi:format-list-bulleted");
+        component[HomeAssistantAbbreviations::name].set("Mode");
+        component[HomeAssistantAbbreviations::object_id].set(HOSTNAME "_" + id);
+        JsonArray options{component[HomeAssistantAbbreviations::options].to<JsonArray>()};
+        for (const std::string_view _name : names)
+        {
+            options.add(_name);
+        }
+        component[HomeAssistantAbbreviations::platform].set("select");
+        component[HomeAssistantAbbreviations::state_topic].set(topic);
+        component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+        component[HomeAssistantAbbreviations::value_template].set("{{value_json.mode}}");
+    }
+}
+#endif // EXTENSION_HOMEASSISTANT
 
 ModesService &ModesService::getInstance()
 {


### PR DESCRIPTION
Refactor the Home Assistant integration by restructuring existing code for improved structure.

## Changes
- Reorganize Home Assistant–related logic across modules/services
- Move existing code to improve structure and separation of concerns
- Align implementation with current architectural patterns
- Minor internal cleanups to support the refactor

## Motivation
Improve maintainability and readability of the Home Assistant integration, making future changes easier without altering behavior.

## Notes
- No functional changes
- No new features introduced
- Pure refactor