### PR TITLE
Specify penv location for uv using environ

### DIFF
--- a/scripts/extra_script.py
+++ b/scripts/extra_script.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import re
 import subprocess
@@ -18,9 +19,15 @@ def main() -> None:
     ]:
         return
 
+    Import("env")
+    env: Environment = typing.cast(Environment, globals()["env"])
+
+    uv_env = os.environ.copy()
+    uv_env["VIRTUAL_ENV"] = os.path.join(env.subst("$PROJECT_CORE_DIR"), "penv")
     uv = subprocess.run(
         [sys.executable, "-m", "uv", "sync", "--active", "--inexact", "--only-group", "scripts"],
         stderr=subprocess.DEVNULL,
+        env=uv_env,
     )
     if uv.returncode:
         match = re.search(r'"(uv==\d+\.\d+\.\d+)"', pathlib.Path("pyproject.toml").read_text())
@@ -31,10 +38,8 @@ def main() -> None:
         if pip.returncode:
             subprocess.run([sys.executable, "-m", "ensurepip"], check=True)
             subprocess.run(pip.args, check=True)
-        subprocess.run(uv.args, check=True)
+        subprocess.run(uv.args, env=uv_env, check=True)
 
-    Import("env")
-    env: Environment = typing.cast(Environment, globals()["env"])
     from src.Frekvens import Frekvens  # noqa: E402
 
     if env.IsCleanTarget():

--- a/scripts/src/components/Types.py
+++ b/scripts/src/components/Types.py
@@ -35,7 +35,13 @@ class Environment:
     def IsCleanTarget(self) -> bool:
         raise NotImplementedError
 
+    def Replace(self, **kwargs: typing.Any) -> None:
+        raise NotImplementedError
+
     def StringifyMacro(self, value: str) -> str:
+        raise NotImplementedError
+
+    def subst(self, key: str) -> str:
         raise NotImplementedError
 
 


### PR DESCRIPTION
Compatibility fix for #524 pioarduino 55.03.38+.

Specifies penv directory as `uv` venv target.