### PR TITLE
Fahrenheit support for RTC-modules

### DIFF
--- a/firmware/include/extensions/RtcExtension.h
+++ b/firmware/include/extensions/RtcExtension.h
@@ -17,11 +17,11 @@ private:
     static constexpr std::string_view name{"RTC"};
 
 #ifdef PIN_INT
-    static inline bool pending = true;
+    static inline bool pending{true};
 #endif
 
 #if defined(RTC_DS3231) || defined(RTC_DS3232)
-    unsigned long lastMillis = 0;
+    unsigned long lastMillis{0UL};
 #endif
 
 #if defined(RTC_DS3231) || defined(RTC_DS3232)

--- a/firmware/src/extensions/RtcExtension.cpp
+++ b/firmware/src/extensions/RtcExtension.cpp
@@ -89,8 +89,7 @@ void RtcExtension::sntpSetTimeSyncNotificationCallback(struct timeval *tv)
     const time_t timer{tv->tv_sec};
     tm utc{};
     gmtime_r(&timer, &utc);
-    rtc.SetDateTime(
-        RtcDateTime(utc->tm_year + 1900, utc->tm_mon + 1, utc->tm_mday, utc->tm_hour, utc->tm_min, utc->tm_sec));
+    rtc.SetDateTime(RtcDateTime(utc.tm_year + 1900, utc.tm_mon + 1, utc.tm_mday, utc.tm_hour, utc.tm_min, utc.tm_sec));
     ESP_LOGV("Status", "NTP synced"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 }
 

--- a/firmware/src/extensions/RtcExtension.cpp
+++ b/firmware/src/extensions/RtcExtension.cpp
@@ -22,7 +22,7 @@ void RtcExtension::configure()
         if (!getLocalTime(&local))
         {
             struct timeval tv{}; // NOLINT(misc-const-correctness)
-            tv.tv_sec = rtc.GetDateTime().Unix64Time();
+            tv.tv_sec = static_cast<time_t>(rtc.GetDateTime().Unix64Time());
             settimeofday(&tv, nullptr);
             ESP_LOGD("Status", "synced"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
         }
@@ -75,17 +75,22 @@ IRAM_ATTR void RtcExtension::onInterrupt() { pending = true; }
 void RtcExtension::transmit()
 {
     JsonDocument doc; // NOLINT(misc-const-correctness)
+#if TEMPERATURE_FAHRENHEIT
+    doc["temperature"].set(rtc.GetTemperature().AsFloatDegF());
+#else
     doc["temperature"].set(rtc.GetTemperature().AsFloatDegC());
+#endif // TEMPERATURE_FAHRENHEIT
     Device.transmit(doc.as<JsonObjectConst>(), name);
 }
 #endif // defined(RTC_DS3231) || defined(RTC_DS3232)
 
 void RtcExtension::sntpSetTimeSyncNotificationCallback(struct timeval *tv)
 {
-    const time_t timer = tv->tv_sec;
-    const tm *local = gmtime(&timer);
-    rtc.SetDateTime(RtcDateTime(
-        local->tm_year + 1900, local->tm_mon + 1, local->tm_mday, local->tm_hour, local->tm_min, local->tm_sec));
+    const time_t timer{tv->tv_sec};
+    tm utc{};
+    gmtime_r(&timer, &utc);
+    rtc.SetDateTime(
+        RtcDateTime(utc->tm_year + 1900, utc->tm_mon + 1, utc->tm_mday, utc->tm_hour, utc->tm_min, utc->tm_sec));
     ESP_LOGV("Status", "NTP synced"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 }
 
@@ -106,7 +111,11 @@ void RtcExtension::onHomeAssistant(JsonDocument &discovery, std::string topic, s
         component[HomeAssistantAbbreviations::state_class].set("measurement");
         component[HomeAssistantAbbreviations::state_topic].set(topic);
         component[HomeAssistantAbbreviations::unique_id].set(unique + id);
+#if TEMPERATURE_FAHRENHEIT
+        component[HomeAssistantAbbreviations::unit_of_measurement].set("°F");
+#else
         component[HomeAssistantAbbreviations::unit_of_measurement].set("°C");
+#endif // TEMPERATURE_FAHRENHEIT
         component[HomeAssistantAbbreviations::value_template].set("{{value_json.temperature}}");
     }
 }


### PR DESCRIPTION
Add support for Fahrenheit as a temperature unit in the RTC extension, enhancing flexibility for users who prefer this measurement.

### Key changes
- Refactor temperature handling to support both Celsius and Fahrenheit.
- Update JSON transmission to include temperature in the selected unit.
- Modify time synchronization logic for improved clarity and correctness.

### Impact
These changes allow users to choose between Celsius and Fahrenheit for temperature readings, improving usability. The refactor also enhances code readability and maintainability. No breaking changes are introduced.