### PR TITLE
Make the Micro font optional

### DIFF
--- a/.env
+++ b/.env
@@ -48,6 +48,7 @@ FONT_LARGE='true'
 FONT_MEDIUM='true'
 FONT_MEDIUMBOLD='true'
 FONT_MEDIUMWIDE='true'
+FONT_MICRO='true'
 FONT_MINI='true'
 FONT_SMALL='true'
 

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -139,6 +139,7 @@ jobs:
           FONT_MEDIUM='true'
           FONT_MEDIUMBOLD='true'
           FONT_MEDIUMWIDE='true'
+          FONT_MICRO='true'
           FONT_MINI='true'
           FONT_SMALL='true'
           HOSTNAME='frekvens'

--- a/.github/workflows/ikea-frekvens-led-multi-use-light.yml
+++ b/.github/workflows/ikea-frekvens-led-multi-use-light.yml
@@ -219,6 +219,7 @@ jobs:
         run: |
           cat <<'EOL' > .env
           EXTENSION_BUTTON='true'
+          FONT_MICRO='true'
           HOSTNAME='frekvens'
           IKEA_FREKVENS='true'
           MODE_ARROW='true'
@@ -329,6 +330,7 @@ jobs:
           FONT_MEDIUM='true'
           FONT_MEDIUMBOLD='true'
           FONT_MEDIUMWIDE='true'
+          FONT_MICRO='true'
           FONT_MINI='true'
           FONT_SMALL='true'
           HOSTNAME='frekvens'
@@ -485,6 +487,7 @@ jobs:
           FONT_MEDIUM='true'
           FONT_MEDIUMBOLD='true'
           FONT_MEDIUMWIDE='true'
+          FONT_MICRO='true'
           FONT_MINI='true'
           FONT_SMALL='true'
           HOSTNAME='frekvens'

--- a/.github/workflows/ikea-obegransad-led-wall-lamp.yml
+++ b/.github/workflows/ikea-obegransad-led-wall-lamp.yml
@@ -218,6 +218,7 @@ jobs:
         run: |
           cat <<'EOL' > .env
           EXTENSION_BUTTON='true'
+          FONT_MICRO='true'
           HOSTNAME='obegransad'
           IKEA_OBEGRANSAD='true'
           MODE_CIRCLE='true'
@@ -326,6 +327,7 @@ jobs:
           FONT_MEDIUM='true'
           FONT_MEDIUMBOLD='true'
           FONT_MEDIUMWIDE='true'
+          FONT_MICRO='true'
           FONT_MINI='true'
           FONT_SMALL='true'
           HOSTNAME='obegransad'
@@ -480,6 +482,7 @@ jobs:
           FONT_MEDIUM='true'
           FONT_MEDIUMBOLD='true'
           FONT_MEDIUMWIDE='true'
+          FONT_MICRO='true'
           FONT_MINI='true'
           FONT_SMALL='true'
           HOSTNAME='obegransad'

--- a/docs/wiki/Fonts.md
+++ b/docs/wiki/Fonts.md
@@ -18,6 +18,12 @@ FONT_BRAILLE='true'
 
 Extremely small 3×3 pixel font, offering basic legibility in tight layouts.
 
+Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
+
+```ini
+FONT_MICRO='true'
+```
+
 ## 🤏 Mini
 
 Balanced 4×5 pixel font providing improved readability without taking up much space.

--- a/firmware/include/fonts/MicroFont.h
+++ b/firmware/include/fonts/MicroFont.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if FONT_MICRO
+
 #include "modules/FontModule.h"
 
 #include <array>
@@ -382,3 +384,5 @@ public:
 
     [[nodiscard]] FontModule::Symbol getChar(uint32_t character) const override;
 };
+
+#endif // FONT_MICRO

--- a/firmware/include/services/FontsService.h
+++ b/firmware/include/services/FontsService.h
@@ -29,8 +29,10 @@ public:
     static constexpr auto names = std::to_array<std::string_view>({
 #if FONT_BRAILLE
         BrailleFont::name,
-#endif
+#endif // FONT_BRAILLE
+#if FONT_MICRO
         MicroFont::name,
+#endif // FONT_MICRO
 #if FONT_MINI
         MiniFont::name,
 #endif // FONT_MINI

--- a/firmware/src/fonts/MicroFont.cpp
+++ b/firmware/src/fonts/MicroFont.cpp
@@ -1,3 +1,5 @@
+#if FONT_MICRO
+
 #include "fonts/MicroFont.h"
 
 FontModule::Symbol MicroFont::getChar(uint32_t character) const
@@ -53,3 +55,5 @@ FontModule::Symbol MicroFont::getChar(uint32_t character) const
     // NOLINTEND(bugprone-branch-clone)
     return {};
 }
+
+#endif // FONT_MICRO

--- a/firmware/src/services/FontsService.cpp
+++ b/firmware/src/services/FontsService.cpp
@@ -12,10 +12,12 @@ std::unique_ptr<const FontModule> FontsService::get(std::string_view fontName) c
         return std::make_unique<const BrailleFont>();
     }
 #endif // FONT_BRAILLE
+#if FONT_MICRO
     if (fontName == MicroFont::name)
     {
         return std::make_unique<const MicroFont>();
     }
+#endif // FONT_MICRO
 #if FONT_MINI
     if (fontName == MiniFont::name)
     {

--- a/firmware/src/services/ModesService.cpp
+++ b/firmware/src/services/ModesService.cpp
@@ -1,10 +1,10 @@
 #include "services/ModesService.h"
 
-#include "fonts/MicroFont.h"      // NOLINT(misc-include-cleaner)
 #include "handlers/TextHandler.h" // NOLINT(misc-include-cleaner)
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
 #include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
+#include "services/FontsService.h"
 
 #include <nvs.h>
 #include <vector>
@@ -346,10 +346,14 @@ void ModesService::setMode(std::string_view modeName, bool power)
         }
         uint8_t height = 0; // NOLINT(misc-const-correctness)
         std::vector<std::unique_ptr<TextHandler>> lines;
-        const MicroFont font;
+#if FONT_MICRO
+        const std::unique_ptr<const FontModule> font{Fonts.get(MicroFont::name)};
+#else
+        const std::unique_ptr<const FontModule> font{Fonts.get(Fonts.names[0])};
+#endif // FONT_MICRO
         for (const std::string &word : words)
         {
-            std::unique_ptr<TextHandler> handler = std::make_unique<TextHandler>(word, font);
+            std::unique_ptr<TextHandler> handler{std::make_unique<TextHandler>(word, *font)};
             const uint8_t lineHeight = handler->getHeight();
             if (height + lineHeight >= GRID_ROWS)
             {


### PR DESCRIPTION
This update makes the Micro font optional, allowing users to enable or disable the Micro font in configuration as desired.

### Key changes
- Added `FONT_MICRO` configuration option in the environment files and workflows.
- Updated relevant firmware files to conditionally include the Micro font based on the new configuration.

### Impact
These changes provide flexibility for users who may not require the Micro font, potentially reducing memory usage and improving performance. The addition of this option does not affect existing functionality for users who choose to keep it enabled.