### PR TITLE
Chunked callback support in Restful API

### DIFF
--- a/firmware/include/extensions/RestfulExtension.h
+++ b/firmware/include/extensions/RestfulExtension.h
@@ -5,13 +5,16 @@
 #include "modules/ExtensionModule.h"
 
 #include <ESPAsyncWebServer.h>
+#include <vector>
 
 class RestfulExtension final : public ExtensionModule
 {
 private:
     static constexpr std::string_view name{"Restful"};
 
-    static constexpr size_t prefixLength = sizeof("/restful/") - 1;
+    static constexpr size_t prefixLength{sizeof("/restful/") - 1ULL};
+
+    static inline std::vector<uint8_t> buffer{};
 
     static void onGet(AsyncWebServerRequest *request);
     static void onPatch(AsyncWebServerRequest *request, const uint8_t *data, size_t len, size_t index, size_t total);

--- a/firmware/src/extensions/RestfulExtension.cpp
+++ b/firmware/src/extensions/RestfulExtension.cpp
@@ -42,6 +42,7 @@ void RestfulExtension::onGet(AsyncWebServerRequest *request)
 void RestfulExtension::onPatch(AsyncWebServerRequest *request, const uint8_t *data, size_t len, size_t index,
                                size_t total)
 {
+    const bool final{index + len == total};
     if (request->contentType() == "application/json")
     {
         if (index != 0U || len != total)
@@ -51,7 +52,7 @@ void RestfulExtension::onPatch(AsyncWebServerRequest *request, const uint8_t *da
                 buffer.resize(total);
             }
             std::copy_n(data, len, buffer.begin() + static_cast<std::ptrdiff_t>(index));
-            if (index + len != total)
+            if (!final)
             {
                 return;
             }
@@ -68,7 +69,10 @@ void RestfulExtension::onPatch(AsyncWebServerRequest *request, const uint8_t *da
             return;
         }
     }
-    request->send(t_http_codes::HTTP_CODE_BAD_REQUEST);
+    else if (final)
+    {
+        request->send(t_http_codes::HTTP_CODE_BAD_REQUEST);
+    }
 }
 
 #endif // EXTENSION_RESTFUL

--- a/firmware/src/extensions/RestfulExtension.cpp
+++ b/firmware/src/extensions/RestfulExtension.cpp
@@ -17,20 +17,20 @@ void RestfulExtension::begin()
 
 void RestfulExtension::onGet(AsyncWebServerRequest *request)
 {
-    const String module = request->url().substring(prefixLength);
+    const String module{request->url().substring(prefixLength)};
     const JsonObjectConst transmits{Device.getTransmits()};
     if (module.isEmpty())
     {
-        const size_t length = measureJson(transmits);
-        std::vector<char> content(length + 1);
-        serializeJson(transmits, content.data(), length + 1);
+        const size_t length{measureJson(transmits)};
+        std::vector<char> content(length + 1U);
+        serializeJson(transmits, content.data(), length + 1U);
         request->send(t_http_codes::HTTP_CODE_OK, "application/json", content.data());
     }
     else if (transmits[module].is<JsonVariantConst>())
     {
-        const size_t length = measureJson(transmits[module]);
-        std::vector<char> content(length + 1);
-        serializeJson(transmits[module], content.data(), length + 1);
+        const size_t length{measureJson(transmits[module])};
+        std::vector<char> content(length + 1U);
+        serializeJson(transmits[module], content.data(), length + 1U);
         request->send(t_http_codes::HTTP_CODE_OK, "application/json", content.data());
     }
     else
@@ -39,21 +39,36 @@ void RestfulExtension::onGet(AsyncWebServerRequest *request)
     }
 }
 
-void RestfulExtension::onPatch(AsyncWebServerRequest *request, const uint8_t *data, size_t len,
-                               size_t index, // NOLINT(misc-unused-parameters)
-                               size_t total) // NOLINT(misc-unused-parameters)
+void RestfulExtension::onPatch(AsyncWebServerRequest *request, const uint8_t *data, size_t len, size_t index,
+                               size_t total)
 {
-    JsonDocument doc; // NOLINT(misc-const-correctness)
-    if (request->contentType() == "application/json" &&
-        deserializeJson(doc, data, len) == DeserializationError::Code::Ok)
+    if (request->contentType() == "application/json")
     {
-        Device.receive(doc.as<JsonObjectConst>(), name, request->url().substring(prefixLength).c_str());
-        request->send(t_http_codes::HTTP_CODE_NO_CONTENT);
+        if (index != 0U || len != total)
+        {
+            if (index == 0U)
+            {
+                buffer.resize(total);
+            }
+            std::copy_n(data, len, buffer.begin() + static_cast<std::ptrdiff_t>(index));
+            if (index + len != total)
+            {
+                return;
+            }
+            data = buffer.data();
+            len = buffer.size();
+        }
+        JsonDocument doc; // NOLINT(misc-const-correctness)
+        if (deserializeJson(doc, data, len) == DeserializationError::Code::Ok)
+        {
+            const String destination{request->url().substring(prefixLength)};
+            Device.receive(
+                doc.as<JsonObjectConst>(), name, std::string_view{destination.c_str(), destination.length()});
+            request->send(t_http_codes::HTTP_CODE_NO_CONTENT);
+            return;
+        }
     }
-    else
-    {
-        request->send(t_http_codes::HTTP_CODE_BAD_REQUEST);
-    }
+    request->send(t_http_codes::HTTP_CODE_BAD_REQUEST);
 }
 
 #endif // EXTENSION_RESTFUL


### PR DESCRIPTION
Enhance the RestfulExtension to support chunked callbacks for handling PATCH requests, improving data transmission efficiency.

### Key changes
- Refactored the onPatch method to handle chunked data.
- Introduced a buffer to accumulate data across multiple requests.
- Updated JSON serialization logic for better clarity and performance.

### Impact
These changes improve the handling of large data payloads in PATCH requests, allowing for more efficient data processing. This may affect existing implementations that rely on single-request data handling, necessitating adjustments for chunked data scenarios.