### PR TITLE
OpenWeather city/village and API 4.0 support

### DIFF
--- a/docs/wiki/Weather.md
+++ b/docs/wiki/Weather.md
@@ -102,7 +102,7 @@ WEATHER_OPENWEATHER='true'
 ```
 
 > [!NOTE]
-> Location coordinates, `LATITUDE` and `LONGITUDE` are required.
+> Location coordinates `LATITUDE` and `LONGITUDE`, or a location name `LOCATION` is required.
 
 See also [Weather](https://github.com/VIPnytt/Frekvens/wiki/Modes#-weather) mode.
 

--- a/firmware/include/config/modes.h
+++ b/firmware/include/config/modes.h
@@ -29,7 +29,9 @@
 /**
  * OpenWeather
  *
- * https://openweathermap.org/api/one-call-3#start
+ * https://openweathermap.org/api/one-call-4?collection=one_call_api#current
+ * https://openweathermap.org/api/one-call-3?collection=one_call_api#current
+ * https://openweathermap.org/api/current?collection=current_forecast#one
  */
 // #define OPENWEATHER_KEY "secret"
 

--- a/firmware/include/middlewares/OpenWeatherMiddleware.h
+++ b/firmware/include/middlewares/OpenWeatherMiddleware.h
@@ -13,16 +13,36 @@ class OpenWeatherMiddleware final : public WeatherHandler
 {
 private:
     // https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2
-    static constexpr std::array<uint16_t, 1> codesClear{800};
-    static constexpr std::array<uint16_t, 1> codesCloudy{804};
-    static constexpr std::array<uint16_t, 3> codesCloudyPartly{801, 802, 803};
-    static constexpr std::array<uint16_t, 10> codesFog{701, 711, 721, 731, 741, 751, 761, 762, 771, 781};
-    static constexpr std::array<uint16_t, 19> codesRain{
-        300, 301, 302, 310, 311, 312, 313, 314, 321, 500, 501, 502, 503, 504, 511, 520, 521, 522, 531};
-    static constexpr std::array<uint16_t, 11> codesSnow{600, 601, 602, 611, 612, 613, 615, 616, 620, 621, 622};
-    static constexpr std::array<uint16_t, 10> codesThunder{200, 201, 202, 210, 211, 212, 221, 230, 231, 232};
+    static constexpr std::array<uint16_t, 1U> codesClear{800U};
+    static constexpr std::array<uint16_t, 1U> codesCloudy{804U};
+    static constexpr std::array<uint16_t, 3U> codesCloudyPartly{801U, 802U, 803U};
+    static constexpr std::array<uint16_t, 10U> codesFog{701U, 711U, 721U, 731U, 741U, 751U, 761U, 762U, 771U, 781U};
+    static constexpr std::array<uint16_t, 19U> codesRain{
+        300U,
+        301U,
+        302U,
+        310U,
+        311U,
+        312U,
+        313U,
+        314U,
+        321U,
+        500U,
+        501U,
+        502U,
+        503U,
+        504U,
+        511U,
+        520U,
+        521U,
+        522U,
+        531U,
+    };
+    static constexpr std::array<uint16_t, 11U> codesSnow{
+        600U, 601U, 602U, 611U, 612U, 613U, 615U, 616U, 620U, 621U, 622U};
+    static constexpr std::array<uint16_t, 10U> codesThunder{200U, 201U, 202U, 210U, 211U, 212U, 221U, 230U, 231U, 232U};
 
-    static constexpr std::array<WeatherHandler::Codeset16, 7> codesets{{
+    static constexpr std::array<WeatherHandler::Codeset16, 7U> codesets{{
         {WeatherHandler::Conditions::CLEAR, codesClear},
         {WeatherHandler::Conditions::CLOUDY, codesCloudy},
         {WeatherHandler::Conditions::CLOUDY_PARTLY, codesCloudyPartly},
@@ -32,48 +52,87 @@ private:
         {WeatherHandler::Conditions::THUNDER, codesThunder},
     }};
 
-    // https://openweathermap.org/api/one-call-3#current
-    // https://openweathermap.org/current#one
+    // https://openweathermap.org/api/one-call-4?collection=one_call_api#current
+    // https://openweathermap.org/api/one-call-3?collection=one_call_api#current
+    // https://openweathermap.org/api/current?collection=current_forecast#one
     static inline std::vector<std::pair<const char *, const char *>> parts{
-        {
-            "/data/3.0/onecall",
-            "lat=" LATITUDE "&lon=" LONGITUDE "&exclude=alerts,daily,hourly,minutely&appid=" OPENWEATHER_KEY,
-        },
+#if defined(LOCATION) && TEMPERATURE_CELSIUS
         {
             "/data/2.5/weather",
-            "lat=" LATITUDE "&lon=" LONGITUDE "&appid=" OPENWEATHER_KEY,
+            "q=" LOCATION "&units=metric&appid=" OPENWEATHER_KEY,
         },
-#if TEMPERATURE_KELVIN
-        {
-            "/data/3.0/onecall",
-            "lat=" LATITUDE "&lon=" LONGITUDE
-            "&exclude=alerts,daily,hourly,minutely&units=standard&appid=" OPENWEATHER_KEY,
-        },
+#elif defined(LOCATION) && TEMPERATURE_FAHRENHEIT
         {
             "/data/2.5/weather",
-            "lat=" LATITUDE "&lon=" LONGITUDE "&units=standard&appid=" OPENWEATHER_KEY,
+            "q=" LOCATION "&units=imperial&appid=" OPENWEATHER_KEY,
         },
-#elif TEMPERATURE_CELSIUS
+#elif defined(LOCATION) && TEMPERATURE_KELVIN
+        {
+            "/data/2.5/weather",
+            "q=" LOCATION "&units=standard&appid=" OPENWEATHER_KEY,
+        },
+#elif defined(LOCATION)
+        {
+            "/data/2.5/weather",
+            "q=" LOCATION "&appid=" OPENWEATHER_KEY,
+        },
+#endif // defined(LOCATION) && TEMPERATURE_CELSIUS
+#if defined(LATITUDE) && defined(LONGITUDE) && TEMPERATURE_CELSIUS
         {
             "/data/3.0/onecall",
             "lat=" LATITUDE "&lon=" LONGITUDE
             "&exclude=alerts,daily,hourly,minutely&units=metric&appid=" OPENWEATHER_KEY,
         },
         {
+            "/data/4.0/onecall/current",
+            "lat=" LATITUDE "&lon=" LONGITUDE "&units=metric&appid=" OPENWEATHER_KEY,
+        },
+        {
             "/data/2.5/weather",
             "lat=" LATITUDE "&lon=" LONGITUDE "&units=metric&appid=" OPENWEATHER_KEY,
         },
-#elif TEMPERATURE_FAHRENHEIT
+#elif defined(LATITUDE) && defined(LONGITUDE) && TEMPERATURE_FAHRENHEIT
         {
             "/data/3.0/onecall",
             "lat=" LATITUDE "&lon=" LONGITUDE
             "&exclude=alerts,daily,hourly,minutely&units=imperial&appid=" OPENWEATHER_KEY,
         },
         {
+            "/data/4.0/onecall/current",
+            "lat=" LATITUDE "&lon=" LONGITUDE "&units=imperial&appid=" OPENWEATHER_KEY,
+        },
+        {
             "/data/2.5/weather",
             "lat=" LATITUDE "&lon=" LONGITUDE "&units=imperial&appid=" OPENWEATHER_KEY,
         },
-#endif // TEMPERATURE_KELVIN
+#elif defined(LATITUDE) && defined(LONGITUDE) && TEMPERATURE_KELVIN
+        {
+            "/data/3.0/onecall",
+            "lat=" LATITUDE "&lon=" LONGITUDE
+            "&exclude=alerts,daily,hourly,minutely&units=standard&appid=" OPENWEATHER_KEY,
+        },
+        {
+            "/data/4.0/onecall/current",
+            "lat=" LATITUDE "&lon=" LONGITUDE "&units=standard&appid=" OPENWEATHER_KEY,
+        },
+        {
+            "/data/2.5/weather",
+            "lat=" LATITUDE "&lon=" LONGITUDE "&units=standard&appid=" OPENWEATHER_KEY,
+        },
+#elif defined(LATITUDE) && defined(LONGITUDE)
+        {
+            "/data/3.0/onecall",
+            "lat=" LATITUDE "&lon=" LONGITUDE "&exclude=alerts,daily,hourly,minutely&appid=" OPENWEATHER_KEY,
+        },
+        {
+            "/data/4.0/onecall/current",
+            "lat=" LATITUDE "&lon=" LONGITUDE "&appid=" OPENWEATHER_KEY,
+        },
+        {
+            "/data/2.5/weather",
+            "lat=" LATITUDE "&lon=" LONGITUDE "&appid=" OPENWEATHER_KEY,
+        },
+#endif // defined(LATITUDE) && defined(LONGITUDE) && TEMPERATURE_CELSIUS
     };
 
 public:

--- a/firmware/src/middlewares/OpenWeatherMiddleware.cpp
+++ b/firmware/src/middlewares/OpenWeatherMiddleware.cpp
@@ -15,29 +15,38 @@ void OpenWeatherMiddleware::update(std::optional<WeatherHandler::Conditions> &co
     path = parts.back().first;
     query = parts.back().second;
     std::vector<char> body;
-    const int status = fetch(body, lastMillis);
+    const int status{fetch(body, lastMillis)};
     if (status != 200)
     {
         if (status >= 400 && status < 500)
         {
             parts.pop_back();
-            lastMillis = millis() - interval + (1U << 12U);
+            lastMillis = millis() - interval + (0b1U << 12U);
         }
         return;
     }
     JsonDocument filter; // NOLINT(misc-const-correctness)
     filter["current"]["temp"].set(true);
     filter["current"]["weather"]["id"].set(true);
+    filter["data"][0U]["temp"].set(true);
+    filter["data"][0U]["weather"][0U]["id"].set(true);
     filter["main"]["temp"].set(true);
-    filter["weather"][0]["id"].set(true);
+    filter["weather"][0U]["id"].set(true);
     JsonDocument doc; // NOLINT(misc-const-correctness)
-    const bool deserialization =
-        deserializeJson(doc, body.data(), DeserializationOption::Filter(filter)) == DeserializationError::Code::Ok;
-    if (deserialization && doc["main"]["temp"].is<float>() && doc["weather"][0]["id"].is<uint16_t>())
+    const bool deserialization{deserializeJson(doc, body.data(), DeserializationOption::Filter(filter)) ==
+                               DeserializationError::Code::Ok};
+    if (deserialization && doc["main"]["temp"].is<float>() && doc["weather"][0U]["id"].is<uint16_t>())
     {
         // API 2.5
-        condition = getCondition(doc["weather"][0]["id"].as<uint16_t>(), codesets);
+        condition = getCondition(doc["weather"][0U]["id"].as<uint16_t>(), codesets);
         temperature = static_cast<int16_t>(lroundf(doc["main"]["temp"].as<float>()));
+        return;
+    }
+    if (deserialization && doc["data"][0U]["temp"].is<float>() && doc["data"][0U]["weather"][0U]["id"].is<uint16_t>())
+    {
+        // API 4.0
+        condition = getCondition(doc["data"][0U]["weather"][0U]["id"].as<uint16_t>(), codesets);
+        temperature = static_cast<int16_t>(lroundf(doc["data"][0U]["temp"].as<float>()));
         return;
     }
     if (deserialization && doc["current"]["temp"].is<float>() && doc["current"]["weather"]["id"].is<uint16_t>())
@@ -49,7 +58,7 @@ void OpenWeatherMiddleware::update(std::optional<WeatherHandler::Conditions> &co
     }
     parts.pop_back();
     ESP_LOGD("Response", "unsupported format"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-    lastMillis = millis() - interval + (1U << 13U);
+    lastMillis = millis() - interval + (0b1U << 13U);
 }
 
 #endif // WEATHER_OPENWEATHER

--- a/firmware/src/middlewares/OpenWeatherMiddleware.cpp
+++ b/firmware/src/middlewares/OpenWeatherMiddleware.cpp
@@ -26,12 +26,12 @@ void OpenWeatherMiddleware::update(std::optional<WeatherHandler::Conditions> &co
         return;
     }
     JsonDocument filter; // NOLINT(misc-const-correctness)
-    filter["current"]["temp"].set(true);
-    filter["current"]["weather"]["id"].set(true);
-    filter["data"][0U]["temp"].set(true);
-    filter["data"][0U]["weather"][0U]["id"].set(true);
-    filter["main"]["temp"].set(true);
-    filter["weather"][0U]["id"].set(true);
+    filter["current"]["temp"].set(true);               // API 3.0
+    filter["current"]["weather"][0U]["id"].set(true);  // API 3.0
+    filter["data"][0U]["temp"].set(true);              // API 4.0
+    filter["data"][0U]["weather"][0U]["id"].set(true); // API 4.0
+    filter["main"]["temp"].set(true);                  // API 2.5
+    filter["weather"][0U]["id"].set(true);             // API 2.5
     JsonDocument doc; // NOLINT(misc-const-correctness)
     const bool deserialization{deserializeJson(doc, body.data(), DeserializationOption::Filter(filter)) ==
                                DeserializationError::Code::Ok};
@@ -49,10 +49,10 @@ void OpenWeatherMiddleware::update(std::optional<WeatherHandler::Conditions> &co
         temperature = static_cast<int16_t>(lroundf(doc["data"][0U]["temp"].as<float>()));
         return;
     }
-    if (deserialization && doc["current"]["temp"].is<float>() && doc["current"]["weather"]["id"].is<uint16_t>())
+    if (deserialization && doc["current"]["temp"].is<float>() && doc["current"]["weather"][0U]["id"].is<uint16_t>())
     {
         // API 3.0
-        condition = getCondition(doc["current"]["weather"]["id"].as<uint16_t>(), codesets);
+        condition = getCondition(doc["current"]["weather"][0U]["id"].as<uint16_t>(), codesets);
         temperature = static_cast<int16_t>(lroundf(doc["current"]["temp"].as<float>()));
         return;
     }

--- a/firmware/src/middlewares/OpenWeatherMiddleware.cpp
+++ b/firmware/src/middlewares/OpenWeatherMiddleware.cpp
@@ -25,14 +25,14 @@ void OpenWeatherMiddleware::update(std::optional<WeatherHandler::Conditions> &co
         }
         return;
     }
-    JsonDocument filter; // NOLINT(misc-const-correctness)
+    JsonDocument filter;                               // NOLINT(misc-const-correctness)
     filter["current"]["temp"].set(true);               // API 3.0
     filter["current"]["weather"][0U]["id"].set(true);  // API 3.0
     filter["data"][0U]["temp"].set(true);              // API 4.0
     filter["data"][0U]["weather"][0U]["id"].set(true); // API 4.0
     filter["main"]["temp"].set(true);                  // API 2.5
     filter["weather"][0U]["id"].set(true);             // API 2.5
-    JsonDocument doc; // NOLINT(misc-const-correctness)
+    JsonDocument doc;                                  // NOLINT(misc-const-correctness)
     const bool deserialization{deserializeJson(doc, body.data(), DeserializationOption::Filter(filter)) ==
                                DeserializationError::Code::Ok};
     if (deserialization && doc["main"]["temp"].is<float>() && doc["weather"][0U]["id"].is<uint16_t>())


### PR DESCRIPTION
Enhances the OpenWeatherMiddleware to support location-based queries using city or village names, alongside the existing latitude and longitude method. This update also integrates support for the new API 4.0.

### Key changes
- Updated the API calls to accommodate location names.
- Refactored code to support API 4.0 alongside previous versions.
- Improved documentation to clarify optional location input.

### Impact
These changes provide users with more flexible options for weather queries, improving usability. The introduction of API 4.0 support is future-proofing ensuring robustness and resilience against upstream changes. Compatibility with previous API versions is maintained.