### PR TITLE
Chunked callback support in WebSocket API

### DIFF
--- a/firmware/include/extensions/WebSocketExtension.h
+++ b/firmware/include/extensions/WebSocketExtension.h
@@ -5,11 +5,14 @@
 #include "modules/ExtensionModule.h"
 
 #include <AsyncWebSocket.h>
+#include <vector>
 
 class WebSocketExtension final : public ExtensionModule
 {
 private:
     static constexpr std::string_view name{"WebSocket"};
+
+    static inline std::vector<uint8_t> buffer{};
 
     static void onEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventType type, void *arg,
                         const uint8_t *data, size_t len);
@@ -17,7 +20,7 @@ private:
 public:
     explicit WebSocketExtension() : ExtensionModule(name) {};
 
-    AsyncWebSocket *server = new AsyncWebSocket("/websocket");
+    AsyncWebSocket *server{new AsyncWebSocket("/websocket")};
 
     void begin() override;
     void handle() override;

--- a/firmware/src/extensions/WebSocketExtension.cpp
+++ b/firmware/src/extensions/WebSocketExtension.cpp
@@ -5,6 +5,8 @@
 #include "services/DeviceService.h"
 #include "services/WebServerService.h"
 
+#include <span>
+
 void WebSocketExtension::begin()
 {
     server->onEvent(&onEvent);
@@ -43,14 +45,15 @@ void WebSocketExtension::onEvent(AsyncWebSocket *server, // NOLINT(misc-unused-p
         const AwsFrameInfo *info{static_cast<AwsFrameInfo *>(arg)};
         if (info->message_opcode == AwsFrameType::WS_TEXT)
         {
-            if (!info->final || info->index != 0U || info->index + len != info->len)
+            if (info->final == 0U || info->index != 0U || info->index + len != info->len)
             {
                 if (info->num == 0U && info->index == 0U)
                 {
                     buffer.clear();
                 }
-                buffer.insert(buffer.end(), data, data + len);
-                if (!info->final || info->index + len != info->len)
+                const std::span<const uint8_t> chunk{data, len};
+                buffer.insert(buffer.end(), chunk.begin(), chunk.end());
+                if (info->final == 0U || info->index + len != info->len)
                 {
                     return;
                 }

--- a/firmware/src/extensions/WebSocketExtension.cpp
+++ b/firmware/src/extensions/WebSocketExtension.cpp
@@ -17,9 +17,9 @@ void WebSocketExtension::onTransmit(JsonObjectConst payload, std::string_view so
 {
     JsonDocument doc; // NOLINT(misc-const-correctness)
     doc[source].set(payload);
-    const size_t length = measureJson(doc);
-    std::vector<char> message(length + 1);
-    serializeJson(doc, message.data(), length + 1);
+    const size_t length{measureJson(doc)};
+    std::vector<char> message(length + 1U);
+    serializeJson(doc, message.data(), length + 1U);
     server->textAll(message.data(), length);
 }
 
@@ -31,17 +31,32 @@ void WebSocketExtension::onEvent(AsyncWebSocket *server, // NOLINT(misc-unused-p
     {
     case AwsEventType::WS_EVT_CONNECT:
     {
-        const JsonObjectConst transmits = Device.getTransmits();
-        const size_t length = measureJson(transmits);
-        std::vector<char> message(length + 1);
-        serializeJson(transmits, message.data(), length + 1);
+        const JsonObjectConst transmits{Device.getTransmits()};
+        const size_t length{measureJson(transmits)};
+        std::vector<char> message(length + 1U);
+        serializeJson(transmits, message.data(), length + 1U);
         client->text(message.data(), length);
     }
     break;
     case AwsEventType::WS_EVT_DATA:
     {
-        if (static_cast<AwsFrameInfo *>(arg)->opcode == AwsFrameType::WS_TEXT)
+        const AwsFrameInfo *info{static_cast<AwsFrameInfo *>(arg)};
+        if (info->message_opcode == AwsFrameType::WS_TEXT)
         {
+            if (!info->final || info->index != 0U || info->index + len != info->len)
+            {
+                if (info->num == 0U && info->index == 0U)
+                {
+                    buffer.clear();
+                }
+                buffer.insert(buffer.end(), data, data + len);
+                if (!info->final || info->index + len != info->len)
+                {
+                    return;
+                }
+                data = buffer.data();
+                len = buffer.size();
+            }
             JsonDocument doc; // NOLINT(misc-const-correctness)
             if (deserializeJson(doc, data, len) == DeserializationError::Code::Ok && doc.is<JsonObjectConst>())
             {
@@ -49,7 +64,9 @@ void WebSocketExtension::onEvent(AsyncWebSocket *server, // NOLINT(misc-unused-p
                 {
                     if (pair.value().is<JsonObjectConst>())
                     {
-                        Device.receive(pair.value().as<JsonObjectConst>(), name, pair.key().c_str());
+                        Device.receive(pair.value().as<JsonObjectConst>(),
+                                       name,
+                                       std::string_view(pair.key().c_str(), pair.key().size()));
                     }
                 }
             }


### PR DESCRIPTION
Enhances the WebSocketExtension to handle chunked data transmission, allowing for more efficient processing of incoming messages.

### Key changes
- Refactored the handling of WebSocket events to support chunked data.
- Introduced a buffer to accumulate incoming data until complete messages are received.
- Updated serialization and deserialization processes for improved performance.

### Impact
These changes improve the WebSocket's ability to manage larger messages and enhance overall responsiveness.