### PR TITLE
CPU-dependent frame rate scaling

### DIFF
--- a/firmware/include/services/DisplayService.h
+++ b/firmware/include/services/DisplayService.h
@@ -14,7 +14,7 @@ private:
 #ifdef FRAME_RATE
     static constexpr uint8_t frameRate = FRAME_RATE;
 #else
-    static constexpr uint8_t frameRate = 60;
+    static constexpr uint8_t frameRate = F_CPU / GRID_COLUMNS / GRID_ROWS / 12'500;
 #endif // FRAME_RATE
 
     enum class Orientation : uint8_t // NOLINT(performance-enum-size)


### PR DESCRIPTION
Introduce CPU-dependent frame rate presets, allowing faster ESP32 variants to run higher display refresh rates while keeping slower chips within stable limits.

## Rationale

Different ESP32 variants operate at different CPU frequencies, yet the display is using a fixed 60 FPS across all boards. This results in:

- Underutilization on higher-performance chips  
- Potential instability or reduced headroom on lower-performance chips  

This PR adjusts the default frame rate based on CPU frequency to better match available processing capacity.

## New defaults

| CPU frequency | Frame rate |
|--------------|-----------|
| 120 MHz      | 37 FPS    |
| 160 MHz      | 50 FPS    |
| 240 MHz      | 75 FPS    |
| 320 MHz      | 100 FPS   |
| 400 MHz      | 125 FPS   |

Notes:
- 240 MHz covers the majority of supported boards  
- 160 MHz applies to chips such as ESP32-C3  
- 120 / 320 / 400 MHz targets are included for completeness, but are currently less relevant for supported hardware  

## Impact

- Better visual performance on higher-end chips (smoother animations, reduced perceived latency)  
- More appropriate defaults for lower-end chips  
- No user configuration required  

This remains a trade-off: higher frame rates increase minimum brightness and can influence PWM behavior.

## Notes on chip support

- ESP32-H series is currently unsupported (no Wi-Fi)  
- ESP32-P4 targets high-performance use cases and is not a typical Frekvens platform  
- Limited or no confirmation yet for 120 / 320 / 400 MHz targets within supported boards  