### PR TITLE
Waveform silence indicator

### DIFF
--- a/firmware/include/modes/WaveformMode.h
+++ b/firmware/include/modes/WaveformMode.h
@@ -164,6 +164,7 @@ private:
 
     unsigned long lastMillis{0UL};
 
+    void draw();
     void setWave(std::string_view waveName);
 
     void transmit();

--- a/firmware/src/modes/WaveformMode.cpp
+++ b/firmware/src/modes/WaveformMode.cpp
@@ -2,7 +2,6 @@
 
 #include "modes/WaveformMode.h"
 
-#include "extensions/MicrophoneExtension.h"
 #include "handlers/BitmapHandler.h" // NOLINT(misc-include-cleaner)
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
@@ -28,17 +27,32 @@ void WaveformMode::configure()
 
 void WaveformMode::handle()
 {
-#if EXTENSION_MICROPHONE
-    if (millis() - lastMillis > (1UL << 9U) && Extensions.Microphone().isTriggered())
-#else
-    if (millis() - lastMillis > (1UL << 9U))
-#endif // EXTENSION_MICROPHONE
+    if (millis() - lastMillis > (0b1U << 9U))
     {
-        lastMillis = millis();
         Display.clearFrame();
-        const std::span<const std::span<const uint16_t>> &_wave{waves[static_cast<size_t>(wave)]};
-        BitmapHandler(_wave[random(_wave.size())]).draw();
+#if EXTENSION_MICROPHONE
+        if (Extensions.Microphone().isTriggered())
+        {
+            draw();
+        }
+        else
+        {
+            for (uint8_t x{0U}; x < GRID_COLUMNS; ++x)
+            {
+                Display.setPixel(x, GRID_ROWS / 2U);
+            }
+        }
+#else
+        draw();
+#endif // EXTENSION_MICROPHONE
+        lastMillis = millis();
     }
+}
+
+void WaveformMode::draw()
+{
+    const std::span<const std::span<const uint16_t>> &_wave{waves[static_cast<size_t>(wave)]};
+    BitmapHandler(_wave[random(_wave.size())]).draw();
 }
 
 void WaveformMode::setWave(std::string_view waveName)


### PR DESCRIPTION
This update introduces a visual indicator for silence when the microphone is in use, enhancing visuals when the Waveform reacts to sounds.

### Key changes
- Added a code snippet to draw a straight line when no audio is detected.
- Refactored the handling logic to differentiate between microphone input and silence.

### Impact
These changes improve the user experience by providing a clear visual cue during periods of silence, which better represent the audio status.