### PR TITLE
Optimize display rendering pipeline and introduce PWM_DEPTH config

### DIFF
--- a/.github/workflows/ikea-frekvens-led-multi-use-light.yml
+++ b/.github/workflows/ikea-frekvens-led-multi-use-light.yml
@@ -536,7 +536,7 @@ jobs:
 
           cat <<'EOL' > firmware/include/config/secrets.h
           #pragma once
-          #define FRAME_RATE 60
+          #define FRAME_RATE 72
           #define GOOGLEWEATHER_KEY "redacted"
           #define HOMEASSISTANT_ENTITY "weather.forecast_home"
           #define HOMEASSISTANT_HOST "homeassistant.local"
@@ -563,6 +563,7 @@ jobs:
           #define PIN_SDA 10
           #define PIN_SW1 11
           #define PIN_SW2 12
+          #define PWM_DEPTH 10
           #define RTC_DS3232
           #define WIFI_COUNTRY "01"
           #define WIFI_KEY "redacted"

--- a/.github/workflows/ikea-obegransad-led-wall-lamp.yml
+++ b/.github/workflows/ikea-obegransad-led-wall-lamp.yml
@@ -531,7 +531,7 @@ jobs:
 
           cat <<'EOL' > firmware/include/config/secrets.h
           #pragma once
-          #define FRAME_RATE 60
+          #define FRAME_RATE 72
           #define GOOGLEWEATHER_KEY "redacted"
           #define HOMEASSISTANT_ENTITY "weather.forecast_home"
           #define HOMEASSISTANT_HOST "homeassistant.local"
@@ -557,6 +557,7 @@ jobs:
           #define PIN_SCLK 9
           #define PIN_SDA 10
           #define PIN_SW2 11
+          #define PWM_DEPTH 10
           #define RTC_DS3231
           #define WIFI_COUNTRY "01"
           #define WIFI_KEY "redacted"

--- a/docs/wiki/Services.md
+++ b/docs/wiki/Services.md
@@ -101,8 +101,20 @@ API payload example:
 
 **Frame rate:**
 
-Configure in [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h):
+The frame rate is automatically scaled based on the ESP32 variant's CPU frequency. While this ranges from 120 fps (400 MHz) down to 24 fps (80 MHz), most common variants running at 240 MHz will result in 72 fps.
+
+To manually set a fixed frame rate, define it in [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h):
 
 ```h
-#define FRAME_RATE 60 // fps
+#define FRAME_RATE 72 // fps
+```
+
+**PWM bit depth:**
+
+To maximize visual quality, the bit depth is dynamically balanced against the frame rate. Higher frame rates favor fluid motion with lower bit depth (e.g. 8-bit at 120 fps), while lower frame rates allow for greater brightness control (e.g. 15-bit at 24 fps). For the common 72 fps configuration, this results in a 10-bit depth by default.
+
+To manually lock the bit depth, define it in [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h):
+
+```h
+#define PWM_DEPTH 10 // bit
 ```

--- a/docs/wiki/Services.md
+++ b/docs/wiki/Services.md
@@ -101,7 +101,7 @@ API payload example:
 
 **Frame rate:**
 
-The frame rate is automatically scaled based on the ESP32 variant's CPU frequency. While this ranges from 120 fps (400 MHz) down to 24 fps (80 MHz), most common variants running at 240 MHz will result in 72 fps.
+The frame rate is automatically scaled based on the ESP32 variant's CPU frequency. While this ranges from 120 fps (400 MHz) down to 36 fps (120 MHz), most common variants running at 240 MHz will result in 72 fps.
 
 To manually set a fixed frame rate, define it in [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h):
 

--- a/firmware/include/config/secrets.h
+++ b/firmware/include/config/secrets.h
@@ -37,5 +37,10 @@
 // #define LATITUDE "0.000"  // °
 // #define LONGITUDE "0.000" // °
 // #define LOCATION "city"
-// #define TEMPERATURE_CELSIUS true    // °C
-// #define TEMPERATURE_FAHRENHEIT true // °F
+
+/**
+ * Miscellaneous (optional)
+ */
+// #define FRAME_RATE 72     // fps
+// #define PWM_DEPTH 10      // bit
+// #define WIFI_COUNTRY "01" // ISO 3166-1 alpha-2

--- a/firmware/include/config/services.h
+++ b/firmware/include/config/services.h
@@ -7,7 +7,8 @@
 /**
  * Display
  */
-// #define FRAME_RATE 60 // fps
+// #define FRAME_RATE 72 // fps
+// #define PWM_DEPTH 10  // bit
 
 /**
  * Weather

--- a/firmware/include/services/DisplayService.h
+++ b/firmware/include/services/DisplayService.h
@@ -22,7 +22,8 @@ private:
 #else
     // NOLINTNEXTLINE(bugprone-throwing-static-initialization)
     static inline const uint8_t depth =
-        min(max<uint8_t>(8U, static_cast<uint8_t>(8.0F - (std::numbers::pi_v<float> * log2f(static_cast<float>(fps) / 120.0F)))),
+        min(max<uint8_t>(
+                8U, static_cast<uint8_t>(8.0F - (std::numbers::pi_v<float> * log2f(static_cast<float>(fps) / 120.0F)))),
             min<uint8_t>(SOC_LEDC_TIMER_BIT_WIDTH,
                          static_cast<uint8_t>(log2f(1.0F / PWM_WIDTH / static_cast<float>(fps)))));
 #endif // PWM_DEPTH

--- a/firmware/include/services/DisplayService.h
+++ b/firmware/include/services/DisplayService.h
@@ -12,22 +12,26 @@ private:
     explicit DisplayService() : ServiceModule("Display") {};
 
 #ifdef FRAME_RATE
-    static constexpr uint8_t frameRate = FRAME_RATE;
+    static constexpr uint8_t fps = FRAME_RATE;
 #else
-    static constexpr uint8_t frameRate = 60;
+    static constexpr uint8_t fps = F_CPU / 13'000U / GRID_COLUMNS / GRID_ROWS;
 #endif // FRAME_RATE
 
-    enum class Orientation : uint8_t // NOLINT(performance-enum-size)
-    {
-        deg0,
-        deg90,
-        deg180,
-        deg270,
-    };
+#ifdef PWM_DEPTH
+    static constexpr uint8_t depth = min<uint8_t>(PWM_DEPTH, SOC_LEDC_TIMER_BIT_WIDTH);
+#else
+    // NOLINTNEXTLINE(bugprone-throwing-static-initialization)
+    static inline const uint8_t depth =
+        min(max<uint8_t>(8U, static_cast<uint8_t>(8.0F - (std::numbers::pi_v<float> * log2f(static_cast<float>(fps) / 120.0F)))),
+            min<uint8_t>(SOC_LEDC_TIMER_BIT_WIDTH,
+                         static_cast<uint8_t>(log2f(1.0F / PWM_WIDTH / static_cast<float>(fps)))));
+#endif // PWM_DEPTH
 
-    // NOLINTNEXTLINE(bugprone-throwing-static-initialization,cert-err58-cpp)
-    inline static const uint8_t depth =
-        min<uint8_t>(log2f(1 / PWM_WIDTH / static_cast<float>(frameRate * 2)), SOC_LEDC_TIMER_BIT_WIDTH);
+#if GRID_COLUMNS == GRID_ROWS && PITCH_HORIZONTAL != PITCH_VERTICAL
+    float ratio = static_cast<float>(PITCH_HORIZONTAL) / static_cast<float>(PITCH_VERTICAL);
+#else
+    static constexpr float ratio = static_cast<float>(PITCH_HORIZONTAL) / static_cast<float>(PITCH_VERTICAL);
+#endif // GRID_COLUMNS == GRID_ROWS && PITCH_HORIZONTAL != PITCH_VERTICAL
 
     static constexpr std::array<uint16_t, 12> splash{
         0b1000001001,
@@ -44,22 +48,26 @@ private:
         0b0011111100,
     };
 
+    enum class Orientation : uint8_t // NOLINT(performance-enum-size)
+    {
+        deg0,
+        deg90,
+        deg180,
+        deg270,
+    };
+
+    static inline DRAM_ATTR std::array<std::array<uint8_t, ((GRID_COLUMNS * GRID_ROWS) + 7U) / 8U>, UINT8_MAX> planes{};
+
     bool pending = false;
     bool power = false;
-
-#if GRID_COLUMNS == GRID_ROWS && PITCH_HORIZONTAL != PITCH_VERTICAL
-    float ratio = static_cast<float>(PITCH_HORIZONTAL) / static_cast<float>(PITCH_VERTICAL);
-#else
-    static constexpr float ratio = static_cast<float>(PITCH_HORIZONTAL) / static_cast<float>(PITCH_VERTICAL);
-#endif // GRID_COLUMNS == GRID_ROWS && PITCH_HORIZONTAL == PITCH_VERTICAL
+    bool render = false;
 
     uint8_t brightness = 0;
 
-    std::array<uint8_t, GRID_COLUMNS * GRID_ROWS> _frame{};
     std::array<uint8_t, GRID_COLUMNS * GRID_ROWS> frame{};
     std::array<uint8_t, GRID_COLUMNS * GRID_ROWS> pixels{LED_MAP};
 
-    Orientation orientation = Orientation::deg0;
+    Orientation orientation{Orientation::deg0};
 
     void transmit();
 
@@ -68,11 +76,7 @@ private:
     static IRAM_ATTR void onTimer();
 
 public:
-    hw_timer_t *timer = nullptr;
-
     void configure();
-    void begin();
-
     void handle();
 
     [[nodiscard]] float getRatio() const;

--- a/firmware/include/services/ExtensionsService.h
+++ b/firmware/include/services/ExtensionsService.h
@@ -147,9 +147,9 @@ private:
     static void onTask(void *parameter = nullptr);
 
 public:
-    TaskHandle_t taskHandle = nullptr;
+    static constexpr uint16_t stackSize = 1U << 13U; // 8 kB
 
-    static constexpr uint16_t stackSize = 1U << 12U; // 4 kB
+    TaskHandle_t taskHandle = nullptr;
 
     void configure();
     void begin();

--- a/firmware/src/extensions/OtaExtension.cpp
+++ b/firmware/src/extensions/OtaExtension.cpp
@@ -45,7 +45,6 @@ void OtaExtension::onStart()
     TextHandler("U", font).draw();
     Display.flush();
     Display.setPower(true);
-    timerWrite(Display.timer, 1'000'000 / (1U << 8U)); // 1 fps
 }
 
 void OtaExtension::onEnd()

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -23,14 +23,14 @@ void DisplayService::configure()
 #else
     SPI.begin(PIN_SCLK, GPIO_NUM_NC, PIN_MOSI, PIN_CS);
 #endif // PIN_MISO
-    SPI.beginTransaction(SPISettings(INT16_MAX * GRID_COLUMNS * GRID_ROWS, MSBFIRST, SPI_MODE0));
+    SPI.beginTransaction(
+        SPISettings(static_cast<uint32_t>(1U << 9U) * GRID_COLUMNS * GRID_ROWS * fps, MSBFIRST, SPI_MODE0));
 
-    timer = timerBegin(1'000'000);
+    hw_timer_t *timer = timerBegin(static_cast<uint32_t>(UINT8_MAX) * fps);
     timerAttachInterrupt(timer, &onTimer);
-    timerAlarm(timer, 1'000'000 / (1U << 8U) / frameRate, true, 0);
-    timerStart(timer);
+    timerAlarm(timer, 1, true, 0);
 
-    ledcAttach(PIN_OE, static_cast<uint32_t>(1.0F / PWM_WIDTH / static_cast<float>(1U << depth)), depth);
+    ledcAttach(PIN_OE, static_cast<uint32_t>(1.0F / static_cast<float>(1U << depth) / PWM_WIDTH), depth);
     ledcOutputInvert(PIN_OE, true);
     ledcWrite(PIN_OE, 0);
 #ifdef SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
@@ -64,43 +64,109 @@ void DisplayService::handle()
 
 IRAM_ATTR void DisplayService::onTimer()
 {
-    static DRAM_ATTR std::array<uint8_t, ((GRID_COLUMNS * GRID_ROWS) + 7) / 8> bytes{};
-    static DRAM_ATTR uint8_t threshold = 0;
-    size_t pixel = 0;
-    for (size_t i = 0; i < GRID_COLUMNS * GRID_ROWS / 8; ++i)
-    {
-        uint8_t byte = 0;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x80U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x40U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x20U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x10U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x08U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x04U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x02U : 0U;
-        byte |= (Display.frame[pixel++] > threshold) ? 0x01U : 0U;
-        bytes[i] = byte;
-    }
-    if constexpr (GRID_COLUMNS * GRID_ROWS % 8 != 0)
-    {
-        uint8_t byte = 0;
-        for (size_t remainder = 0; remainder < GRID_COLUMNS * GRID_ROWS % 8; ++remainder)
-        {
-            byte |= (Display.frame[pixel++] > threshold) ? (0x80U >> remainder) : 0U;
-        }
-        bytes[GRID_COLUMNS * GRID_ROWS / 8] = byte;
-    }
-    threshold += 1;
+    static DRAM_ATTR uint8_t plane = 0;
     gpio_set_level(static_cast<gpio_num_t>(PIN_CS), LOW);
-    SPI.transferBytes(bytes.data(), nullptr, bytes.size());
+    SPI.transferBytes(planes[plane].data(), nullptr, planes[0].size());
     gpio_set_level(static_cast<gpio_num_t>(PIN_CS), HIGH);
+    if (++plane >= UINT8_MAX)
+    {
+        plane = 0;
+    }
 }
 
 void DisplayService::flush()
 {
-    if (frame != _frame)
+    if (!render)
     {
-        frame = _frame;
+        return;
     }
+    size_t idx = 0;
+    for (size_t byte = 0; byte < GRID_COLUMNS * GRID_ROWS / 8; ++byte)
+    {
+        uint8_t bits = 0;
+        if (frame[idx++] != 0)
+        {
+            bits |= 0b10000000U;
+        }
+        if (frame[idx++] != 0)
+        {
+            bits |= 0b01000000U;
+        }
+        if (frame[idx++] != 0)
+        {
+            bits |= 0b00100000U;
+        }
+        if (frame[idx++] != 0)
+        {
+            bits |= 0b00010000U;
+        }
+        if (frame[idx++] != 0)
+        {
+            bits |= 0b00001000U;
+        }
+        if (frame[idx++] != 0)
+        {
+            bits |= 0b00000100U;
+        }
+        if (frame[idx++] != 0)
+        {
+            bits |= 0b00000010U;
+        }
+        if (frame[idx++] != 0)
+        {
+            bits |= 0b00000001U;
+        }
+        planes[0][byte] = bits;
+    }
+    if constexpr (GRID_COLUMNS * GRID_ROWS % 8 != 0)
+    {
+        uint8_t bits = 0;
+        for (size_t bit = 0; bit < GRID_COLUMNS * GRID_ROWS % 8; ++bit)
+        {
+            if (frame[idx++] != 0)
+            {
+                bits |= static_cast<uint8_t>(0b10000000U >> bit);
+            }
+        }
+        planes[0][GRID_COLUMNS * GRID_ROWS / 8] = bits;
+    }
+    std::array<size_t, UINT8_MAX> counts{};
+    for (size_t idx = 0; idx < frame.size(); ++idx)
+    {
+        const uint8_t value = frame[idx];
+        if (value > 0 && value < UINT8_MAX)
+        {
+            ++counts[value];
+        }
+    }
+    std::array<size_t, UINT8_MAX> offsets{};
+    for (size_t value = 1; value < counts.size(); ++value)
+    {
+        offsets[value] = offsets[value - 1] + counts[value - 1];
+    }
+    std::array<size_t, UINT8_MAX> next = offsets;
+    std::array<size_t, GRID_COLUMNS * GRID_ROWS> indices{};
+    for (size_t idx = 0; idx < frame.size(); ++idx)
+    {
+        const uint8_t value = frame[idx];
+        if (value > 0 && value < UINT8_MAX)
+        {
+            indices[next[value]++] = idx;
+        }
+    }
+    for (uint8_t plane = 1; plane < UINT8_MAX; ++plane)
+    {
+        for (size_t byte = 0; byte < planes[0].size(); ++byte)
+        {
+            planes[plane][byte] = planes[plane - 1][byte];
+        }
+        for (size_t i = offsets[plane]; i < offsets[plane] + counts[plane]; ++i)
+        {
+            planes[plane][indices[i] >> 3U] &=
+                static_cast<uint8_t>(~static_cast<uint8_t>(0b10000000U >> (indices[i] & 7U)));
+        }
+    }
+    render = false;
 }
 
 float DisplayService::getRatio() const { return ratio; }
@@ -217,6 +283,7 @@ void DisplayService::onPowerOff()
     Display.pending = true;
     Modes.setActive(false);
     Display.frame.fill(0);
+    Display.render = true;
 }
 
 uint8_t DisplayService::getBrightness() const { return brightness; }
@@ -283,16 +350,22 @@ void DisplayService::setFrame(std::span<const uint8_t> _frame)
     {
         frame[pixels[idx]] = _frame[idx];
     }
+    render = true;
 }
 
-void DisplayService::clearFrame(uint8_t brightness) { _frame.fill(brightness); }
+void DisplayService::clearFrame(uint8_t _brightness)
+{
+    frame.fill(_brightness);
+    render = true;
+}
 
 void DisplayService::invertFrame()
 {
-    for (uint8_t &pixel : _frame)
+    for (uint8_t &idx : frame)
     {
-        pixel = UINT8_MAX - pixel;
+        idx = UINT8_MAX - idx;
     }
+    render = true;
 }
 
 uint8_t DisplayService::getPixel(uint8_t x, uint8_t y) const
@@ -311,6 +384,7 @@ void DisplayService::setPixel(uint8_t x, uint8_t y, uint8_t brightness)
         ESP_LOGV("Device", "invalid pixel %d:%d", x, y); // NOLINT(cppcoreguidelines-pro-type-vararg)
     }
     frame[pixels[x + (y * GRID_COLUMNS)]] = brightness;
+    render = true;
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
@@ -318,9 +392,9 @@ void DisplayService::drawEllipse(float x, float y, float radius, float ratio, bo
 {
 #if PITCH_HORIZONTAL == PITCH_VERTICAL
     const float xRatio =
-        static_cast<float>(2 * PITCH_HORIZONTAL) / (ratio * static_cast<float>(PITCH_VERTICAL + PITCH_HORIZONTAL));
+        static_cast<float>(PITCH_HORIZONTAL * 2) / (ratio * static_cast<float>(PITCH_VERTICAL + PITCH_HORIZONTAL));
     const float yRatio =
-        static_cast<float>(2 * PITCH_VERTICAL) / (ratio * static_cast<float>(PITCH_VERTICAL + PITCH_HORIZONTAL));
+        static_cast<float>(PITCH_VERTICAL * 2) / (ratio * static_cast<float>(PITCH_VERTICAL + PITCH_HORIZONTAL));
 #else
     const bool rotated = (static_cast<uint8_t>(orientation) & 1U) != 0;
     const float xRatio = static_cast<float>(2 * (rotated ? PITCH_VERTICAL : PITCH_HORIZONTAL)) /


### PR DESCRIPTION
This PR introduces a configurable `PWM_DEPTH` setting and significantly optimizes the display rendering pipeline by shifting to a bitplane-based approach. These changes reduce the computational overhead during high-frequency hardware interrupts, resulting in smoother rendering and more efficient CPU usage. 

## Key Changes
* **Configurable PWM Depth:** Added `PWM_DEPTH` support to `config/secrets.h` and `config/services.h`, allowing developers to manually dictate the PWM bit depth rather than relying strictly on automatic calculations. 
* **Bitplane Rendering Pipeline:** Refactored `DisplayService::onTimer()` and `flush()` to pre-calculate and process display frames into bitplanes (`planes[plane]`). This allows the high-frequency timer interrupt to simply push pre-formatted bytes via SPI.
* **Hardware Timer & SPI Adjustments:** Updated the SPI speed and timer alarm configurations in `DisplayService.cpp` to dynamically align with the newly established `PWM_DEPTH` and frame rate variables.
* **Code Cleanup:** Standardized array iteration logic (e.g., swapping `pixel` for `idx`) and minor refactoring across the core display and extension services.

## Impact
* **Performance:** Extracting the heavy bitwise brightness thresholding logic from `onTimer()` severely reduces the time spent inside the interrupt service routine (ISR).
* **Customization:** Users can now tailor the balance between visual depth and performance based on their specific hardware capabilities by adjusting `PWM_DEPTH`.