### PR TITLE
v2.5.0-dev0

### DIFF
--- a/firmware/include/config/version.h
+++ b/firmware/include/config/version.h
@@ -4,4 +4,4 @@
  * https://github.com/VIPnytt/Frekvens/wiki
  */
 
-#define VERSION "2.4.1"
+#define VERSION "2.5.0-dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "frekvens"
 description = "Toolbox for the Frekvens project."
-version = "2.4.1"
+version = "2.5.0.dev0"
 license = "MIT"
 classifiers = [
     "Private :: Do Not Upload",

--- a/scripts/src/config/version.py
+++ b/scripts/src/config/version.py
@@ -1,1 +1,1 @@
-VERSION: str = "2.4.1"
+VERSION: str = "2.5.0-dev0"

--- a/uv.lock
+++ b/uv.lock
@@ -401,7 +401,7 @@ wheels = [
 
 [[package]]
 name = "frekvens"
-version = "2.4.1"
+version = "2.5.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "frekvens",
-    "version": "2.4.1",
+    "version": "2.5.0-dev0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "frekvens",
-            "version": "2.4.1",
+            "version": "2.5.0-dev0",
             "license": "MIT",
             "dependencies": {
                 "@mdi/js": "7.4.47",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "frekvens",
-    "version": "2.4.1",
+    "version": "2.5.0-dev0",
     "homepage": "https://github.com/VIPnytt/Frekvens",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR bumps the internal version to `2.5.0-dev0`, marking the transition from a stable release to ongoing development on the main branch.

### Key changes

Bumped the internal version.

### Impact

Makes it clear that the main branch now represents a development version rather than a stable release.