### PR TITLE
Fix y-offset of the character ä

### DIFF
--- a/firmware/include/fonts/SmallFont.h
+++ b/firmware/include/fonts/SmallFont.h
@@ -961,7 +961,7 @@ private:
     };
 
     // 0xE4, ä LATIN SMALL LETTER A WITH DIAERESIS
-    static constexpr std::array<uint8_t, 7> charE4 = {
+    static constexpr std::array<uint8_t, 6> charE4 = {
         0b10001,
         0b01110,
         0b00001,


### PR DESCRIPTION
Regression: Fixes the y-offset of the character ä (LATIN SMALL LETTER A WITH DIAERESIS)