### PR TITLE
MQTT chunked payload support

### DIFF
--- a/firmware/include/extensions/MqttExtension.h
+++ b/firmware/include/extensions/MqttExtension.h
@@ -4,7 +4,9 @@
 
 #include "modules/ExtensionModule.h"
 
+#include <array>
 #include <espMqttClient.h>
+#include <vector>
 
 class MqttExtension final : public ExtensionModule
 {
@@ -13,7 +15,7 @@ private:
 
     unsigned long lastMillis = 0;
 
-    static inline bool subscribed = false;
+    static inline std::vector<uint8_t> buffer{};
 
     static constexpr size_t prefixLength = sizeof("frekvens/" HOSTNAME "/") - 1;
     static constexpr size_t suffixLength = sizeof("/set") - 1;
@@ -26,7 +28,9 @@ private:
 public:
     explicit MqttExtension() : ExtensionModule(name) {};
 
-    espMqttClient client;
+    static constexpr std::array<uint8_t, 1> emptyMessage{0};
+
+    espMqttClient client{espMqttClientTypes::UseInternalTask::NO};
 
     void configure() override;
     void handle() override;

--- a/firmware/src/extensions/HomeAssistantExtension.cpp
+++ b/firmware/src/extensions/HomeAssistantExtension.cpp
@@ -84,7 +84,12 @@ void HomeAssistantExtension::handle()
 
 void HomeAssistantExtension::undiscover()
 {
-    Extensions.MQTT().client.publish(discoveryTopic.c_str(), 1, true, std::array<uint8_t, 1>{0}.data(), 0);
+    MqttExtension &_mqtt{Extensions.MQTT()};
+    _mqtt.client.publish(discoveryTopic.c_str(),
+                         static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS1),
+                         true,
+                         _mqtt.emptyMessage.data(),
+                         _mqtt.emptyMessage.size() - 1U);
     ESP_LOGW("MQTT", "discovery packet removed"); // NOLINT(cppcoreguidelines-avoid-do-while)
 }
 

--- a/firmware/src/extensions/HomeAssistantExtension.cpp
+++ b/firmware/src/extensions/HomeAssistantExtension.cpp
@@ -70,7 +70,11 @@ void HomeAssistantExtension::begin()
     const size_t length{measureJson(discovery)};
     std::vector<uint8_t> payload(length + 1);
     serializeJson(discovery, payload.data(), length + 1);
-    Extensions.MQTT().client.publish(discoveryTopic.c_str(), 0, true, payload.data(), length);
+    Extensions.MQTT().client.publish(discoveryTopic.c_str(),
+                                     static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS0),
+                                     true,
+                                     payload.data(),
+                                     length);
 }
 
 void HomeAssistantExtension::handle()
@@ -84,7 +88,7 @@ void HomeAssistantExtension::handle()
 
 void HomeAssistantExtension::undiscover()
 {
-    MqttExtension &_mqtt{Extensions.MQTT()};
+    MqttExtension &_mqtt{Extensions.MQTT()}; // NOLINT(misc-const-correctness)
     _mqtt.client.publish(discoveryTopic.c_str(),
                          static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS1),
                          true,

--- a/firmware/src/extensions/MqttExtension.cpp
+++ b/firmware/src/extensions/MqttExtension.cpp
@@ -16,11 +16,15 @@ void MqttExtension::configure()
     client.onDisconnect(&onDisconnect);
     client.setCleanSession(false);
     client.setClientId(HOSTNAME);
-    client.setWill("frekvens/" HOSTNAME "/availability", 1, true, std::array<uint8_t, 1>{0}.data(), 0);
+    client.setWill("frekvens/" HOSTNAME "/availability",
+                   static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS1),
+                   true,
+                   emptyMessage.data(),
+                   emptyMessage.size() - 1U);
 #ifdef MQTT_PORT
     client.setServer(MQTT_HOST, MQTT_PORT);
 #else
-    client.setServer(MQTT_HOST, 1883);
+    client.setServer(MQTT_HOST, 1883U);
 #endif // MQTT_PORT
     client.setCredentials(MQTT_USER, MQTT_KEY);
     if (WiFi.isConnected())
@@ -31,18 +35,14 @@ void MqttExtension::configure()
 
 void MqttExtension::handle()
 {
-    if (!client.connected() && WiFi.isConnected() && millis() - lastMillis > UINT16_MAX)
+    client.loop();
+#if EXTENSION_STATUSLED
+    if (!client.connected() && WiFi.isConnected() && millis() - lastMillis > UINT8_MAX)
     {
         lastMillis = millis();
-#if EXTENSION_STATUSLED
         Extensions.StatusLed().warning();
-#endif // EXTENSION_STATUSLED
-        if (!client.connect() && client.queueSize() > INT8_MAX)
-        {
-            client.clearQueue();
-            ESP_LOGD("Queue", "dropped"); // NOLINT(cppcoreguidelines-avoid-do-while)
-        }
     }
+#endif // EXTENSION_STATUSLED
 }
 
 void MqttExtension::disconnect()
@@ -50,7 +50,11 @@ void MqttExtension::disconnect()
     lastMillis = millis();
     if (client.connected())
     {
-        client.publish("frekvens/" HOSTNAME "/availability", 1, true, std::array<uint8_t, 1>{0}.data(), 0);
+        client.publish("frekvens/" HOSTNAME "/availability",
+                       static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS1),
+                       true,
+                       emptyMessage.data(),
+                       emptyMessage.size() - 1U);
         client.loop();
         client.disconnect();
     }
@@ -59,34 +63,45 @@ void MqttExtension::disconnect()
 void MqttExtension::onConnect(bool sessionPresent)
 {
     ESP_LOGD("Wi-Fi", "connected"); // NOLINT(cppcoreguidelines-avoid-do-while)
-    if (!sessionPresent ||
-        (!subscribed && esp_sleep_get_wakeup_cause() == esp_sleep_source_t::ESP_SLEEP_WAKEUP_UNDEFINED))
-    {
-        Extensions.MQTT().client.subscribe("frekvens/" HOSTNAME "/+/set", 2);
-        subscribed = true;
-    }
-    Extensions.MQTT().client.publish("frekvens/" HOSTNAME "/availability", 1, true, "online");
+    Extensions.MQTT().client.subscribe("frekvens/" HOSTNAME "/+/set",
+                                       static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS2));
+    Extensions.MQTT().client.publish("frekvens/" HOSTNAME "/availability",
+                                     static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS1),
+                                     true,
+                                     "online");
 }
 
 void MqttExtension::onMessage(const espMqttClientTypes::MessageProperties &properties, // NOLINT(misc-unused-parameters)
-                              const char *topic, const uint8_t *payload, size_t len,
-                              size_t index, // NOLINT(misc-unused-parameters)
-                              size_t total) // NOLINT(misc-unused-parameters)
+                              const char *topic, const uint8_t *payload, size_t len, size_t index, size_t total)
 {
+    if (index != 0 || len != total)
+    {
+        if (index == 0)
+        {
+            buffer.resize(total);
+        }
+        std::copy_n(payload, len, buffer.begin() + static_cast<std::ptrdiff_t>(index));
+        if (index + len != total)
+        {
+            return;
+        }
+        payload = buffer.data();
+        len = buffer.size();
+    }
     JsonDocument doc; // NOLINT(misc-const-correctness)
     if (deserializeJson(doc, payload, len) == DeserializationError::Code::Ok)
     {
-        Device.receive(doc.as<JsonObjectConst>(),
-                       name,
-                       std::string(topic).substr(prefixLength, strlen(topic) - prefixLength - suffixLength).c_str());
+        const std::string_view _topic{topic};
+        Device.receive(
+            doc.as<JsonObjectConst>(), name, _topic.substr(prefixLength, _topic.size() - prefixLength - suffixLength));
     }
 }
 
 void MqttExtension::onDisconnect(espMqttClientTypes::DisconnectReason reason) // NOLINT(misc-unused-parameters)
 {
-    ESP_LOGD("Wi-Fi", "disconnected"); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGD("MQTT", "disconnected"); // NOLINT(cppcoreguidelines-avoid-do-while)
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
-    ESP_LOGV("Wi-Fi", "%s", espMqttClientTypes::disconnectReasonToString(reason));
+    ESP_LOGV("MQTT", "%s", espMqttClientTypes::disconnectReasonToString(reason));
 }
 
 void MqttExtension::onTransmit(JsonObjectConst payload, std::string_view source)
@@ -95,7 +110,8 @@ void MqttExtension::onTransmit(JsonObjectConst payload, std::string_view source)
     std::vector<char> message(length + 1);
     serializeJson(payload, message.data(), length + 1);
     client.publish(std::string("frekvens/" HOSTNAME "/").append(source).c_str(),
-                   payload["event"].isUnbound() ? 0 : 2,
+                   payload["event"].isUnbound() ? static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS0)
+                                                : static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS2),
                    false,
                    reinterpret_cast<const uint8_t *>(message.data()),
                    length);

--- a/firmware/src/extensions/MqttExtension.cpp
+++ b/firmware/src/extensions/MqttExtension.cpp
@@ -60,7 +60,7 @@ void MqttExtension::disconnect()
     }
 }
 
-void MqttExtension::onConnect(bool sessionPresent)
+void MqttExtension::onConnect(bool sessionPresent) // NOLINT(misc-unused-parameters)
 {
     ESP_LOGD("Wi-Fi", "connected"); // NOLINT(cppcoreguidelines-avoid-do-while)
     Extensions.MQTT().client.subscribe("frekvens/" HOSTNAME "/+/set",


### PR DESCRIPTION
Enhance MQTT functionality by introducing support for chunked payloads, allowing for more efficient message handling.

### Key changes
- Refactored MQTT extension to manage chunked messages.
- Updated publish and subscribe methods to accommodate chunked payloads.
- Introduced a buffer to handle incoming message segments.

### Impact
These changes improve the MQTT communication efficiency, enabling the handling of larger messages without overwhelming the system. This may affect existing message handling logic, requiring updates to accommodate the new chunking behavior.

### Issues
- Fixes #569