### PR TITLE
Clamp photocell brightness to a positive value

### DIFF
--- a/firmware/include/extensions/PhotocellExtension.h
+++ b/firmware/include/extensions/PhotocellExtension.h
@@ -9,20 +9,20 @@ class PhotocellExtension final : public ExtensionModule
 private:
     static constexpr std::string_view name{"Photocell"};
 
-    bool active = false;
-    bool direction = false;
-    bool pending = false;
+    bool active{false};
+    bool direction{false};
+    bool pending{false};
 
-    float gamma = 1.0F;
+    float gamma{1.0F};
 
-    uint8_t brightness = UINT8_MAX;
+    int16_t debounce{0};
 
-    int16_t counter = 0;
+    uint8_t brightness{UINT8_MAX};
 
-    uint16_t raw = 0;
+    uint16_t raw{0U};
 
-    unsigned long lastMillis = 0;
-    unsigned long _lastMillis = 0;
+    unsigned long lastMillis{0UL};
+    unsigned long _lastMillis{0UL};
 
     void setGamma(float _gamma);
 

--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -16,8 +16,8 @@ void PhotocellExtension::begin()
     nvs_handle_t handle{};
     if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
     {
-        size_t len{sizeof(gamma)};
-        nvs_get_blob(handle, "gamma", &gamma, &len);
+        size_t length{sizeof(gamma)};
+        nvs_get_blob(handle, "gamma", &gamma, &length);
         uint8_t _active{0U};
         if (nvs_get_u8(handle, "active", &_active) == ESP_OK)
         {

--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -16,9 +16,9 @@ void PhotocellExtension::begin()
     nvs_handle_t handle{};
     if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
     {
-        size_t len = sizeof(gamma);
+        size_t len{sizeof(gamma)};
         nvs_get_blob(handle, "gamma", &gamma, &len);
-        uint8_t _active{0};
+        uint8_t _active{0U};
         if (nvs_get_u8(handle, "active", &_active) == ESP_OK)
         {
             nvs_close(handle);
@@ -46,18 +46,20 @@ void PhotocellExtension::handle()
     {
         _lastMillis = millis();
         raw = analogRead(PIN_LDR);
-        const uint8_t _brightness = static_cast<uint8_t>(
-            powf(static_cast<float>(raw) / static_cast<float>((1U << 12U) - 1), gamma) * UINT8_MAX);
+        const uint8_t _brightness{static_cast<uint8_t>(
+            static_cast<uint16_t>(powf(static_cast<float>(raw) / static_cast<float>((1U << 12U) - 1U), gamma) *
+                                  static_cast<float>(UINT8_MAX - 1U)) +
+            1U)};
         if ((direction && _brightness < brightness) || (!direction && _brightness > brightness))
         {
             direction = !direction;
-            counter /= 2;
+            debounce /= 2;
         }
-        counter = static_cast<int16_t>(counter + _brightness - brightness);
-        if (abs(counter) > UINT8_MAX)
+        debounce += static_cast<int16_t>(_brightness - brightness);
+        if (abs(debounce) > UINT8_MAX)
         {
             brightness = _brightness;
-            counter = 0;
+            debounce = 0;
             Display.setBrightness(brightness);
         }
     }
@@ -69,7 +71,7 @@ void PhotocellExtension::setActive(bool _active)
 {
     if (_active)
     {
-        counter = 0;
+        debounce = 0;
         brightness = Display.getBrightness();
     }
     active = _active;
@@ -125,7 +127,7 @@ void PhotocellExtension::onTransmit(JsonObjectConst payload, std::string_view so
         if (_brightness != brightness)
         {
             setGamma(logf(static_cast<float>(_brightness) / static_cast<float>(1U << 8U)) /
-                     logf(static_cast<float>(raw + 1) / static_cast<float>((1U << 12U) + 1)));
+                     logf(static_cast<float>(raw + 1U) / static_cast<float>((1U << 12U) + 1U)));
         }
     }
 }

--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -55,7 +55,7 @@ void PhotocellExtension::handle()
             direction = !direction;
             debounce /= 2;
         }
-        debounce += static_cast<int16_t>(_brightness - brightness);
+        debounce = static_cast<int16_t>(debounce + _brightness - brightness);
         if (abs(debounce) > UINT8_MAX)
         {
             brightness = _brightness;

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -295,51 +295,49 @@ uint8_t DisplayService::getBrightness() const { return brightness; }
 
 void DisplayService::setBrightness(uint8_t _brightness)
 {
-    if (_brightness == 0U)
+    if (_brightness != 0U)
     {
-        setPower(false);
-        return;
-    }
-    ESP_LOGI("Action", "brightness"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        ESP_LOGI("Action", "brightness"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 #ifdef SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
-    ledcFadeGamma(
-        PIN_OE,
-        power ? max<uint16_t>(brightness,
-                              powf(static_cast<float>(brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
-                                  ((1U << depth) - 2U))
-              : 0U,
-        max<uint16_t>(_brightness,
-                      powf(static_cast<float>(_brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
-                          ((1U << depth) - 2U)),
-        (1U << 4U) *
-            abs(brightness -
-                _brightness)); // -2 offset due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGamma`.
+        ledcFadeGamma(
+            PIN_OE,
+            power ? max<uint16_t>(brightness,
+                                  powf(static_cast<float>(brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
+                                      ((1U << depth) - 2U))
+                  : 0U,
+            max<uint16_t>(_brightness,
+                          powf(static_cast<float>(_brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
+                              ((1U << depth) - 2U)),
+            (1U << 4U) *
+                abs(brightness -
+                    _brightness)); // -2 offset due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGamma`.
 #else
-    ledcFade(PIN_OE,
-             power ? max<uint16_t>(brightness,
-                                   powf(static_cast<float>(brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
-                                       ((1U << depth) - 2U))
-                   : 0U,
-             max<uint16_t>(_brightness,
-                           powf(static_cast<float>(_brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
-                               ((1U << depth) - 2U)),
-             (1U << 4U) * abs(brightness - _brightness)); // -2 offset due to `ledcFade` stability issues.
+        ledcFade(PIN_OE,
+                 power ? max<uint16_t>(brightness,
+                                       powf(static_cast<float>(brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
+                                           ((1U << depth) - 2U))
+                       : 0U,
+                 max<uint16_t>(_brightness,
+                               powf(static_cast<float>(_brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
+                                   ((1U << depth) - 2U)),
+                 (1U << 4U) * abs(brightness - _brightness)); // -2 offset due to `ledcFade` stability issues.
 #endif // SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
-    if (!power)
-    {
-        power = true;
-        Modes.setActive(true);
-        render = true;
+        if (!power)
+        {
+            power = true;
+            Modes.setActive(true);
+            render = true;
+        }
+        brightness = _brightness;
+        nvs_handle_t handle{};
+        if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
+        {
+            nvs_set_u8(handle, "brightness", brightness);
+            nvs_commit(handle);
+            nvs_close(handle);
+        }
+        pending = true;
     }
-    brightness = _brightness;
-    nvs_handle_t handle{};
-    if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
-    {
-        nvs_set_u8(handle, "brightness", brightness);
-        nvs_commit(handle);
-        nvs_close(handle);
-    }
-    pending = true;
 }
 
 void DisplayService::getFrame(std::span<uint8_t> _frame) const

--- a/firmware/src/services/DisplayService.cpp
+++ b/firmware/src/services/DisplayService.cpp
@@ -295,49 +295,46 @@ uint8_t DisplayService::getBrightness() const { return brightness; }
 
 void DisplayService::setBrightness(uint8_t _brightness)
 {
-    if (_brightness != 0U)
-    {
-        ESP_LOGI("Action", "brightness"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+    ESP_LOGI("Action", "brightness"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 #ifdef SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
-        ledcFadeGamma(
-            PIN_OE,
-            power ? max<uint16_t>(brightness,
-                                  powf(static_cast<float>(brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
-                                      ((1U << depth) - 2U))
-                  : 0U,
-            max<uint16_t>(_brightness,
-                          powf(static_cast<float>(_brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
-                              ((1U << depth) - 2U)),
-            (1U << 4U) *
-                abs(brightness -
-                    _brightness)); // -2 offset due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGamma`.
+    ledcFadeGamma(
+        PIN_OE,
+        power ? max<uint16_t>(brightness,
+                              powf(static_cast<float>(brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
+                                  ((1U << depth) - 2U))
+              : 0U,
+        max<uint16_t>(_brightness,
+                      powf(static_cast<float>(_brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
+                          ((1U << depth) - 2U)),
+        (1U << 4U) *
+            abs(brightness -
+                _brightness)); // -2 offset due to `ledcFade` stability issues. Unconfirmed for `ledcFadeGamma`.
 #else
-        ledcFade(PIN_OE,
-                 power ? max<uint16_t>(brightness,
-                                       powf(static_cast<float>(brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
-                                           ((1U << depth) - 2U))
-                       : 0U,
-                 max<uint16_t>(_brightness,
-                               powf(static_cast<float>(_brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
-                                   ((1U << depth) - 2U)),
-                 (1U << 4U) * abs(brightness - _brightness)); // -2 offset due to `ledcFade` stability issues.
+    ledcFade(PIN_OE,
+             power ? max<uint16_t>(brightness,
+                                   powf(static_cast<float>(brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
+                                       ((1U << depth) - 2U))
+                   : 0U,
+             max<uint16_t>(_brightness,
+                           powf(static_cast<float>(_brightness) / static_cast<float>(UINT8_MAX), GAMMA) *
+                               ((1U << depth) - 2U)),
+             (1U << 4U) * abs(brightness - _brightness)); // -2 offset due to `ledcFade` stability issues.
 #endif // SOC_LEDC_GAMMA_CURVE_FADE_SUPPORTED
-        if (!power)
-        {
-            power = true;
-            Modes.setActive(true);
-            render = true;
-        }
-        brightness = _brightness;
-        nvs_handle_t handle{};
-        if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
-        {
-            nvs_set_u8(handle, "brightness", brightness);
-            nvs_commit(handle);
-            nvs_close(handle);
-        }
-        pending = true;
+    if (!power)
+    {
+        power = true;
+        Modes.setActive(true);
+        render = true;
     }
+    brightness = _brightness;
+    nvs_handle_t handle{};
+    if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
+    {
+        nvs_set_u8(handle, "brightness", brightness);
+        nvs_commit(handle);
+        nvs_close(handle);
+    }
+    pending = true;
 }
 
 void DisplayService::getFrame(std::span<uint8_t> _frame) const


### PR DESCRIPTION
This pull request refactors the PhotocellExtension code and ensures that brightness values remain positive, improving stability and functionality.

### Key changes
- Refactored variable initializations for clarity.
- Implemented clamping of brightness to a positive value.

### Impact
These changes enhance the reliability of the brightness handling in the PhotocellExtension, preventing potential issues with neutral brightness value and improving overall performance.

### Issues
Fixes #582 