### PR TITLE
Refine rendering pipeline and optimize PWM bit depth

### DIFF
--- a/firmware/include/config/secrets.h
+++ b/firmware/include/config/secrets.h
@@ -37,5 +37,9 @@
 // #define LATITUDE "0.000"  // °
 // #define LONGITUDE "0.000" // °
 // #define LOCATION "city"
-// #define TEMPERATURE_CELSIUS true    // °C
-// #define TEMPERATURE_FAHRENHEIT true // °F
+
+/**
+ * Miscellaneous (optional)
+ */
+// #define FRAME_RATE 60     // fps
+// #define WIFI_COUNTRY "01" // ISO 3166-1 alpha-2

--- a/firmware/include/services/DisplayService.h
+++ b/firmware/include/services/DisplayService.h
@@ -17,18 +17,6 @@ private:
     static constexpr uint8_t frameRate = 60;
 #endif // FRAME_RATE
 
-    enum class Orientation : uint8_t // NOLINT(performance-enum-size)
-    {
-        deg0,
-        deg90,
-        deg180,
-        deg270,
-    };
-
-    // NOLINTNEXTLINE(bugprone-throwing-static-initialization,cert-err58-cpp)
-    inline static const uint8_t depth =
-        min<uint8_t>(log2f(1 / PWM_WIDTH / static_cast<float>(frameRate * 2)), SOC_LEDC_TIMER_BIT_WIDTH);
-
     static constexpr std::array<uint16_t, 12> splash{
         0b1000001001,
         0b1000000001,
@@ -44,6 +32,20 @@ private:
         0b0011111100,
     };
 
+    enum class Orientation : uint8_t // NOLINT(performance-enum-size)
+    {
+        deg0,
+        deg90,
+        deg180,
+        deg270,
+    };
+
+    inline static const uint8_t depth =
+        min<uint8_t>(min<uint8_t>(static_cast<uint8_t>(14.0F - (6.0F * log2f(static_cast<float>(frameRate) / 60.0F))),
+                                  static_cast<uint8_t>(log2f((1.0F / PWM_WIDTH) / static_cast<float>(frameRate)))),
+                     SOC_LEDC_TIMER_BIT_WIDTH);
+
+    bool _pending = false;
     bool pending = false;
     bool power = false;
 
@@ -59,7 +61,9 @@ private:
     std::array<uint8_t, GRID_COLUMNS * GRID_ROWS> frame{};
     std::array<uint8_t, GRID_COLUMNS * GRID_ROWS> pixel{LED_MAP};
 
-    Orientation orientation = Orientation::deg0;
+    hw_timer_t *timer{};
+
+    Orientation orientation{Orientation::deg0};
 
     void transmit();
 
@@ -68,10 +72,7 @@ private:
     static IRAM_ATTR void onTimer();
 
 public:
-    hw_timer_t *timer = nullptr;
-
     void configure();
-    void begin();
 
     void handle();
 

--- a/firmware/include/services/DisplayService.h
+++ b/firmware/include/services/DisplayService.h
@@ -40,6 +40,7 @@ private:
         deg270,
     };
 
+    // NOLINTNEXTLINE(bugprone-throwing-static-initialization)
     inline static const uint8_t depth =
         min<uint8_t>(min<uint8_t>(static_cast<uint8_t>(14.0F - (6.0F * log2f(static_cast<float>(frameRate) / 60.0F))),
                                   static_cast<uint8_t>(log2f((1.0F / PWM_WIDTH) / static_cast<float>(frameRate)))),

--- a/firmware/include/services/DisplayService.h
+++ b/firmware/include/services/DisplayService.h
@@ -41,10 +41,10 @@ private:
     };
 
     // NOLINTNEXTLINE(bugprone-throwing-static-initialization)
-    inline static const uint8_t depth =
-        min<uint8_t>(min<uint8_t>(static_cast<uint8_t>(14.0F - (6.0F * log2f(static_cast<float>(frameRate) / 60.0F))),
-                                  static_cast<uint8_t>(log2f((1.0F / PWM_WIDTH) / static_cast<float>(frameRate)))),
-                     SOC_LEDC_TIMER_BIT_WIDTH);
+    inline static const uint8_t depth = std::clamp<uint8_t>(
+        min<uint8_t>(static_cast<uint8_t>(14.0F - (3.0F * log2f(static_cast<float>(frameRate) / 30.0F))),
+                     static_cast<uint8_t>(log2f((1.0F / PWM_WIDTH) / static_cast<float>(frameRate)))),
+        8U, SOC_LEDC_TIMER_BIT_WIDTH);
 
     bool _pending = false;
     bool pending = false;

--- a/firmware/src/extensions/OtaExtension.cpp
+++ b/firmware/src/extensions/OtaExtension.cpp
@@ -45,7 +45,6 @@ void OtaExtension::onStart()
     TextHandler("U", font).draw();
     Display.flush();
     Display.setPower(true);
-    timerWrite(Display.timer, 1'000'000 / (1U << 8U)); // 1 fps
 }
 
 void OtaExtension::onEnd()

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -23,11 +23,11 @@ void DisplayService::configure()
 #else
     SPI.begin(PIN_SCLK, GPIO_NUM_NC, PIN_MOSI, PIN_CS);
 #endif // PIN_MISO
-    SPI.beginTransaction(SPISettings(INT16_MAX * GRID_COLUMNS * GRID_ROWS, MSBFIRST, SPI_MODE0));
+    SPI.beginTransaction(SPISettings(frameRate * GRID_COLUMNS * GRID_ROWS * (1U << 9U), MSBFIRST, SPI_MODE0));
 
-    timer = timerBegin(1'000'000);
+    timer = timerBegin(1'000'000U);
     timerAttachInterrupt(timer, &onTimer);
-    timerAlarm(timer, 1'000'000 / (1U << 8U) / frameRate, true, 0);
+    timerAlarm(timer, 1'000'000U / (1U << 8U) / frameRate, true, 0);
     timerStart(timer);
 
     ledcAttach(PIN_OE, static_cast<uint32_t>(1.0F / PWM_WIDTH / static_cast<float>(1U << depth)), depth);
@@ -63,30 +63,112 @@ IRAM_ATTR void DisplayService::onTimer()
 {
     static DRAM_ATTR std::array<uint8_t, ((GRID_COLUMNS * GRID_ROWS) + 7) / 8> bytes{};
     static DRAM_ATTR uint8_t threshold = 0;
-    size_t pixel = 0;
-    for (size_t i = 0; i < GRID_COLUMNS * GRID_ROWS / 8; ++i)
+    const uint8_t *frame = Display.frame.data();
+    if (threshold != UINT8_MAX)
     {
-        uint8_t byte = 0;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x80U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x40U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x20U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x10U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x08U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x04U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x02U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x01U : 0U;
-        bytes[i] = byte;
-    }
-    if constexpr (GRID_COLUMNS * GRID_ROWS % 8 != 0)
-    {
-        uint8_t byte = 0;
-        for (size_t remainder = 0; remainder < GRID_COLUMNS * GRID_ROWS % 8; ++remainder)
+        for (size_t i = 0; i < GRID_COLUMNS * GRID_ROWS / 8; ++i)
         {
-            byte |= (Display.frame[pixel++] > threshold) ? (0x80U >> remainder) : 0U;
+            uint8_t byte = 0;
+            if (*frame++ > threshold)
+            {
+                byte |= 0x80U;
+            }
+            if (*frame++ > threshold)
+            {
+                byte |= 0x40U;
+            }
+            if (*frame++ > threshold)
+            {
+                byte |= 0x20U;
+            }
+            if (*frame++ > threshold)
+            {
+                byte |= 0x10U;
+            }
+            if (*frame++ > threshold)
+            {
+                byte |= 0x08U;
+            }
+            if (*frame++ > threshold)
+            {
+                byte |= 0x04U;
+            }
+            if (*frame++ > threshold)
+            {
+                byte |= 0x02U;
+            }
+            if (*frame++ > threshold)
+            {
+                byte |= 0x01U;
+            }
+            bytes[i] = byte;
         }
-        bytes[GRID_COLUMNS * GRID_ROWS / 8] = byte;
+        if constexpr (GRID_COLUMNS * GRID_ROWS % 8 != 0)
+        {
+            uint8_t byte = 0;
+            for (size_t bit = 0; bit < GRID_COLUMNS * GRID_ROWS % 8; ++bit)
+            {
+                if (*frame++ > threshold)
+                {
+                    byte |= static_cast<uint8_t>(0x80U >> bit);
+                }
+            }
+            bytes[GRID_COLUMNS * GRID_ROWS / 8] = byte;
+        }
     }
-    threshold += 1;
+    else
+    {
+        for (size_t i = 0; i < GRID_COLUMNS * GRID_ROWS / 8; ++i)
+        {
+            uint8_t byte = 0;
+            if (*frame++ == UINT8_MAX)
+            {
+                byte |= 0x80U;
+            }
+            if (*frame++ == UINT8_MAX)
+            {
+                byte |= 0x40U;
+            }
+            if (*frame++ == UINT8_MAX)
+            {
+                byte |= 0x20U;
+            }
+            if (*frame++ == UINT8_MAX)
+            {
+                byte |= 0x10U;
+            }
+            if (*frame++ == UINT8_MAX)
+            {
+                byte |= 0x08U;
+            }
+            if (*frame++ == UINT8_MAX)
+            {
+                byte |= 0x04U;
+            }
+            if (*frame++ == UINT8_MAX)
+            {
+                byte |= 0x02U;
+            }
+            if (*frame++ == UINT8_MAX)
+            {
+                byte |= 0x01U;
+            }
+            bytes[i] = byte;
+        }
+        if constexpr (GRID_COLUMNS * GRID_ROWS % 8 != 0)
+        {
+            uint8_t byte = 0;
+            for (size_t bit = 0; bit < GRID_COLUMNS * GRID_ROWS % 8; ++bit)
+            {
+                if (*frame++ == UINT8_MAX)
+                {
+                    byte |= static_cast<uint8_t>(0x80U >> bit);
+                }
+            }
+            bytes[GRID_COLUMNS * GRID_ROWS / 8] = byte;
+        }
+    }
+    ++threshold;
     gpio_set_level(static_cast<gpio_num_t>(PIN_CS), LOW);
     SPI.transferBytes(bytes.data(), nullptr, bytes.size());
     gpio_set_level(static_cast<gpio_num_t>(PIN_CS), HIGH);
@@ -94,9 +176,10 @@ IRAM_ATTR void DisplayService::onTimer()
 
 void DisplayService::flush()
 {
-    if (frame != _frame)
+    if (_pending)
     {
         frame = _frame;
+        _pending = false;
     }
 }
 
@@ -210,6 +293,7 @@ void DisplayService::onPowerOff()
     Display.pending = true;
     Modes.setActive(false);
     Display.frame.fill(0);
+    Display._pending = true;
 }
 
 uint8_t DisplayService::getBrightness() const { return brightness; }
@@ -277,9 +361,14 @@ void DisplayService::setFrame(std::span<const uint8_t> frameNext)
     {
         _frame[pixel[i]] = frameNext[i];
     }
+    _pending = true;
 }
 
-void DisplayService::clearFrame(uint8_t brightness) { _frame.fill(brightness); }
+void DisplayService::clearFrame(uint8_t brightness)
+{
+    _frame.fill(brightness);
+    _pending = true;
+}
 
 void DisplayService::invertFrame()
 {
@@ -305,6 +394,7 @@ void DisplayService::setPixel(uint8_t x, uint8_t y, uint8_t brightness)
         ESP_LOGV(name, "invalid pixel %d:%d", x, y);
     }
     _frame[pixel[x + (y * GRID_COLUMNS)]] = brightness;
+    _pending = true;
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -59,7 +59,7 @@ void DisplayService::handle()
     }
 }
 
-IRAM_ATTR void DisplayService::onTimer()
+IRAM_ATTR void DisplayService::onTimer() // NOLINT(readability-function-cognitive-complexity)
 {
     static DRAM_ATTR std::array<uint8_t, ((GRID_COLUMNS * GRID_ROWS) + 7) / 8> bytes{};
     static DRAM_ATTR uint8_t threshold = 0;
@@ -69,35 +69,35 @@ IRAM_ATTR void DisplayService::onTimer()
         for (size_t i = 0; i < GRID_COLUMNS * GRID_ROWS / 8; ++i)
         {
             uint8_t byte = 0;
-            if (*frame++ > threshold)
+            if (*frame++ > threshold) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x80U;
             }
-            if (*frame++ > threshold)
+            if (*frame++ > threshold) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x40U;
             }
-            if (*frame++ > threshold)
+            if (*frame++ > threshold) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x20U;
             }
-            if (*frame++ > threshold)
+            if (*frame++ > threshold) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x10U;
             }
-            if (*frame++ > threshold)
+            if (*frame++ > threshold) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x08U;
             }
-            if (*frame++ > threshold)
+            if (*frame++ > threshold) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x04U;
             }
-            if (*frame++ > threshold)
+            if (*frame++ > threshold) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x02U;
             }
-            if (*frame++ > threshold)
+            if (*frame++ > threshold) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x01U;
             }
@@ -108,7 +108,7 @@ IRAM_ATTR void DisplayService::onTimer()
             uint8_t byte = 0;
             for (size_t bit = 0; bit < GRID_COLUMNS * GRID_ROWS % 8; ++bit)
             {
-                if (*frame++ > threshold)
+                if (*frame++ > threshold) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                 {
                     byte |= static_cast<uint8_t>(0x80U >> bit);
                 }
@@ -121,35 +121,35 @@ IRAM_ATTR void DisplayService::onTimer()
         for (size_t i = 0; i < GRID_COLUMNS * GRID_ROWS / 8; ++i)
         {
             uint8_t byte = 0;
-            if (*frame++ == UINT8_MAX)
+            if (*frame++ == UINT8_MAX) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x80U;
             }
-            if (*frame++ == UINT8_MAX)
+            if (*frame++ == UINT8_MAX) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x40U;
             }
-            if (*frame++ == UINT8_MAX)
+            if (*frame++ == UINT8_MAX) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x20U;
             }
-            if (*frame++ == UINT8_MAX)
+            if (*frame++ == UINT8_MAX) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x10U;
             }
-            if (*frame++ == UINT8_MAX)
+            if (*frame++ == UINT8_MAX) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x08U;
             }
-            if (*frame++ == UINT8_MAX)
+            if (*frame++ == UINT8_MAX) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x04U;
             }
-            if (*frame++ == UINT8_MAX)
+            if (*frame++ == UINT8_MAX) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x02U;
             }
-            if (*frame++ == UINT8_MAX)
+            if (*frame++ == UINT8_MAX) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             {
                 byte |= 0x01U;
             }
@@ -160,7 +160,7 @@ IRAM_ATTR void DisplayService::onTimer()
             uint8_t byte = 0;
             for (size_t bit = 0; bit < GRID_COLUMNS * GRID_ROWS % 8; ++bit)
             {
-                if (*frame++ == UINT8_MAX)
+                if (*frame++ == UINT8_MAX) // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                 {
                     byte |= static_cast<uint8_t>(0x80U >> bit);
                 }


### PR DESCRIPTION
This PR introduces a set of rendering refinements and low-level optimizations to improve performance and visual consistency in the display pipeline.

## Key Changes

- Reduced redundant operations during byte construction for SPI transmission
- Improved memory access patterns when iterating over the frame buffer
- Tweaks to better align software PWM behavior with hardware (`ledc`) brightness control

## Impact

- Less visual lagging in dynamic modes like Metaballs
- Marginally higher minimum-brightness on higher frame rates