### PR TITLE
Refactor font handling for readability and maintainability

### DIFF
--- a/extra/Python/FontGenerator.py
+++ b/extra/Python/FontGenerator.py
@@ -4,7 +4,6 @@
 
 import argparse
 import fontTools.ttLib
-import logging
 import matplotlib.font_manager
 import pathlib
 import PIL.Image
@@ -114,13 +113,21 @@ class FontGenerator:
                 cp = ord(character)
                 comment = unicodedata.name(character)
                 self.characters[character] = (offsetX, offsetY, comment)
+                prefix = (
+                    "    // "
+                    if character
+                    in {
+                        "∪",  # UNION
+                    }
+                    else ""
+                )
                 h.append(f"    // 0x{cp:X}, {character} {comment}")
                 h.append(
-                    f"    static constexpr std::array<uint{max(8, 1 << (len(bitmap[0]) - 1).bit_length())}_t, {len(bitmap)}U> {''.join(word.title() if i else word.lower() for i, word in enumerate(comment.replace('-', ' ').split()))}{{"
+                    f"    {prefix}static constexpr std::array<uint{max(8, 1 << (len(bitmap[0]) - 1).bit_length())}_t, {len(bitmap)}U> {''.join(word.title() if i else word.lower() for i, word in enumerate(comment.replace('-', ' ').split()))}{{"
                 )
                 for row in bitmap:
-                    h.append(f"        0b{row}U,")
-                h.append("    };")
+                    h.append(f"    {prefix}    0b{row}U,")
+                h.append(f"    {prefix}}};")
                 h.append("")
         h.extend(
             [
@@ -150,31 +157,31 @@ class FontGenerator:
             "    switch (character)",
             "    {",
         ]
-        count = 0
-        ignore = ""
+        literal = ""
+        prefix = ""
         for character, (offsetX, offsetY, comment) in self.characters.items():
-            cp = ord(character)
             escape = (
                 "\\"
                 if character
                 in {
-                    "'",
-                    "\\",
+                    "'",  # APOSTROPHE
+                    "\\",  # REVERSE SOLIDUS
                 }
                 else ""
             )
-            unicode = "U" if cp >= 1 << 7 else ""
-            if count == (1 << 7):
-                ignore = "    // "
-            count += 1
-            cpp.append(f"    {ignore}case {unicode}'{escape + character}': // {comment}")
-            cpp.append(
-                f"    {ignore}    return {{{''.join(word.title() if i else word.lower() for i, word in enumerate(comment.replace('-', ' ').split()))}, {offsetX}U, {offsetY}}};"
+            variable = "".join(
+                word.title() if i else word.lower() for i, word in enumerate(comment.replace("-", " ").split())
             )
+            if ord(character) >= 1 << 7:
+                literal = "U"
+                prefix = "    // "
+            cpp.append(f"    {prefix}case {literal}'{escape + character}': // {comment}")
+            cpp.append(f"    {prefix}    return {{{variable}, {offsetX}U, {offsetY}}};")
         cpp.extend(
             [
+                "    default:",
+                "        return {};",
                 "    }",
-                "    return {};",
                 "}",
                 "",
             ]

--- a/extra/Python/FontGenerator.py
+++ b/extra/Python/FontGenerator.py
@@ -14,28 +14,13 @@ import unicodedata
 
 
 class FontGenerator:
-    characters: dict[int, tuple[int, int, str | None]]
+    characters: dict[str, tuple[int, int, str]]
     path: pathlib.Path
     size: int
 
     def __init__(self, path: pathlib.Path | str, size: int = 8) -> None:
         self.path = pathlib.Path(path)
         self.size = size
-
-    def _character_to_description(self, character: str) -> str | None:
-        if character.isprintable() and character.strip() and ord(character) != 0x5C:
-            if ord(character) >= 0x80:
-                try:
-                    return f"{character} {unicodedata.name(character)}"
-                except ValueError as e:
-                    logging.debug("Character name for %s not found: %s", character, e)
-            return character
-        else:
-            try:
-                return unicodedata.name(character)
-            except ValueError as e:
-                logging.debug("Character name for %s not found: %s", character, e)
-                return None
 
     def _characters_to_bitmaps(self, characters: list[str], index: int = 0) -> dict[str, list[str]]:
         bitmaps = {}
@@ -86,13 +71,12 @@ class FontGenerator:
                     codepoints.update(table.cmap.keys())
         characters = []
         for codepoint in sorted(codepoints):
-            try:
-                characters.append(chr(codepoint))
-            except ValueError:
-                continue
+            character = chr(codepoint)
+            if character.isprintable() and character.strip():
+                characters.append(character)
         return characters
 
-    def source(self) -> list[str]:
+    def source(self) -> set[str]:
         self.characters = {}
         unique = self.path.stem
         name = unique
@@ -102,10 +86,10 @@ class FontGenerator:
                     name = record.toUnicode()
                 elif record.nameID == 6:
                     unique = record.toUnicode()
-        return [
+        return {
             self._source_h(unique, name),
             self._source_cpp(unique),
-        ]
+        }
 
     def _source_h(self, unique: str, name: str) -> str:
         h = [
@@ -128,27 +112,24 @@ class FontGenerator:
             bitmap, offsetX, offsetY = self._crop(bitmaps[character])
             if bitmap:
                 cp = ord(character)
-                comment = self._character_to_description(character)
-                self.characters[cp] = (offsetX, offsetY, comment)
-                if comment:
-                    h.append(f"    // 0x{cp:X}, {comment}")
-                else:
-                    h.append(f"    // 0x{cp:X}")
+                comment = unicodedata.name(character)
+                self.characters[character] = (offsetX, offsetY, comment)
+                h.append(f"    // 0x{cp:X}, {character} {comment}")
                 h.append(
-                    f"    static constexpr std::array<uint{max(8, 1 << (len(bitmap[0]) - 1).bit_length())}_t, {len(bitmap)}> _{cp:X} = {{"
+                    f"    static constexpr std::array<uint{max(8, 1 << (len(bitmap[0]) - 1).bit_length())}_t, {len(bitmap)}U> {''.join(word.title() if i else word.lower() for i, word in enumerate(comment.replace('-', ' ').split()))}{{"
                 )
                 for row in bitmap:
-                    h.append(f"        0b{row},")
+                    h.append(f"        0b{row}U,")
                 h.append("    };")
                 h.append("")
         h.extend(
             [
                 "public:",
-                f'    static constexpr std::string_view name = "{name}";',
+                f'    static constexpr std::string_view name{{"{name}"}};',
                 "",
                 f"    explicit {unique}Font() : FontModule(name) {{}};",
                 "",
-                "    [[nodiscard]] Symbol getChar(uint32_t character) const override;",
+                "    [[nodiscard]] Symbol getChar(char32_t character) const override;",
                 "};",
                 "",
             ]
@@ -164,22 +145,32 @@ class FontGenerator:
             "// @warning Automatically generated file",
             "//",
             "",
-            f"FontModule::Symbol {unique}Font::getChar(uint32_t character) const",
+            f"FontModule::Symbol {unique}Font::getChar(char32_t character) const",
             "{",
             "    switch (character)",
             "    {",
         ]
         count = 0
-        prefix = ""
-        for cp, (offsetX, offsetY, comment) in self.characters.items():
+        ignore = ""
+        for character, (offsetX, offsetY, comment) in self.characters.items():
+            cp = ord(character)
+            escape = (
+                "\\"
+                if character
+                in {
+                    "'",
+                    "\\",
+                }
+                else ""
+            )
+            unicode = "U" if cp >= 1 << 7 else ""
             if count == (1 << 7):
-                prefix = "    // "
+                ignore = "    // "
             count += 1
-            if comment:
-                cpp.append(f"    {prefix}case 0x{cp:X}: // {comment}")
-            else:
-                cpp.append(f"    {prefix}case 0x{cp:X}:")
-            cpp.append(f"    {prefix}    return {{_{cp:X}, {offsetX}, {offsetY}}};")
+            cpp.append(f"    {ignore}case {unicode}'{escape + character}': // {comment}")
+            cpp.append(
+                f"    {ignore}    return {{{''.join(word.title() if i else word.lower() for i, word in enumerate(comment.replace('-', ' ').split()))}, {offsetX}U, {offsetY}}};"
+            )
         cpp.extend(
             [
                 "    }",
@@ -213,7 +204,7 @@ def main() -> None:
         }.items()
         if value is not None
     }
-    paths: list[str] = []
+    paths: set[str] = set()
     if input_path.is_file():
         paths = FontGenerator(**kwargs).source()
     else:

--- a/extra/Python/FontGenerator.py
+++ b/extra/Python/FontGenerator.py
@@ -13,7 +13,7 @@ import unicodedata
 
 
 class FontGenerator:
-    characters: dict[str, tuple[int, int, str]]
+    characters: dict[str, tuple[str, int, int]]
     path: pathlib.Path
     size: int
 
@@ -78,19 +78,19 @@ class FontGenerator:
     def source(self) -> set[str]:
         self.characters = {}
         unique = self.path.stem
-        name = unique
+        friendly = unique
         with fontTools.ttLib.TTFont(self.path) as font:
             for record in font["name"].names:
                 if record.nameID == 4:
-                    name = record.toUnicode()
+                    friendly = record.toUnicode()
                 elif record.nameID == 6:
                     unique = record.toUnicode()
         return {
-            self._source_h(unique, name),
+            self._source_h(unique, friendly),
             self._source_cpp(unique),
         }
 
-    def _source_h(self, unique: str, name: str) -> str:
+    def _source_h(self, unique: str, friendly: str) -> str:
         h = [
             "#pragma once",
             "",
@@ -111,19 +111,21 @@ class FontGenerator:
             bitmap, offsetX, offsetY = self._crop(bitmaps[character])
             if bitmap:
                 cp = ord(character)
-                comment = unicodedata.name(character)
-                self.characters[character] = (offsetX, offsetY, comment)
+                name = unicodedata.name(character)
+                self.characters[character] = (name, offsetX, offsetY)
                 prefix = (
                     "    // "
                     if character
                     in {
-                        "∪",  # UNION
+                        "∪",  # U+222A UNION
+                        "⊨",  # U+22A8 TRUE
+                        "⊻",  # U+22BB XOR
                     }
                     else ""
                 )
-                h.append(f"    // 0x{cp:X}, {character} {comment}")
+                h.append(f"    // U+{cp:04X} {character} {name}")
                 h.append(
-                    f"    {prefix}static constexpr std::array<uint{max(8, 1 << (len(bitmap[0]) - 1).bit_length())}_t, {len(bitmap)}U> {''.join(word.title() if i else word.lower() for i, word in enumerate(comment.replace('-', ' ').split()))}{{"
+                    f"    {prefix}static constexpr std::array<uint{max(8, 1 << (len(bitmap[0]) - 1).bit_length())}_t, {len(bitmap)}U> {''.join(word.title() if i else word.lower() for i, word in enumerate(name.replace('-', ' ').split()))}{{"
                 )
                 for row in bitmap:
                     h.append(f"    {prefix}    0b{row}U,")
@@ -132,7 +134,7 @@ class FontGenerator:
         h.extend(
             [
                 "public:",
-                f'    static constexpr std::string_view name{{"{name}"}};',
+                f'    static constexpr std::string_view name{{"{friendly}"}};',
                 "",
                 f"    explicit {unique}Font() : FontModule(name) {{}};",
                 "",
@@ -159,23 +161,24 @@ class FontGenerator:
         ]
         literal = ""
         prefix = ""
-        for character, (offsetX, offsetY, comment) in self.characters.items():
+        for character, (name, offsetX, offsetY) in self.characters.items():
+            codepoint = ord(character)
             escape = (
                 "\\"
                 if character
                 in {
-                    "'",  # APOSTROPHE
-                    "\\",  # REVERSE SOLIDUS
+                    "'",  # U+0027 APOSTROPHE
+                    "\\",  # U+005C REVERSE SOLIDUS
                 }
                 else ""
             )
             variable = "".join(
-                word.title() if i else word.lower() for i, word in enumerate(comment.replace("-", " ").split())
+                word.title() if i else word.lower() for i, word in enumerate(name.replace("-", " ").split())
             )
-            if ord(character) >= 1 << 7:
+            if codepoint >= 1 << 7:
                 literal = "U"
                 prefix = "    // "
-            cpp.append(f"    {prefix}case {literal}'{escape + character}': // {comment}")
+            cpp.append(f"    {prefix}case {literal}'{escape + character}': // U+{codepoint:04X} {name}")
             cpp.append(f"    {prefix}    return {{{variable}, {offsetX}U, {offsetY}}};")
         cpp.extend(
             [

--- a/extra/Python/FontGenerator.py
+++ b/extra/Python/FontGenerator.py
@@ -110,26 +110,25 @@ class FontGenerator:
         for character in bitmaps:
             bitmap, offsetX, offsetY = self._crop(bitmaps[character])
             if bitmap:
-                cp = ord(character)
+                codepoint = ord(character)
                 name = unicodedata.name(character)
                 self.characters[character] = (name, offsetX, offsetY)
-                prefix = (
-                    "    // "
-                    if character
-                    in {
-                        "∪",  # U+222A UNION
-                        "⊨",  # U+22A8 TRUE
-                        "⊻",  # U+22BB XOR
-                    }
-                    else ""
-                )
-                h.append(f"    // U+{cp:04X} {character} {name}")
+                comment = character in {
+                    "∪",  # U+222A UNION
+                    "⊨",  # U+22A8 TRUE
+                    "⊻",  # U+22BB XOR
+                }
+                if comment:
+                    h.append("    /*")
+                h.append(f"    // U+{codepoint:04X} {character} {name}")
                 h.append(
-                    f"    {prefix}static constexpr std::array<uint{max(8, 1 << (len(bitmap[0]) - 1).bit_length())}_t, {len(bitmap)}U> {''.join(word.title() if i else word.lower() for i, word in enumerate(name.replace('-', ' ').split()))}{{"
+                    f"    static constexpr std::array<uint{max(8, 1 << (len(bitmap[0]) - 1).bit_length())}_t, {len(bitmap)}U> {''.join(word.title() if i else word.lower() for i, word in enumerate(name.replace('-', ' ').split()))}{{"
                 )
                 for row in bitmap:
-                    h.append(f"    {prefix}    0b{row}U,")
-                h.append(f"    {prefix}}};")
+                    h.append(f"        0b{row}U,")
+                h.append("    };")
+                if comment:
+                    h.append("    */")
                 h.append("")
         h.extend(
             [
@@ -160,7 +159,7 @@ class FontGenerator:
             "    {",
         ]
         literal = ""
-        prefix = ""
+        comment = ""
         for character, (name, offsetX, offsetY) in self.characters.items():
             codepoint = ord(character)
             escape = (
@@ -177,9 +176,9 @@ class FontGenerator:
             )
             if codepoint >= 1 << 7:
                 literal = "U"
-                prefix = "    // "
-            cpp.append(f"    {prefix}case {literal}'{escape + character}': // U+{codepoint:04X} {name}")
-            cpp.append(f"    {prefix}    return {{{variable}, {offsetX}U, {offsetY}}};")
+                comment = "    // "
+            cpp.append(f"    {comment}case {literal}'{escape + character}': // U+{codepoint:04X} {name}")
+            cpp.append(f"    {comment}    return {{{variable}, {offsetX}U, {offsetY}}};")
         cpp.extend(
             [
                 "    default:",

--- a/firmware/include/fonts/BrailleFont.h
+++ b/firmware/include/fonts/BrailleFont.h
@@ -10,93 +10,93 @@ class BrailleFont final : public FontModule
 {
 private:
     static constexpr std::array<uint8_t, 26U> latinLetterA_latinLetterZ{
-        // 0x31, 1 DIGIT ONE
-        // 0x41, A LATIN CAPITAL LETTER A
-        // 0x61, a LATIN SMALL LETTER A
+        // U+0031 1 DIGIT ONE
+        // U+0041 A LATIN CAPITAL LETTER A
+        // U+0061 a LATIN SMALL LETTER A
         0b10'00'00U,
-        // 0x32, 2 DIGIT TWO
-        // 0x42, B LATIN CAPITAL LETTER B
-        // 0x62, b LATIN SMALL LETTER B
+        // U+0032 2 DIGIT TWO
+        // U+0042 B LATIN CAPITAL LETTER B
+        // U+0062 b LATIN SMALL LETTER B
         0b10'10'00U,
-        // 0x33, 3 DIGIT THREE
-        // 0x43, C LATIN CAPITAL LETTER C
-        // 0x63, c LATIN SMALL LETTER C
+        // U+0033 3 DIGIT THREE
+        // U+0043 C LATIN CAPITAL LETTER C
+        // U+0063 c LATIN SMALL LETTER C
         0b11'00'00U,
-        // 0x34, 4 DIGIT FOUR
-        // 0x44, D LATIN CAPITAL LETTER D
-        // 0x64, d LATIN SMALL LETTER D
+        // U+0034 4 DIGIT FOUR
+        // U+0044 D LATIN CAPITAL LETTER D
+        // U+0064 d LATIN SMALL LETTER D
         0b11'01'00U,
-        // 0x35, 5 DIGIT FIVE
-        // 0x45, E LATIN CAPITAL LETTER E
-        // 0x65, e LATIN SMALL LETTER E
+        // U+0035 5 DIGIT FIVE
+        // U+0045 E LATIN CAPITAL LETTER E
+        // U+0065 e LATIN SMALL LETTER E
         0b10'01'00U,
-        // 0x36, 6 DIGIT SIX
-        // 0x46, F LATIN CAPITAL LETTER F
-        // 0x66, f LATIN SMALL LETTER F
+        // U+0036 6 DIGIT SIX
+        // U+0046 F LATIN CAPITAL LETTER F
+        // U+0066 f LATIN SMALL LETTER F
         0b11'10'00U,
-        // 0x37, 7 DIGIT SEVEN
-        // 0x47, G LATIN CAPITAL LETTER G
-        // 0x67, g LATIN SMALL LETTER G
+        // U+0037 7 DIGIT SEVEN
+        // U+0047 G LATIN CAPITAL LETTER G
+        // U+0067 g LATIN SMALL LETTER G
         0b11'11'00U,
-        // 0x38, 8 DIGIT EIGHT
-        // 0x48, H LATIN CAPITAL LETTER H
-        // 0x68, h LATIN SMALL LETTER H
+        // U+0038 8 DIGIT EIGHT
+        // U+0048 H LATIN CAPITAL LETTER H
+        // U+0068 h LATIN SMALL LETTER H
         0b10'1100U,
-        // 0x39, 9 DIGIT NINE
-        // 0x49, I LATIN CAPITAL LETTER I
-        // 0x69, i LATIN SMALL LETTER I
+        // U+0039 9 DIGIT NINE
+        // U+0049 I LATIN CAPITAL LETTER I
+        // U+0069 i LATIN SMALL LETTER I
         0b01'10'00U,
-        // 0x30, 0 DIGIT ZERO
-        // 0x4A, J LATIN CAPITAL LETTER J
-        // 0x6A, j LATIN SMALL LETTER J
+        // U+0030 0 DIGIT ZERO
+        // U+004A J LATIN CAPITAL LETTER J
+        // U+006A j LATIN SMALL LETTER J
         0b11'10'0U,
-        // 0x4B, K LATIN CAPITAL LETTER K
-        // 0x6B, k LATIN SMALL LETTER K
+        // U+004B K LATIN CAPITAL LETTER K
+        // U+006B k LATIN SMALL LETTER K
         0b10'00'10U,
-        // 0x4C, L LATIN CAPITAL LETTER L
-        // 0x6C, l LATIN SMALL LETTER L
+        // U+004C L LATIN CAPITAL LETTER L
+        // U+006C l LATIN SMALL LETTER L
         0b10'10'10U,
-        // 0x4D, M LATIN CAPITAL LETTER M
-        // 0x6D, m LATIN SMALL LETTER M
+        // U+004D M LATIN CAPITAL LETTER M
+        // U+006D m LATIN SMALL LETTER M
         0b11'00'10U,
-        // 0x4E, N LATIN CAPITAL LETTER N
-        // 0x6E, n LATIN SMALL LETTER N
+        // U+004E N LATIN CAPITAL LETTER N
+        // U+006E n LATIN SMALL LETTER N
         0b11'01'10U,
-        // 0x4F, O LATIN CAPITAL LETTER O
-        // 0x6F, o LATIN SMALL LETTER O
+        // U+004F O LATIN CAPITAL LETTER O
+        // U+006F o LATIN SMALL LETTER O
         0b10'01'10U,
-        // 0x50, P LATIN CAPITAL LETTER P
-        // 0x70, p LATIN SMALL LETTER P
+        // U+0050 P LATIN CAPITAL LETTER P
+        // U+0070 p LATIN SMALL LETTER P
         0b11'10'10U,
-        // 0x51, Q LATIN CAPITAL LETTER Q
-        // 0x71, q LATIN SMALL LETTER Q
+        // U+0051 Q LATIN CAPITAL LETTER Q
+        // U+0071 q LATIN SMALL LETTER Q
         0b11'11'10U,
-        // 0x52, R LATIN CAPITAL LETTER R
-        // 0x72, r LATIN SMALL LETTER R
+        // U+0052 R LATIN CAPITAL LETTER R
+        // U+0072 r LATIN SMALL LETTER R
         0b10'11'10U,
-        // 0x53, S LATIN CAPITAL LETTER S
-        // 0x73, s LATIN SMALL LETTER S
+        // U+0053 S LATIN CAPITAL LETTER S
+        // U+0073 s LATIN SMALL LETTER S
         0b01'11'10U,
-        // 0x54, T LATIN CAPITAL LETTER T
-        // 0x74, t LATIN SMALL LETTER T
+        // U+0054 T LATIN CAPITAL LETTER T
+        // U+0074 t LATIN SMALL LETTER T
         0b11'110U,
-        // 0x55, U LATIN CAPITAL LETTER U
-        // 0x75, u LATIN SMALL LETTER U
+        // U+0055 U LATIN CAPITAL LETTER U
+        // U+0075 u LATIN SMALL LETTER U
         0b10'00'11U,
-        // 0x56, V LATIN CAPITAL LETTER V
-        // 0x76, v LATIN SMALL LETTER V
+        // U+0056 V LATIN CAPITAL LETTER V
+        // U+0076 v LATIN SMALL LETTER V
         0b10'10'11U,
-        // 0x57, W LATIN CAPITAL LETTER W
-        // 0x77, w LATIN SMALL LETTER W
+        // U+0057 W LATIN CAPITAL LETTER W
+        // U+0077 w LATIN SMALL LETTER W
         0b01'11'01U,
-        // 0x58, X LATIN CAPITAL LETTER X
-        // 0x78, x LATIN SMALL LETTER X
+        // U+0058 X LATIN CAPITAL LETTER X
+        // U+0078 x LATIN SMALL LETTER X
         0b11'00'11U,
-        // 0x59, Y LATIN CAPITAL LETTER Y
-        // 0x79, y LATIN SMALL LETTER Y
+        // U+0059 Y LATIN CAPITAL LETTER Y
+        // U+0079 y LATIN SMALL LETTER Y
         0b11'01'11U,
-        // 0x5A, Z LATIN CAPITAL LETTER Z
-        // 0x7A, z LATIN SMALL LETTER Z
+        // U+005A Z LATIN CAPITAL LETTER Z
+        // U+007A z LATIN SMALL LETTER Z
         0b10'01'11U,
     };
 

--- a/firmware/include/fonts/BrailleFont.h
+++ b/firmware/include/fonts/BrailleFont.h
@@ -9,105 +9,105 @@
 class BrailleFont final : public FontModule
 {
 private:
-    static constexpr std::array<uint8_t, 26> chars41{
-        // 0x31, 1
-        // 0x41, A
-        // 0x61, a
-        0b100000,
-        // 0x32, 2
-        // 0x42, B
-        // 0x62, b
-        0b101000,
-        // 0x33, 3
-        // 0x43, C
-        // 0x63, c
-        0b110000,
-        // 0x34, 4
-        // 0x44, D
-        // 0x64, d
-        0b110100,
-        // 0x35, 5
-        // 0x45, E
-        // 0x65, e
-        0b100100,
-        // 0x36, 6
-        // 0x46, F
-        // 0x66, f
-        0b111000,
-        // 0x37, 7
-        // 0x47, G
-        // 0x67, g
-        0b111100,
-        // 0x38, 8
-        // 0x48, H
-        // 0x68, h
-        0b101100,
-        // 0x39, 9
-        // 0x49, I
-        // 0x69, i
-        0b11000,
-        // 0x30, 0
-        // 0x4A, J
-        // 0x6A, j
-        0b11100,
-        // 0x4B, K
-        // 0x6B, k
-        0b100010,
-        // 0x4C, L
-        // 0x6C, l
-        0b101010,
-        // 0x4D, M
-        // 0x6D, m
-        0b110010,
-        // 0x4E, N
-        // 0x6E, n
-        0b110110,
-        // 0x4F, O
-        // 0x6F, o
-        0b100110,
-        // 0x50, P
-        // 0x70, p
-        0b111010,
-        // 0x51, Q
-        // 0x71, q
-        0b111110,
-        // 0x52, R
-        // 0x72, r
-        0b101110,
-        // 0x53, S
-        // 0x73, s
-        0b11010,
-        // 0x54, T
-        // 0x74, t
-        0b11110,
-        // 0x55, U
-        // 0x75, u
-        0b100011,
-        // 0x56, V
-        // 0x76, v
-        0b101011,
-        // 0x57, W
-        // 0x77, w
-        0b11101,
-        // 0x58, X
-        // 0x78, x
-        0b110011,
-        // 0x59, Y
-        // 0x79, y
-        0b110111,
-        // 0x5A, Z
-        // 0x7A, z
-        0b100111,
+    static constexpr std::array<uint8_t, 26U> latinLetterA_latinLetterZ{
+        // 0x31, 1 DIGIT ONE
+        // 0x41, A LATIN CAPITAL LETTER A
+        // 0x61, a LATIN SMALL LETTER A
+        0b10'00'00U,
+        // 0x32, 2 DIGIT TWO
+        // 0x42, B LATIN CAPITAL LETTER B
+        // 0x62, b LATIN SMALL LETTER B
+        0b10'10'00U,
+        // 0x33, 3 DIGIT THREE
+        // 0x43, C LATIN CAPITAL LETTER C
+        // 0x63, c LATIN SMALL LETTER C
+        0b11'00'00U,
+        // 0x34, 4 DIGIT FOUR
+        // 0x44, D LATIN CAPITAL LETTER D
+        // 0x64, d LATIN SMALL LETTER D
+        0b11'01'00U,
+        // 0x35, 5 DIGIT FIVE
+        // 0x45, E LATIN CAPITAL LETTER E
+        // 0x65, e LATIN SMALL LETTER E
+        0b10'01'00U,
+        // 0x36, 6 DIGIT SIX
+        // 0x46, F LATIN CAPITAL LETTER F
+        // 0x66, f LATIN SMALL LETTER F
+        0b11'10'00U,
+        // 0x37, 7 DIGIT SEVEN
+        // 0x47, G LATIN CAPITAL LETTER G
+        // 0x67, g LATIN SMALL LETTER G
+        0b11'11'00U,
+        // 0x38, 8 DIGIT EIGHT
+        // 0x48, H LATIN CAPITAL LETTER H
+        // 0x68, h LATIN SMALL LETTER H
+        0b10'1100U,
+        // 0x39, 9 DIGIT NINE
+        // 0x49, I LATIN CAPITAL LETTER I
+        // 0x69, i LATIN SMALL LETTER I
+        0b01'10'00U,
+        // 0x30, 0 DIGIT ZERO
+        // 0x4A, J LATIN CAPITAL LETTER J
+        // 0x6A, j LATIN SMALL LETTER J
+        0b11'10'0U,
+        // 0x4B, K LATIN CAPITAL LETTER K
+        // 0x6B, k LATIN SMALL LETTER K
+        0b10'00'10U,
+        // 0x4C, L LATIN CAPITAL LETTER L
+        // 0x6C, l LATIN SMALL LETTER L
+        0b10'10'10U,
+        // 0x4D, M LATIN CAPITAL LETTER M
+        // 0x6D, m LATIN SMALL LETTER M
+        0b11'00'10U,
+        // 0x4E, N LATIN CAPITAL LETTER N
+        // 0x6E, n LATIN SMALL LETTER N
+        0b11'01'10U,
+        // 0x4F, O LATIN CAPITAL LETTER O
+        // 0x6F, o LATIN SMALL LETTER O
+        0b10'01'10U,
+        // 0x50, P LATIN CAPITAL LETTER P
+        // 0x70, p LATIN SMALL LETTER P
+        0b11'10'10U,
+        // 0x51, Q LATIN CAPITAL LETTER Q
+        // 0x71, q LATIN SMALL LETTER Q
+        0b11'11'10U,
+        // 0x52, R LATIN CAPITAL LETTER R
+        // 0x72, r LATIN SMALL LETTER R
+        0b10'11'10U,
+        // 0x53, S LATIN CAPITAL LETTER S
+        // 0x73, s LATIN SMALL LETTER S
+        0b01'11'10U,
+        // 0x54, T LATIN CAPITAL LETTER T
+        // 0x74, t LATIN SMALL LETTER T
+        0b11'110U,
+        // 0x55, U LATIN CAPITAL LETTER U
+        // 0x75, u LATIN SMALL LETTER U
+        0b10'00'11U,
+        // 0x56, V LATIN CAPITAL LETTER V
+        // 0x76, v LATIN SMALL LETTER V
+        0b10'10'11U,
+        // 0x57, W LATIN CAPITAL LETTER W
+        // 0x77, w LATIN SMALL LETTER W
+        0b01'11'01U,
+        // 0x58, X LATIN CAPITAL LETTER X
+        // 0x78, x LATIN SMALL LETTER X
+        0b11'00'11U,
+        // 0x59, Y LATIN CAPITAL LETTER Y
+        // 0x79, y LATIN SMALL LETTER Y
+        0b11'01'11U,
+        // 0x5A, Z LATIN CAPITAL LETTER Z
+        // 0x7A, z LATIN SMALL LETTER Z
+        0b10'01'11U,
     };
 
     [[nodiscard]] FontModule::Symbol toSymbol(uint8_t bits) const;
 
 public:
-    static constexpr std::string_view name = "Braille";
+    static constexpr std::string_view name{"Braille"};
 
     explicit BrailleFont() : FontModule(name) {};
 
-    [[nodiscard]] FontModule::Symbol getChar(uint32_t character) const override;
+    [[nodiscard]] FontModule::Symbol getChar(char32_t character) const override;
 };
 
 #endif // FONT_BRAILLE

--- a/firmware/include/fonts/LargeFont.h
+++ b/firmware/include/fonts/LargeFont.h
@@ -10,72 +10,72 @@
 class LargeFont final : public FontModule
 {
 private:
-    // 0x21, !
-    static constexpr std::array<uint8_t, 8> char21 = {
-        0b11,
-        0b11,
-        0b11,
-        0b11,
-        0b11,
-        0b00,
-        0b11,
-        0b11,
+    // 0x21, ! EXCLAMATION MARK
+    static constexpr std::array<uint8_t, 8U> exclamationMark{
+        0b11U,
+        0b11U,
+        0b11U,
+        0b11U,
+        0b11U,
+        0b00U,
+        0b11U,
+        0b11U,
     };
 
-    // 0x49, I
-    static constexpr std::array<uint8_t, 8> char49 = {
-        0b111111,
-        0b001100,
-        0b001100,
-        0b001100,
-        0b001100,
-        0b001100,
-        0b001100,
-        0b111111,
+    // 0x49, I LATIN CAPITAL LETTER I
+    static constexpr std::array<uint8_t, 8U> latinCapitalLetterI{
+        0b111111U,
+        0b001100U,
+        0b001100U,
+        0b001100U,
+        0b001100U,
+        0b001100U,
+        0b001100U,
+        0b111111U,
     };
 
-    // 0x52, R
-    static constexpr std::array<uint8_t, 8> char52 = {
-        0b111110,
-        0b110011,
-        0b110011,
-        0b110010,
-        0b111100,
-        0b110011,
-        0b110011,
-        0b110011,
+    // 0x52, R LATIN CAPITAL LETTER R
+    static constexpr std::array<uint8_t, 8U> latinCapitalLetterR{
+        0b111110U,
+        0b110011U,
+        0b110011U,
+        0b110010U,
+        0b111100U,
+        0b110011U,
+        0b110011U,
+        0b110011U,
     };
 
-    // 0x55, U
-    static constexpr std::array<uint8_t, 8> char55 = {
-        0b110011,
-        0b110011,
-        0b110011,
-        0b110011,
-        0b110011,
-        0b110011,
-        0b111111,
-        0b011111,
+    // 0x55, U LATIN CAPITAL LETTER U
+    static constexpr std::array<uint8_t, 8U> latinCapitalLetterU{
+        0b110011U,
+        0b110011U,
+        0b110011U,
+        0b110011U,
+        0b110011U,
+        0b110011U,
+        0b111111U,
+        0b011111U,
     };
 
     // 0x3C0, π GREEK SMALL LETTER PI
-    static constexpr std::array<uint8_t, 8> char3C0 = {
-        0b11111111,
-        0b11111111,
-        0b00100100,
-        0b00100100,
-        0b00100100,
-        0b00100100,
-        0b00100101,
-        0b11000010,
+    static constexpr std::array<uint8_t, 8U> greekSmallLetterPi{
+        0b11111111U,
+        0b11111111U,
+        0b00100100U,
+        0b00100100U,
+        0b00100100U,
+        0b00100100U,
+        0b00100101U,
+        0b11000010U,
     };
 
 public:
-    static constexpr std::string_view name = "Large";
+    static constexpr std::string_view name{"Large"};
 
     explicit LargeFont() : FontModule(name) {};
 
-    [[nodiscard]] FontModule::Symbol getChar(uint32_t character) const override;
+    [[nodiscard]] FontModule::Symbol getChar(char32_t character) const override;
 };
 
 #endif // FONT_LARGE

--- a/firmware/include/fonts/LargeFont.h
+++ b/firmware/include/fonts/LargeFont.h
@@ -10,7 +10,7 @@
 class LargeFont final : public FontModule
 {
 private:
-    // 0x21, ! EXCLAMATION MARK
+    // U+0021 ! EXCLAMATION MARK
     static constexpr std::array<uint8_t, 8U> exclamationMark{
         0b11U,
         0b11U,
@@ -22,7 +22,7 @@ private:
         0b11U,
     };
 
-    // 0x49, I LATIN CAPITAL LETTER I
+    // U+0049 I LATIN CAPITAL LETTER I
     static constexpr std::array<uint8_t, 8U> latinCapitalLetterI{
         0b111111U,
         0b001100U,
@@ -34,7 +34,7 @@ private:
         0b111111U,
     };
 
-    // 0x52, R LATIN CAPITAL LETTER R
+    // U+0052 R LATIN CAPITAL LETTER R
     static constexpr std::array<uint8_t, 8U> latinCapitalLetterR{
         0b111110U,
         0b110011U,
@@ -46,7 +46,7 @@ private:
         0b110011U,
     };
 
-    // 0x55, U LATIN CAPITAL LETTER U
+    // U+0055 U LATIN CAPITAL LETTER U
     static constexpr std::array<uint8_t, 8U> latinCapitalLetterU{
         0b110011U,
         0b110011U,
@@ -58,7 +58,7 @@ private:
         0b011111U,
     };
 
-    // 0x3C0, π GREEK SMALL LETTER PI
+    // U+03C0 π GREEK SMALL LETTER PI
     static constexpr std::array<uint8_t, 8U> greekSmallLetterPi{
         0b11111111U,
         0b11111111U,

--- a/firmware/include/fonts/MediumBoldFont.h
+++ b/firmware/include/fonts/MediumBoldFont.h
@@ -12,7 +12,7 @@ class MediumBoldFont final : public FontModule
 private:
     static constexpr std::array<std::array<uint8_t, 7U>, 10U> digitZero_digitNine{{
         {
-            // 0x30, 0 DIGIT ZERO
+            // U+0030 0 DIGIT ZERO
             0b011110U,
             0b111111U,
             0b111111U,
@@ -22,7 +22,7 @@ private:
             0b011110U,
         },
         {
-            // 0x31, 1 DIGIT ONE
+            // U+0031 1 DIGIT ONE
             0b0011U,
             0b0111U,
             0b1111U,
@@ -32,7 +32,7 @@ private:
             0b0011U,
         },
         {
-            // 0x32, 2 DIGIT TWO
+            // U+0032 2 DIGIT TWO
             0b011110U,
             0b111111U,
             0b000011U,
@@ -42,7 +42,7 @@ private:
             0b111111U,
         },
         {
-            // 0x33, 3 DIGIT THREE
+            // U+0033 3 DIGIT THREE
             0b011110U,
             0b111111U,
             0b000011U,
@@ -52,7 +52,7 @@ private:
             0b011110U,
         },
         {
-            // 0x34, 4 DIGIT FOUR
+            // U+0034 4 DIGIT FOUR
             0b111111U,
             0b111111U,
             0b111111U,
@@ -62,7 +62,7 @@ private:
             0b000011U,
         },
         {
-            // 0x35, 5 DIGIT FIVE
+            // U+0035 5 DIGIT FIVE
             0b111111U,
             0b111111U,
             0b110000U,
@@ -72,7 +72,7 @@ private:
             0b011110U,
         },
         {
-            // 0x36, 6 DIGIT SIX
+            // U+0036 6 DIGIT SIX
             0b011110U,
             0b111111U,
             0b110000U,
@@ -82,7 +82,7 @@ private:
             0b011110U,
         },
         {
-            // 0x37, 7 DIGIT SEVEN
+            // U+0037 7 DIGIT SEVEN
             0b111111U,
             0b111111U,
             0b000110U,
@@ -92,7 +92,7 @@ private:
             0b001100U,
         },
         {
-            // 0x38, 8 DIGIT EIGHT
+            // U+0038 8 DIGIT EIGHT
             0b011110U,
             0b111111U,
             0b111111U,
@@ -102,7 +102,7 @@ private:
             0b011110U,
         },
         {
-            // 0x39, 9 DIGIT NINE
+            // U+0039 9 DIGIT NINE
             0b011110U,
             0b111111U,
             0b111111U,
@@ -113,7 +113,7 @@ private:
         },
     }};
 
-    // 0x49, I LATIN CAPITAL LETTER I
+    // U+0049 I LATIN CAPITAL LETTER I
     static constexpr std::array<uint8_t, 7U> latinCapitalLetterI{
         0b111111U,
         0b001100U,
@@ -124,7 +124,7 @@ private:
         0b111111U,
     };
 
-    // 0x4F, O LATIN CAPITAL LETTER O
+    // U+004F O LATIN CAPITAL LETTER O
     static constexpr std::array<uint8_t, 7U> latinCapitalLetterO{
         0b011110U,
         0b111111U,
@@ -135,7 +135,7 @@ private:
         0b011110U,
     };
 
-    // 0x6F, o LATIN SMALL LETTER O
+    // U+006F o LATIN SMALL LETTER O
     static constexpr std::array<uint8_t, 5U> latinSmallLetterO{
         0b01110U,
         0b11111U,

--- a/firmware/include/fonts/MediumBoldFont.h
+++ b/firmware/include/fonts/MediumBoldFont.h
@@ -10,146 +10,146 @@
 class MediumBoldFont final : public FontModule
 {
 private:
-    static constexpr std::array<std::array<uint8_t, 7>, 10> chars30 = {{
+    static constexpr std::array<std::array<uint8_t, 7U>, 10U> digitZero_digitNine{{
         {
-            // 0x30, 0
-            0b011110,
-            0b111111,
-            0b111111,
-            0b111111,
-            0b111111,
-            0b111111,
-            0b011110,
+            // 0x30, 0 DIGIT ZERO
+            0b011110U,
+            0b111111U,
+            0b111111U,
+            0b111111U,
+            0b111111U,
+            0b111111U,
+            0b011110U,
         },
         {
-            // 0x31, 1
-            0b0011,
-            0b0111,
-            0b1111,
-            0b0011,
-            0b0011,
-            0b0011,
-            0b0011,
+            // 0x31, 1 DIGIT ONE
+            0b0011U,
+            0b0111U,
+            0b1111U,
+            0b0011U,
+            0b0011U,
+            0b0011U,
+            0b0011U,
         },
         {
-            // 0x32, 2
-            0b011110,
-            0b111111,
-            0b000011,
-            0b001110,
-            0b011000,
-            0b111111,
-            0b111111,
+            // 0x32, 2 DIGIT TWO
+            0b011110U,
+            0b111111U,
+            0b000011U,
+            0b001110U,
+            0b011000U,
+            0b111111U,
+            0b111111U,
         },
         {
-            // 0x33, 3
-            0b011110,
-            0b111111,
-            0b000011,
-            0b001111,
-            0b000011,
-            0b111111,
-            0b011110,
+            // 0x33, 3 DIGIT THREE
+            0b011110U,
+            0b111111U,
+            0b000011U,
+            0b001111U,
+            0b000011U,
+            0b111111U,
+            0b011110U,
         },
         {
-            // 0x34, 4
-            0b111111,
-            0b111111,
-            0b111111,
-            0b011111,
-            0b000011,
-            0b000011,
-            0b000011,
+            // 0x34, 4 DIGIT FOUR
+            0b111111U,
+            0b111111U,
+            0b111111U,
+            0b011111U,
+            0b000011U,
+            0b000011U,
+            0b000011U,
         },
         {
-            // 0x35, 5
-            0b111111,
-            0b111111,
-            0b110000,
-            0b111110,
-            0b000011,
-            0b111111,
-            0b011110,
+            // 0x35, 5 DIGIT FIVE
+            0b111111U,
+            0b111111U,
+            0b110000U,
+            0b111110U,
+            0b000011U,
+            0b111111U,
+            0b011110U,
         },
         {
-            // 0x36, 6
-            0b011110,
-            0b111111,
-            0b110000,
-            0b111110,
-            0b111111,
-            0b111111,
-            0b011110,
+            // 0x36, 6 DIGIT SIX
+            0b011110U,
+            0b111111U,
+            0b110000U,
+            0b111110U,
+            0b111111U,
+            0b111111U,
+            0b011110U,
         },
         {
-            // 0x37, 7
-            0b111111,
-            0b111111,
-            0b000110,
-            0b001100,
-            0b001100,
-            0b001100,
-            0b001100,
+            // 0x37, 7 DIGIT SEVEN
+            0b111111U,
+            0b111111U,
+            0b000110U,
+            0b001100U,
+            0b001100U,
+            0b001100U,
+            0b001100U,
         },
         {
-            // 0x38, 8
-            0b011110,
-            0b111111,
-            0b111111,
-            0b011110,
-            0b111111,
-            0b111111,
-            0b011110,
+            // 0x38, 8 DIGIT EIGHT
+            0b011110U,
+            0b111111U,
+            0b111111U,
+            0b011110U,
+            0b111111U,
+            0b111111U,
+            0b011110U,
         },
         {
-            // 0x39, 9
-            0b011110,
-            0b111111,
-            0b111111,
-            0b011111,
-            0b000011,
-            0b111111,
-            0b011110,
+            // 0x39, 9 DIGIT NINE
+            0b011110U,
+            0b111111U,
+            0b111111U,
+            0b011111U,
+            0b000011U,
+            0b111111U,
+            0b011110U,
         },
     }};
 
-    // 0x49, I
-    static constexpr std::array<uint8_t, 7> char49 = {
-        0b111111,
-        0b001100,
-        0b001100,
-        0b001100,
-        0b001100,
-        0b001100,
-        0b111111,
+    // 0x49, I LATIN CAPITAL LETTER I
+    static constexpr std::array<uint8_t, 7U> latinCapitalLetterI{
+        0b111111U,
+        0b001100U,
+        0b001100U,
+        0b001100U,
+        0b001100U,
+        0b001100U,
+        0b111111U,
     };
 
-    // 0x4F, O
-    static constexpr std::array<uint8_t, 7> char4F = {
-        0b011110,
-        0b111111,
-        0b111111,
-        0b111111,
-        0b111111,
-        0b111111,
-        0b011110,
+    // 0x4F, O LATIN CAPITAL LETTER O
+    static constexpr std::array<uint8_t, 7U> latinCapitalLetterO{
+        0b011110U,
+        0b111111U,
+        0b111111U,
+        0b111111U,
+        0b111111U,
+        0b111111U,
+        0b011110U,
     };
 
-    // 0x6F, o
-    static constexpr std::array<uint8_t, 5> char6F = {
-        0b01110,
-        0b11111,
-        0b11111,
-        0b11111,
-        0b01110,
+    // 0x6F, o LATIN SMALL LETTER O
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterO{
+        0b01110U,
+        0b11111U,
+        0b11111U,
+        0b11111U,
+        0b01110U,
     };
 
 public:
-    static constexpr std::string_view name = "Medium bold";
+    static constexpr std::string_view name{"Medium bold"};
 
     explicit MediumBoldFont() : FontModule(name) {};
 
-    [[nodiscard]] FontModule::Symbol getChar(uint32_t character) const override;
+    [[nodiscard]] FontModule::Symbol getChar(char32_t character) const override;
 };
 
 #endif // FONT_MEDIUMBOLD

--- a/firmware/include/fonts/MediumFont.h
+++ b/firmware/include/fonts/MediumFont.h
@@ -11,7 +11,7 @@ class MediumFont final : public FontModule
 private:
     static constexpr std::array<std::array<uint8_t, 7U>, 10U> digitZero_digitNine{{
         {
-            // 0x30, 0 DIGIT ZERO
+            // U+0030 0 DIGIT ZERO
             0b011110U,
             0b110011U,
             0b110011U,
@@ -21,7 +21,7 @@ private:
             0b011110U,
         },
         {
-            // 0x31, 1 DIGIT ONE
+            // U+0031 1 DIGIT ONE
             0b0011U,
             0b0111U,
             0b1111U,
@@ -31,7 +31,7 @@ private:
             0b0011U,
         },
         {
-            // 0x32, 2 DIGIT TWO
+            // U+0032 2 DIGIT TWO
             0b011110U,
             0b110011U,
             0b000011U,
@@ -41,7 +41,7 @@ private:
             0b111111U,
         },
         {
-            // 0x33, 3 DIGIT THREE
+            // U+0033 3 DIGIT THREE
             0b011110U,
             0b110011U,
             0b000011U,
@@ -51,7 +51,7 @@ private:
             0b011110U,
         },
         {
-            // 0x34, 4 DIGIT FOUR
+            // U+0034 4 DIGIT FOUR
             0b110011U,
             0b110011U,
             0b110011U,
@@ -61,7 +61,7 @@ private:
             0b000011U,
         },
         {
-            // 0x35, 5 DIGIT FIVE
+            // U+0035 5 DIGIT FIVE
             0b111111U,
             0b110000U,
             0b110000U,
@@ -71,7 +71,7 @@ private:
             0b011110U,
         },
         {
-            // 0x36, 6 DIGIT SIX
+            // U+0036 6 DIGIT SIX
             0b011110U,
             0b110011U,
             0b110000U,
@@ -81,7 +81,7 @@ private:
             0b011110U,
         },
         {
-            // 0x37, 7 DIGIT SEVEN
+            // U+0037 7 DIGIT SEVEN
             0b111111U,
             0b000011U,
             0b000110U,
@@ -91,7 +91,7 @@ private:
             0b001100U,
         },
         {
-            // 0x38, 8 DIGIT EIGHT
+            // U+0038 8 DIGIT EIGHT
             0b011110U,
             0b110011U,
             0b110011U,
@@ -101,7 +101,7 @@ private:
             0b011110U,
         },
         {
-            // 0x39, 9 DIGIT NINE
+            // U+0039 9 DIGIT NINE
             0b011110U,
             0b110011U,
             0b110011U,
@@ -112,7 +112,7 @@ private:
         },
     }};
 
-    // 0x49, I LATIN CAPITAL LETTER I
+    // U+0049 I LATIN CAPITAL LETTER I
     static constexpr std::array<uint8_t, 7U> latinCapitalLetterI{
         0b111111U,
         0b001100U,
@@ -123,7 +123,7 @@ private:
         0b111111U,
     };
 
-    // 0x4F, O LATIN CAPITAL LETTER O
+    // U+004F O LATIN CAPITAL LETTER O
     static constexpr std::array<uint8_t, 7U> latinCapitalLetterO{
         0b011110U,
         0b111111U,
@@ -134,7 +134,7 @@ private:
         0b011110U,
     };
 
-    // 0x6F, o LATIN SMALL LETTER O
+    // U+006F o LATIN SMALL LETTER O
     static constexpr std::array<uint8_t, 5U> latinSmallLetterO{
         0b01110U,
         0b11111U,

--- a/firmware/include/fonts/MediumFont.h
+++ b/firmware/include/fonts/MediumFont.h
@@ -9,146 +9,146 @@
 class MediumFont final : public FontModule
 {
 private:
-    static constexpr std::array<std::array<uint8_t, 7>, 10> chars30 = {{
+    static constexpr std::array<std::array<uint8_t, 7U>, 10U> digitZero_digitNine{{
         {
-            // 0x30, 0
-            0b011110,
-            0b110011,
-            0b110011,
-            0b110011,
-            0b110011,
-            0b110011,
-            0b011110,
+            // 0x30, 0 DIGIT ZERO
+            0b011110U,
+            0b110011U,
+            0b110011U,
+            0b110011U,
+            0b110011U,
+            0b110011U,
+            0b011110U,
         },
         {
-            // 0x31, 1
-            0b0011,
-            0b0111,
-            0b1111,
-            0b0011,
-            0b0011,
-            0b0011,
-            0b0011,
+            // 0x31, 1 DIGIT ONE
+            0b0011U,
+            0b0111U,
+            0b1111U,
+            0b0011U,
+            0b0011U,
+            0b0011U,
+            0b0011U,
         },
         {
-            // 0x32, 2
-            0b011110,
-            0b110011,
-            0b000011,
-            0b001110,
-            0b011000,
-            0b110000,
-            0b111111,
+            // 0x32, 2 DIGIT TWO
+            0b011110U,
+            0b110011U,
+            0b000011U,
+            0b001110U,
+            0b011000U,
+            0b110000U,
+            0b111111U,
         },
         {
-            // 0x33, 3
-            0b011110,
-            0b110011,
-            0b000011,
-            0b001110,
-            0b000011,
-            0b110011,
-            0b011110,
+            // 0x33, 3 DIGIT THREE
+            0b011110U,
+            0b110011U,
+            0b000011U,
+            0b001110U,
+            0b000011U,
+            0b110011U,
+            0b011110U,
         },
         {
-            // 0x34, 4
-            0b110011,
-            0b110011,
-            0b110011,
-            0b011111,
-            0b000011,
-            0b000011,
-            0b000011,
+            // 0x34, 4 DIGIT FOUR
+            0b110011U,
+            0b110011U,
+            0b110011U,
+            0b011111U,
+            0b000011U,
+            0b000011U,
+            0b000011U,
         },
         {
-            // 0x35, 5
-            0b111111,
-            0b110000,
-            0b110000,
-            0b111110,
-            0b000011,
-            0b110011,
-            0b011110,
+            // 0x35, 5 DIGIT FIVE
+            0b111111U,
+            0b110000U,
+            0b110000U,
+            0b111110U,
+            0b000011U,
+            0b110011U,
+            0b011110U,
         },
         {
-            // 0x36, 6
-            0b011110,
-            0b110011,
-            0b110000,
-            0b111110,
-            0b110011,
-            0b110011,
-            0b011110,
+            // 0x36, 6 DIGIT SIX
+            0b011110U,
+            0b110011U,
+            0b110000U,
+            0b111110U,
+            0b110011U,
+            0b110011U,
+            0b011110U,
         },
         {
-            // 0x37, 7
-            0b111111,
-            0b000011,
-            0b000110,
-            0b001100,
-            0b001100,
-            0b001100,
-            0b001100,
+            // 0x37, 7 DIGIT SEVEN
+            0b111111U,
+            0b000011U,
+            0b000110U,
+            0b001100U,
+            0b001100U,
+            0b001100U,
+            0b001100U,
         },
         {
-            // 0x38, 8
-            0b011110,
-            0b110011,
-            0b110011,
-            0b011110,
-            0b110011,
-            0b110011,
-            0b011110,
+            // 0x38, 8 DIGIT EIGHT
+            0b011110U,
+            0b110011U,
+            0b110011U,
+            0b011110U,
+            0b110011U,
+            0b110011U,
+            0b011110U,
         },
         {
-            // 0x39, 9
-            0b011110,
-            0b110011,
-            0b110011,
-            0b011111,
-            0b000011,
-            0b110011,
-            0b011110,
+            // 0x39, 9 DIGIT NINE
+            0b011110U,
+            0b110011U,
+            0b110011U,
+            0b011111U,
+            0b000011U,
+            0b110011U,
+            0b011110U,
         },
     }};
 
-    // 0x49, I
-    static constexpr std::array<uint8_t, 7> char49 = {
-        0b111111,
-        0b001100,
-        0b001100,
-        0b001100,
-        0b001100,
-        0b001100,
-        0b111111,
+    // 0x49, I LATIN CAPITAL LETTER I
+    static constexpr std::array<uint8_t, 7U> latinCapitalLetterI{
+        0b111111U,
+        0b001100U,
+        0b001100U,
+        0b001100U,
+        0b001100U,
+        0b001100U,
+        0b111111U,
     };
 
-    // 0x4F, O
-    static constexpr std::array<uint8_t, 7> char4F = {
-        0b011110,
-        0b111111,
-        0b110011,
-        0b110011,
-        0b110011,
-        0b111111,
-        0b011110,
+    // 0x4F, O LATIN CAPITAL LETTER O
+    static constexpr std::array<uint8_t, 7U> latinCapitalLetterO{
+        0b011110U,
+        0b111111U,
+        0b110011U,
+        0b110011U,
+        0b110011U,
+        0b111111U,
+        0b011110U,
     };
 
-    // 0x6F, o
-    static constexpr std::array<uint8_t, 5> char6F = {
-        0b01110,
-        0b11111,
-        0b11011,
-        0b11111,
-        0b01110,
+    // 0x6F, o LATIN SMALL LETTER O
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterO{
+        0b01110U,
+        0b11111U,
+        0b11011U,
+        0b11111U,
+        0b01110U,
     };
 
 public:
-    static constexpr std::string_view name = "Medium";
+    static constexpr std::string_view name{"Medium"};
 
     explicit MediumFont() : FontModule(name) {};
 
-    [[nodiscard]] FontModule::Symbol getChar(uint32_t character) const override;
+    [[nodiscard]] FontModule::Symbol getChar(char32_t character) const override;
 };
 
 #endif // FONT_MEDIUM

--- a/firmware/include/fonts/MediumWideFont.h
+++ b/firmware/include/fonts/MediumWideFont.h
@@ -9,146 +9,146 @@
 class MediumWideFont final : public FontModule
 {
 private:
-    static constexpr std::array<std::array<uint8_t, 7>, 10> chars30 = {{
+    static constexpr std::array<std::array<uint8_t, 7U>, 10U> digitZero_digitNine{{
         {
-            // 0x30, 0
-            0b0111110,
-            0b1100011,
-            0b1100111,
-            0b1101011,
-            0b1110011,
-            0b1100011,
-            0b0111110,
+            // 0x30, 0 DIGIT ZERO
+            0b0111110U,
+            0b1100011U,
+            0b1100111U,
+            0b1101011U,
+            0b1110011U,
+            0b1100011U,
+            0b0111110U,
         },
         {
-            // 0x31, 1
-            0b0011,
-            0b0111,
-            0b1111,
-            0b0011,
-            0b0011,
-            0b0011,
-            0b0011,
+            // 0x31, 1 DIGIT ONE
+            0b0011U,
+            0b0111U,
+            0b1111U,
+            0b0011U,
+            0b0011U,
+            0b0011U,
+            0b0011U,
         },
         {
-            // 0x32, 2
-            0b1111110,
-            0b0000011,
-            0b0000011,
-            0b0111110,
-            0b1100000,
-            0b1100011,
-            0b1111111,
+            // 0x32, 2 DIGIT TWO
+            0b1111110U,
+            0b0000011U,
+            0b0000011U,
+            0b0111110U,
+            0b1100000U,
+            0b1100011U,
+            0b1111111U,
         },
         {
-            // 0x33, 3
-            0b0111110,
-            0b1100011,
-            0b0000011,
-            0b0011111,
-            0b0000011,
-            0b1100011,
-            0b0111110,
+            // 0x33, 3 DIGIT THREE
+            0b0111110U,
+            0b1100011U,
+            0b0000011U,
+            0b0011111U,
+            0b0000011U,
+            0b1100011U,
+            0b0111110U,
         },
         {
-            // 0x34, 4
-            0b1100011,
-            0b1100011,
-            0b1100011,
-            0b0111111,
-            0b0000011,
-            0b0000011,
-            0b0000011,
+            // 0x34, 4 DIGIT FOUR
+            0b1100011U,
+            0b1100011U,
+            0b1100011U,
+            0b0111111U,
+            0b0000011U,
+            0b0000011U,
+            0b0000011U,
         },
         {
-            // 0x35, 5
-            0b1111111,
-            0b1100011,
-            0b1100000,
-            0b1111110,
-            0b0000011,
-            0b1100011,
-            0b0111110,
+            // 0x35, 5 DIGIT FIVE
+            0b1111111U,
+            0b1100011U,
+            0b1100000U,
+            0b1111110U,
+            0b0000011U,
+            0b1100011U,
+            0b0111110U,
         },
         {
-            // 0x36, 6
-            0b0111110,
-            0b1100011,
-            0b1100000,
-            0b1111110,
-            0b1100011,
-            0b1100011,
-            0b0111110,
+            // 0x36, 6 DIGIT SIX
+            0b0111110U,
+            0b1100011U,
+            0b1100000U,
+            0b1111110U,
+            0b1100011U,
+            0b1100011U,
+            0b0111110U,
         },
         {
-            // 0x37, 7
-            0b1111111,
-            0b1000011,
-            0b0000111,
-            0b0001100,
-            0b0011000,
-            0b0011000,
-            0b0011000,
+            // 0x37, 7 DIGIT SEVEN
+            0b1111111U,
+            0b1000011U,
+            0b0000111U,
+            0b0001100U,
+            0b0011000U,
+            0b0011000U,
+            0b0011000U,
         },
         {
-            // 0x38, 8
-            0b0111110,
-            0b1100011,
-            0b1100011,
-            0b0111110,
-            0b1100011,
-            0b1100011,
-            0b0111110,
+            // 0x38, 8 DIGIT EIGHT
+            0b0111110U,
+            0b1100011U,
+            0b1100011U,
+            0b0111110U,
+            0b1100011U,
+            0b1100011U,
+            0b0111110U,
         },
         {
-            // 0x39, 9
-            0b0111110,
-            0b1100011,
-            0b1100011,
-            0b0111111,
-            0b0000011,
-            0b1100011,
-            0b0111110,
+            // 0x39, 9 DIGIT NINE
+            0b0111110U,
+            0b1100011U,
+            0b1100011U,
+            0b0111111U,
+            0b0000011U,
+            0b1100011U,
+            0b0111110U,
         },
     }};
 
-    // 0x49, I
-    static constexpr std::array<uint8_t, 7> char49 = {
-        0b111,
-        0b010,
-        0b010,
-        0b010,
-        0b010,
-        0b010,
-        0b111,
+    // 0x49, I LATIN CAPITAL LETTER I
+    static constexpr std::array<uint8_t, 7U> latinCapitalLetterI{
+        0b111U,
+        0b010U,
+        0b010U,
+        0b010U,
+        0b010U,
+        0b010U,
+        0b111U,
     };
 
-    // 0x4F, O
-    static constexpr std::array<uint8_t, 7> char4F = {
-        0b011110,
-        0b100001,
-        0b100001,
-        0b100001,
-        0b100001,
-        0b100001,
-        0b011110,
+    // 0x4F, O LATIN CAPITAL LETTER O
+    static constexpr std::array<uint8_t, 7U> latinCapitalLetterO{
+        0b011110U,
+        0b100001U,
+        0b100001U,
+        0b100001U,
+        0b100001U,
+        0b100001U,
+        0b011110U,
     };
 
-    // 0x6F, o
-    static constexpr std::array<uint8_t, 5> char6F = {
-        0b01110,
-        0b10001,
-        0b10001,
-        0b10001,
-        0b01110,
+    // 0x6F, o LATIN SMALL LETTER O
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterO{
+        0b01110U,
+        0b10001U,
+        0b10001U,
+        0b10001U,
+        0b01110U,
     };
 
 public:
-    static constexpr std::string_view name = "Medium wide";
+    static constexpr std::string_view name{"Medium wide"};
 
     explicit MediumWideFont() : FontModule(name) {};
 
-    [[nodiscard]] FontModule::Symbol getChar(uint32_t character) const override;
+    [[nodiscard]] FontModule::Symbol getChar(char32_t character) const override;
 };
 
 #endif // FONT_MEDIUMWIDE

--- a/firmware/include/fonts/MediumWideFont.h
+++ b/firmware/include/fonts/MediumWideFont.h
@@ -11,7 +11,7 @@ class MediumWideFont final : public FontModule
 private:
     static constexpr std::array<std::array<uint8_t, 7U>, 10U> digitZero_digitNine{{
         {
-            // 0x30, 0 DIGIT ZERO
+            // U+0030 0 DIGIT ZERO
             0b0111110U,
             0b1100011U,
             0b1100111U,
@@ -21,7 +21,7 @@ private:
             0b0111110U,
         },
         {
-            // 0x31, 1 DIGIT ONE
+            // U+0031 1 DIGIT ONE
             0b0011U,
             0b0111U,
             0b1111U,
@@ -31,7 +31,7 @@ private:
             0b0011U,
         },
         {
-            // 0x32, 2 DIGIT TWO
+            // U+0032 2 DIGIT TWO
             0b1111110U,
             0b0000011U,
             0b0000011U,
@@ -41,7 +41,7 @@ private:
             0b1111111U,
         },
         {
-            // 0x33, 3 DIGIT THREE
+            // U+0033 3 DIGIT THREE
             0b0111110U,
             0b1100011U,
             0b0000011U,
@@ -51,7 +51,7 @@ private:
             0b0111110U,
         },
         {
-            // 0x34, 4 DIGIT FOUR
+            // U+0034 4 DIGIT FOUR
             0b1100011U,
             0b1100011U,
             0b1100011U,
@@ -61,7 +61,7 @@ private:
             0b0000011U,
         },
         {
-            // 0x35, 5 DIGIT FIVE
+            // U+0035 5 DIGIT FIVE
             0b1111111U,
             0b1100011U,
             0b1100000U,
@@ -71,7 +71,7 @@ private:
             0b0111110U,
         },
         {
-            // 0x36, 6 DIGIT SIX
+            // U+0036 6 DIGIT SIX
             0b0111110U,
             0b1100011U,
             0b1100000U,
@@ -81,7 +81,7 @@ private:
             0b0111110U,
         },
         {
-            // 0x37, 7 DIGIT SEVEN
+            // U+0037 7 DIGIT SEVEN
             0b1111111U,
             0b1000011U,
             0b0000111U,
@@ -91,7 +91,7 @@ private:
             0b0011000U,
         },
         {
-            // 0x38, 8 DIGIT EIGHT
+            // U+0038 8 DIGIT EIGHT
             0b0111110U,
             0b1100011U,
             0b1100011U,
@@ -101,7 +101,7 @@ private:
             0b0111110U,
         },
         {
-            // 0x39, 9 DIGIT NINE
+            // U+0039 9 DIGIT NINE
             0b0111110U,
             0b1100011U,
             0b1100011U,
@@ -112,7 +112,7 @@ private:
         },
     }};
 
-    // 0x49, I LATIN CAPITAL LETTER I
+    // U+0049 I LATIN CAPITAL LETTER I
     static constexpr std::array<uint8_t, 7U> latinCapitalLetterI{
         0b111U,
         0b010U,
@@ -123,7 +123,7 @@ private:
         0b111U,
     };
 
-    // 0x4F, O LATIN CAPITAL LETTER O
+    // U+004F O LATIN CAPITAL LETTER O
     static constexpr std::array<uint8_t, 7U> latinCapitalLetterO{
         0b011110U,
         0b100001U,
@@ -134,7 +134,7 @@ private:
         0b011110U,
     };
 
-    // 0x6F, o LATIN SMALL LETTER O
+    // U+006F o LATIN SMALL LETTER O
     static constexpr std::array<uint8_t, 5U> latinSmallLetterO{
         0b01110U,
         0b10001U,

--- a/firmware/include/fonts/MicroFont.h
+++ b/firmware/include/fonts/MicroFont.h
@@ -9,24 +9,24 @@
 class MicroFont final : public FontModule
 {
 private:
-    static constexpr std::array<uint8_t, 1U> quotationMark{0b11U}; // 0x22, " QUOTATION MARK
+    static constexpr std::array<uint8_t, 1U> quotationMark{0b11U}; // U+0022 " QUOTATION MARK
 
-    // 0x27, ' APOSTROPHE
-    // 0x2A, * ASTERISK
-    // 0x2C, , COMMA
-    // 0x2E, . FULL STOP
-    // 0x60, ` GRAVE ACCENT
-    // 0xB0, ° DEGREE SIGN
+    // U+0027 ' APOSTROPHE
+    // U+002A * ASTERISK
+    // U+002C , COMMA
+    // U+002E . FULL STOP
+    // U+0060 ` GRAVE ACCENT
+    // U+00B0 ° DEGREE SIGN
     static constexpr std::array<uint8_t, 1U> apostrophe{0b1U};
 
     static constexpr std::array<std::array<uint8_t, 3U>, 2U> leftParenthesis_rightParenthesis{{
-        // 0x28, ( LEFT PARENTHESIS
+        // U+0028 ( LEFT PARENTHESIS
         {
             0b01U,
             0b10U,
             0b01U,
         },
-        // 0x29, ) RIGHT PARENTHESIS
+        // U+0029 ) RIGHT PARENTHESIS
         {
             0b10U,
             0b01U,
@@ -34,109 +34,109 @@ private:
         },
     }};
 
-    // 0x2B, + PLUS SIGN
+    // U+002B + PLUS SIGN
     static constexpr std::array<uint8_t, 3U> plusSign{
         0b010U,
         0b111U,
         0b010U,
     };
 
-    // 0x2D, - HYPHEN-MINUS
-    // 0x5F, _ LOW LINE
+    // U+002D - HYPHEN-MINUS
+    // U+005F _ LOW LINE
     static constexpr std::array<uint8_t, 1U> hyphenMinus{0b111U};
 
     static constexpr std::array<std::array<uint8_t, 3U>, 16U> solidus_greaterThanSign{{
-        // 0x2F, / SOLIDUS
+        // U+002F / SOLIDUS
         {
             0b001U,
             0b010U,
             0b100U,
         },
-        // 0x30, 0 DIGIT ZERO
+        // U+0030 0 DIGIT ZERO
         {
             0b111U,
             0b101U,
             0b111U,
         },
-        // 0x31, 1 DIGIT ONE
+        // U+0031 1 DIGIT ONE
         {
             0b11U,
             0b01U,
             0b01U,
         },
-        // 0x32, 2 DIGIT TWO
+        // U+0032 2 DIGIT TWO
         {
             0b110U,
             0b010U,
             0b011U,
         },
-        // 0x33, 3 DIGIT THREE
+        // U+0033 3 DIGIT THREE
         {
             0b111U,
             0b011U,
             0b111U,
         },
-        // 0x34, 4 DIGIT FOUR
+        // U+0034 4 DIGIT FOUR
         {
             0b101U,
             0b111U,
             0b001U,
         },
-        // 0x35, 5 DIGIT FIVE
+        // U+0035 5 DIGIT FIVE
         {
             0b011U,
             0b010U,
             0b110U,
         },
-        // 0x36, 6 DIGIT SIX
+        // U+0036 6 DIGIT SIX
         {
             0b100U,
             0b111U,
             0b111U,
         },
-        // 0x37, 7 DIGIT SEVEN
+        // U+0037 7 DIGIT SEVEN
         {
             0b111U,
             0b011U,
             0b001U,
         },
-        // 0x38, 8 DIGIT EIGHT
+        // U+0038 8 DIGIT EIGHT
         {
             0b111U,
             0b111U,
             0b111U,
         },
-        // 0x39, 9 DIGIT NINE
+        // U+0039 9 DIGIT NINE
         {
             0b111U,
             0b111U,
             0b001U,
         },
-        // 0x3A, : COLON
+        // U+003A : COLON
         {
             0b1U,
             0b0U,
             0b1U,
         },
-        // 0x3B, ; SEMICOLON
+        // U+003B ; SEMICOLON
         {
             0b01U,
             0b00U,
             0b11U,
         },
-        // 0x3C, < LESS-THAN SIGN
+        // U+003C < LESS-THAN SIGN
         {
             0b01U,
             0b10U,
             0b01U,
         },
-        // 0x3D, = EQUALS SIGN
+        // U+003D = EQUALS SIGN
         {
             0b111U,
             0b000U,
             0b111U,
         },
-        // 0x3E, > GREATER-THAN SIGN
+        // U+003E > GREATER-THAN SIGN
         {
             0b10U,
             0b01U,
@@ -145,183 +145,183 @@ private:
     }};
 
     static constexpr std::array<std::array<uint8_t, 3U>, 26U> latinLetterA_latinLetterZ{{
-        // 0x41, A LATIN CAPITAL LETTER A
-        // 0x61, a LATIN SMALL LETTER A
+        // U+0041 A LATIN CAPITAL LETTER A
+        // U+0061 a LATIN SMALL LETTER A
         {
             0b011U,
             0b111U,
             0b111U,
         },
-        // 0x42, B LATIN CAPITAL LETTER B
-        // 0x62, b LATIN SMALL LETTER B
+        // U+0042 B LATIN CAPITAL LETTER B
+        // U+0062 b LATIN SMALL LETTER B
         {
             0b100U,
             0b111U,
             0b111U,
         },
-        // 0x43, C LATIN CAPITAL LETTER C
-        // 0x63, c LATIN SMALL LETTER C
+        // U+0043 C LATIN CAPITAL LETTER C
+        // U+0063 c LATIN SMALL LETTER C
         {
             0b111U,
             0b100U,
             0b111U,
         },
-        // 0x44, D LATIN CAPITAL LETTER D
-        // 0x64, d LATIN SMALL LETTER D
+        // U+0044 D LATIN CAPITAL LETTER D
+        // U+0064 d LATIN SMALL LETTER D
         {
             0b001U,
             0b111U,
             0b111U,
         },
-        // 0x45, E LATIN CAPITAL LETTER E
-        // 0x65, e LATIN SMALL LETTER E
+        // U+0045 E LATIN CAPITAL LETTER E
+        // U+0065 e LATIN SMALL LETTER E
         {
             0b111U,
             0b110U,
             0b111U,
         },
-        // 0x46, F LATIN CAPITAL LETTER F
-        // 0x66, f LATIN SMALL LETTER F
+        // U+0046 F LATIN CAPITAL LETTER F
+        // U+0066 f LATIN SMALL LETTER F
         {
             0b111U,
             0b110U,
             0b100U,
         },
-        // 0x47, G LATIN CAPITAL LETTER G
-        // 0x67, g LATIN SMALL LETTER G
+        // U+0047 G LATIN CAPITAL LETTER G
+        // U+0067 g LATIN SMALL LETTER G
         {
             0b111U,
             0b111U,
             0b111U,
         },
-        // 0x48, H LATIN CAPITAL LETTER H
-        // 0x68, h LATIN SMALL LETTER H
+        // U+0048 H LATIN CAPITAL LETTER H
+        // U+0068 h LATIN SMALL LETTER H
         {
             0b101U,
             0b111U,
             0b101U,
         },
-        // 0x49, I LATIN CAPITAL LETTER I
-        // 0x69, i LATIN SMALL LETTER I
+        // U+0049 I LATIN CAPITAL LETTER I
+        // U+0069 i LATIN SMALL LETTER I
         {
             0b111U,
             0b010U,
             0b111U,
         },
-        // 0x4A, J LATIN CAPITAL LETTER J
-        // 0x6A, j LATIN SMALL LETTER J
+        // U+004A J LATIN CAPITAL LETTER J
+        // U+006A j LATIN SMALL LETTER J
         {
             0b111U,
             0b010U,
             0b110U,
         },
-        // 0x4B, K LATIN CAPITAL LETTER K
-        // 0x6B, k LATIN SMALL LETTER K
+        // U+004B K LATIN CAPITAL LETTER K
+        // U+006B k LATIN SMALL LETTER K
         {
             0b101U,
             0b110U,
             0b101U,
         },
-        // 0x4C, L LATIN CAPITAL LETTER L
-        // 0x6C, l LATIN SMALL LETTER L
+        // U+004C L LATIN CAPITAL LETTER L
+        // U+006C l LATIN SMALL LETTER L
         {
             0b100U,
             0b100U,
             0b111U,
         },
-        // 0x4D, M LATIN CAPITAL LETTER M
-        // 0x6D, m LATIN SMALL LETTER M
+        // U+004D M LATIN CAPITAL LETTER M
+        // U+006D m LATIN SMALL LETTER M
         {
             0b111U,
             0b111U,
             0b101U,
         },
-        // 0x4E, N LATIN CAPITAL LETTER N
-        // 0x6E, n LATIN SMALL LETTER N
+        // U+004E N LATIN CAPITAL LETTER N
+        // U+006E n LATIN SMALL LETTER N
         {
             0b111U,
             0b101U,
             0b101U,
         },
-        // 0x4F, O LATIN CAPITAL LETTER O
-        // 0x6F, o LATIN SMALL LETTER O
+        // U+004F O LATIN CAPITAL LETTER O
+        // U+006F o LATIN SMALL LETTER O
         {
             0b111U,
             0b101U,
             0b111U,
         },
-        // 0x50, P LATIN CAPITAL LETTER P
-        // 0x70, p LATIN SMALL LETTER P
+        // U+0050 P LATIN CAPITAL LETTER P
+        // U+0070 p LATIN SMALL LETTER P
         {
             0b111U,
             0b111U,
             0b100U,
         },
-        // 0x51, Q LATIN CAPITAL LETTER Q
-        // 0x71, q LATIN SMALL LETTER Q
+        // U+0051 Q LATIN CAPITAL LETTER Q
+        // U+0071 q LATIN SMALL LETTER Q
         {
             0b111U,
             0b111U,
             0b001U,
         },
-        // 0x52, R LATIN CAPITAL LETTER R
-        // 0x72, r LATIN SMALL LETTER R
+        // U+0052 R LATIN CAPITAL LETTER R
+        // U+0072 r LATIN SMALL LETTER R
         {
             0b111U,
             0b110U,
             0b101U,
         },
-        // 0x53, S LATIN CAPITAL LETTER S
-        // 0x73, s LATIN SMALL LETTER S
+        // U+0053 S LATIN CAPITAL LETTER S
+        // U+0073 s LATIN SMALL LETTER S
         {
             0b011U,
             0b010U,
             0b110U,
         },
-        // 0x54, T LATIN CAPITAL LETTER T
-        // 0x74, t LATIN SMALL LETTER T
+        // U+0054 T LATIN CAPITAL LETTER T
+        // U+0074 t LATIN SMALL LETTER T
         {
             0b111U,
             0b010U,
             0b010U,
         },
-        // 0x55, U LATIN CAPITAL LETTER U
-        // 0x75, u LATIN SMALL LETTER U
+        // U+0055 U LATIN CAPITAL LETTER U
+        // U+0075 u LATIN SMALL LETTER U
         {
             0b101U,
             0b101U,
             0b111U,
         },
-        // 0x56, V LATIN CAPITAL LETTER V
-        // 0x76, v LATIN SMALL LETTER V
+        // U+0056 V LATIN CAPITAL LETTER V
+        // U+0076 v LATIN SMALL LETTER V
         {
             0b101U,
             0b101U,
             0b010U,
         },
-        // 0x57, W LATIN CAPITAL LETTER W
-        // 0x77, w LATIN SMALL LETTER W
+        // U+0057 W LATIN CAPITAL LETTER W
+        // U+0077 w LATIN SMALL LETTER W
         {
             0b101U,
             0b111U,
             0b111U,
         },
-        // 0x58, X LATIN CAPITAL LETTER X
-        // 0x78, x LATIN SMALL LETTER X
+        // U+0058 X LATIN CAPITAL LETTER X
+        // U+0078 x LATIN SMALL LETTER X
         {
             0b101U,
             0b010U,
             0b101U,
         },
-        // 0x59, Y LATIN CAPITAL LETTER Y
-        // 0x79, y LATIN SMALL LETTER Y
+        // U+0059 Y LATIN CAPITAL LETTER Y
+        // U+0079 y LATIN SMALL LETTER Y
         {
             0b101U,
             0b111U,
             0b010U,
         },
-        // 0x5A, Z LATIN CAPITAL LETTER Z
-        // 0x7A, z LATIN SMALL LETTER Z
+        // U+005A Z LATIN CAPITAL LETTER Z
+        // U+007A z LATIN SMALL LETTER Z
         {
             0b110U,
             0b010U,
@@ -330,19 +330,19 @@ private:
     }};
 
     static constexpr std::array<std::array<uint8_t, 3U>, 3U> leftSquareBracket_rightSquareBracket{{
-        // 0x5B, [ LEFT SQUARE BRACKET
+        // U+005B [ LEFT SQUARE BRACKET
         {
             0b11U,
             0b10U,
             0b11U,
         },
-        // 0x5C, REVERSE SOLIDUS
+        // U+005C REVERSE SOLIDUS
         {
             0b100U,
             0b010U,
             0b001U,
         },
-        // 0x5D, ] RIGHT SQUARE BRACKET
+        // U+005D ] RIGHT SQUARE BRACKET
         {
             0b11U,
             0b01U,
@@ -350,26 +350,26 @@ private:
         },
     }};
 
-    // 0x5E, ^ CIRCUMFLEX ACCENT
+    // U+005E ^ CIRCUMFLEX ACCENT
     static constexpr std::array<uint8_t, 2U> circumflexAccent{
         0b010U,
         0b101U,
     };
 
     static constexpr std::array<std::array<uint8_t, 3U>, 3U> leftCurlyBracket_rightCurlyBracket{{
-        // 0x7B, { LEFT CURLY BRACKET
+        // U+007B { LEFT CURLY BRACKET
         {
             0b001U,
             0b110U,
             0b001U,
         },
-        // 0x7C, | VERTICAL LINE
+        // U+007C | VERTICAL LINE
         {
             0b1U,
             0b1U,
             0b1U,
         },
-        // 0x7D, } RIGHT CURLY BRACKET
+        // U+007D } RIGHT CURLY BRACKET
         {
             0b100U,
             0b011U,

--- a/firmware/include/fonts/MicroFont.h
+++ b/firmware/include/fonts/MicroFont.h
@@ -9,380 +9,380 @@
 class MicroFont final : public FontModule
 {
 private:
-    static constexpr std::array<uint8_t, 1> char22 = {0b11}; // 0x22, "
+    static constexpr std::array<uint8_t, 1U> quotationMark{0b11U}; // 0x22, " QUOTATION MARK
 
-    // 0x27, '
-    // 0x2A, *
-    // 0x2C, ,
-    // 0x2E, .
-    // 0x60, `
+    // 0x27, ' APOSTROPHE
+    // 0x2A, * ASTERISK
+    // 0x2C, , COMMA
+    // 0x2E, . FULL STOP
+    // 0x60, ` GRAVE ACCENT
     // 0xB0, ° DEGREE SIGN
-    static constexpr std::array<uint8_t, 1> char27 = {0b1};
+    static constexpr std::array<uint8_t, 1U> apostrophe{0b1U};
 
-    static constexpr std::array<std::array<uint8_t, 3>, 2> chars28 = {{
-        // 0x28, (
+    static constexpr std::array<std::array<uint8_t, 3U>, 2U> leftParenthesis_rightParenthesis{{
+        // 0x28, ( LEFT PARENTHESIS
         {
-            0b01,
-            0b10,
-            0b01,
+            0b01U,
+            0b10U,
+            0b01U,
         },
-        // 0x29, (
+        // 0x29, ) RIGHT PARENTHESIS
         {
-            0b10,
-            0b01,
-            0b10,
+            0b10U,
+            0b01U,
+            0b10U,
         },
     }};
 
-    // 0x2B, +
-    static constexpr std::array<uint8_t, 3> char2B = {
-        0b010,
-        0b111,
-        0b010,
+    // 0x2B, + PLUS SIGN
+    static constexpr std::array<uint8_t, 3U> plusSign{
+        0b010U,
+        0b111U,
+        0b010U,
     };
 
-    // 0x2D, -
-    // 0x5F, _
-    static constexpr std::array<uint8_t, 1> char2D = {0b111};
+    // 0x2D, - HYPHEN-MINUS
+    // 0x5F, _ LOW LINE
+    static constexpr std::array<uint8_t, 1U> hyphenMinus{0b111U};
 
-    static constexpr std::array<std::array<uint8_t, 3>, 16> chars2F = {{
-        // 0x2F, /
+    static constexpr std::array<std::array<uint8_t, 3U>, 16U> solidus_greaterThanSign{{
+        // 0x2F, / SOLIDUS
         {
-            0b001,
-            0b010,
-            0b100,
+            0b001U,
+            0b010U,
+            0b100U,
         },
-        // 0x30, 0
+        // 0x30, 0 DIGIT ZERO
         {
-            0b111,
-            0b101,
-            0b111,
+            0b111U,
+            0b101U,
+            0b111U,
         },
-        // 0x31, 1
+        // 0x31, 1 DIGIT ONE
         {
-            0b11,
-            0b01,
-            0b01,
+            0b11U,
+            0b01U,
+            0b01U,
         },
-        // 0x32, 2
+        // 0x32, 2 DIGIT TWO
         {
-            0b110,
-            0b010,
-            0b011,
+            0b110U,
+            0b010U,
+            0b011U,
         },
-        // 0x33, 3
+        // 0x33, 3 DIGIT THREE
         {
-            0b111,
-            0b011,
-            0b111,
+            0b111U,
+            0b011U,
+            0b111U,
         },
-        // 0x34, 4
+        // 0x34, 4 DIGIT FOUR
         {
-            0b101,
-            0b111,
-            0b001,
+            0b101U,
+            0b111U,
+            0b001U,
         },
-        // 0x35, 5
+        // 0x35, 5 DIGIT FIVE
         {
-            0b011,
-            0b010,
-            0b110,
+            0b011U,
+            0b010U,
+            0b110U,
         },
-        // 0x36, 6
+        // 0x36, 6 DIGIT SIX
         {
-            0b100,
-            0b111,
-            0b111,
+            0b100U,
+            0b111U,
+            0b111U,
         },
-        // 0x37, 7
+        // 0x37, 7 DIGIT SEVEN
         {
-            0b111,
-            0b011,
-            0b001,
+            0b111U,
+            0b011U,
+            0b001U,
         },
-        // 0x38, 8
+        // 0x38, 8 DIGIT EIGHT
         {
-            0b111,
-            0b111,
-            0b111,
+            0b111U,
+            0b111U,
+            0b111U,
         },
-        // 0x39, 9
+        // 0x39, 9 DIGIT NINE
         {
-            0b111,
-            0b111,
-            0b001,
+            0b111U,
+            0b111U,
+            0b001U,
         },
-        // 0x3A, :
+        // 0x3A, : COLON
         {
-            0b1,
-            0b0,
-            0b1,
+            0b1U,
+            0b0U,
+            0b1U,
         },
-        // 0x3B, ;
+        // 0x3B, ; SEMICOLON
         {
-            0b01,
-            0b00,
-            0b11,
+            0b01U,
+            0b00U,
+            0b11U,
         },
-        // 0x3C, <
+        // 0x3C, < LESS-THAN SIGN
         {
-            0b01,
-            0b10,
-            0b01,
+            0b01U,
+            0b10U,
+            0b01U,
         },
-        // 0x3D, =
+        // 0x3D, = EQUALS SIGN
         {
-            0b111,
-            0b000,
-            0b111,
+            0b111U,
+            0b000U,
+            0b111U,
         },
-        // 0x3E, >
+        // 0x3E, > GREATER-THAN SIGN
         {
-            0b10,
-            0b01,
-            0b10,
+            0b10U,
+            0b01U,
+            0b10U,
         },
     }};
 
-    static constexpr std::array<std::array<uint8_t, 3>, 26> chars41 = {{
-        // 0x41, A
-        // 0x61, a
+    static constexpr std::array<std::array<uint8_t, 3U>, 26U> latinLetterA_latinLetterZ{{
+        // 0x41, A LATIN CAPITAL LETTER A
+        // 0x61, a LATIN SMALL LETTER A
         {
-            0b011,
-            0b111,
-            0b111,
+            0b011U,
+            0b111U,
+            0b111U,
         },
-        // 0x42, B
-        // 0x62, b
+        // 0x42, B LATIN CAPITAL LETTER B
+        // 0x62, b LATIN SMALL LETTER B
         {
-            0b100,
-            0b111,
-            0b111,
+            0b100U,
+            0b111U,
+            0b111U,
         },
-        // 0x43, C
-        // 0x63, c
+        // 0x43, C LATIN CAPITAL LETTER C
+        // 0x63, c LATIN SMALL LETTER C
         {
-            0b111,
-            0b100,
-            0b111,
+            0b111U,
+            0b100U,
+            0b111U,
         },
-        // 0x44, D
-        // 0x64, d
+        // 0x44, D LATIN CAPITAL LETTER D
+        // 0x64, d LATIN SMALL LETTER D
         {
-            0b001,
-            0b111,
-            0b111,
+            0b001U,
+            0b111U,
+            0b111U,
         },
-        // 0x45, E
-        // 0x65, e
+        // 0x45, E LATIN CAPITAL LETTER E
+        // 0x65, e LATIN SMALL LETTER E
         {
-            0b111,
-            0b110,
-            0b111,
+            0b111U,
+            0b110U,
+            0b111U,
         },
-        // 0x46, F
-        // 0x66, f
+        // 0x46, F LATIN CAPITAL LETTER F
+        // 0x66, f LATIN SMALL LETTER F
         {
-            0b111,
-            0b110,
-            0b100,
+            0b111U,
+            0b110U,
+            0b100U,
         },
-        // 0x47, G
-        // 0x67, g
+        // 0x47, G LATIN CAPITAL LETTER G
+        // 0x67, g LATIN SMALL LETTER G
         {
-            0b111,
-            0b111,
-            0b111,
+            0b111U,
+            0b111U,
+            0b111U,
         },
-        // 0x48, H
-        // 0x68, h
+        // 0x48, H LATIN CAPITAL LETTER H
+        // 0x68, h LATIN SMALL LETTER H
         {
-            0b101,
-            0b111,
-            0b101,
+            0b101U,
+            0b111U,
+            0b101U,
         },
-        // 0x49, I
-        // 0x69, i
+        // 0x49, I LATIN CAPITAL LETTER I
+        // 0x69, i LATIN SMALL LETTER I
         {
-            0b111,
-            0b010,
-            0b111,
+            0b111U,
+            0b010U,
+            0b111U,
         },
-        // 0x4A, J
-        // 0x6A, j
+        // 0x4A, J LATIN CAPITAL LETTER J
+        // 0x6A, j LATIN SMALL LETTER J
         {
-            0b111,
-            0b010,
-            0b110,
+            0b111U,
+            0b010U,
+            0b110U,
         },
-        // 0x4B, K
-        // 0x6B, k
+        // 0x4B, K LATIN CAPITAL LETTER K
+        // 0x6B, k LATIN SMALL LETTER K
         {
-            0b101,
-            0b110,
-            0b101,
+            0b101U,
+            0b110U,
+            0b101U,
         },
-        // 0x4C, L
-        // 0x6C, l
+        // 0x4C, L LATIN CAPITAL LETTER L
+        // 0x6C, l LATIN SMALL LETTER L
         {
-            0b100,
-            0b100,
-            0b111,
+            0b100U,
+            0b100U,
+            0b111U,
         },
-        // 0x4D, M
-        // 0x6D, m
+        // 0x4D, M LATIN CAPITAL LETTER M
+        // 0x6D, m LATIN SMALL LETTER M
         {
-            0b111,
-            0b111,
-            0b101,
+            0b111U,
+            0b111U,
+            0b101U,
         },
-        // 0x4E, N
-        // 0x6E, n
+        // 0x4E, N LATIN CAPITAL LETTER N
+        // 0x6E, n LATIN SMALL LETTER N
         {
-            0b111,
-            0b101,
-            0b101,
+            0b111U,
+            0b101U,
+            0b101U,
         },
-        // 0x4F, O
-        // 0x6F, o
+        // 0x4F, O LATIN CAPITAL LETTER O
+        // 0x6F, o LATIN SMALL LETTER O
         {
-            0b111,
-            0b101,
-            0b111,
+            0b111U,
+            0b101U,
+            0b111U,
         },
-        // 0x50, P
-        // 0x70, p
+        // 0x50, P LATIN CAPITAL LETTER P
+        // 0x70, p LATIN SMALL LETTER P
         {
-            0b111,
-            0b111,
-            0b100,
+            0b111U,
+            0b111U,
+            0b100U,
         },
-        // 0x51, Q
-        // 0x71, q
+        // 0x51, Q LATIN CAPITAL LETTER Q
+        // 0x71, q LATIN SMALL LETTER Q
         {
-            0b111,
-            0b111,
-            0b001,
+            0b111U,
+            0b111U,
+            0b001U,
         },
-        // 0x52, R
-        // 0x72, r
+        // 0x52, R LATIN CAPITAL LETTER R
+        // 0x72, r LATIN SMALL LETTER R
         {
-            0b111,
-            0b110,
-            0b101,
+            0b111U,
+            0b110U,
+            0b101U,
         },
-        // 0x53, S
-        // 0x73, s
+        // 0x53, S LATIN CAPITAL LETTER S
+        // 0x73, s LATIN SMALL LETTER S
         {
-            0b011,
-            0b010,
-            0b110,
+            0b011U,
+            0b010U,
+            0b110U,
         },
-        // 0x54, T
-        // 0x74, t
+        // 0x54, T LATIN CAPITAL LETTER T
+        // 0x74, t LATIN SMALL LETTER T
         {
-            0b111,
-            0b010,
-            0b010,
+            0b111U,
+            0b010U,
+            0b010U,
         },
-        // 0x55, U
-        // 0x75, u
+        // 0x55, U LATIN CAPITAL LETTER U
+        // 0x75, u LATIN SMALL LETTER U
         {
-            0b101,
-            0b101,
-            0b111,
+            0b101U,
+            0b101U,
+            0b111U,
         },
-        // 0x56, V
-        // 0x76, v
+        // 0x56, V LATIN CAPITAL LETTER V
+        // 0x76, v LATIN SMALL LETTER V
         {
-            0b101,
-            0b101,
-            0b010,
+            0b101U,
+            0b101U,
+            0b010U,
         },
-        // 0x57, W
-        // 0x77, w
+        // 0x57, W LATIN CAPITAL LETTER W
+        // 0x77, w LATIN SMALL LETTER W
         {
-            0b101,
-            0b111,
-            0b111,
+            0b101U,
+            0b111U,
+            0b111U,
         },
-        // 0x58, X
-        // 0x78, x
+        // 0x58, X LATIN CAPITAL LETTER X
+        // 0x78, x LATIN SMALL LETTER X
         {
-            0b101,
-            0b010,
-            0b101,
+            0b101U,
+            0b010U,
+            0b101U,
         },
-        // 0x59, Y
-        // 0x79, y
+        // 0x59, Y LATIN CAPITAL LETTER Y
+        // 0x79, y LATIN SMALL LETTER Y
         {
-            0b101,
-            0b111,
-            0b010,
+            0b101U,
+            0b111U,
+            0b010U,
         },
-        // 0x5A, Z
-        // 0x7A, z
+        // 0x5A, Z LATIN CAPITAL LETTER Z
+        // 0x7A, z LATIN SMALL LETTER Z
         {
-            0b110,
-            0b010,
-            0b011,
+            0b110U,
+            0b010U,
+            0b011U,
         },
     }};
 
-    static constexpr std::array<std::array<uint8_t, 3>, 3> chars5B = {{
-        // 0x5B, [
+    static constexpr std::array<std::array<uint8_t, 3U>, 3U> leftSquareBracket_rightSquareBracket{{
+        // 0x5B, [ LEFT SQUARE BRACKET
         {
-            0b11,
-            0b10,
-            0b11,
+            0b11U,
+            0b10U,
+            0b11U,
         },
         // 0x5C, REVERSE SOLIDUS
         {
-            0b100,
-            0b010,
-            0b001,
+            0b100U,
+            0b010U,
+            0b001U,
         },
-        // 0x5D, ]
+        // 0x5D, ] RIGHT SQUARE BRACKET
         {
-            0b11,
-            0b01,
-            0b11,
+            0b11U,
+            0b01U,
+            0b11U,
         },
     }};
 
-    // 0x5E, ^
-    static constexpr std::array<uint8_t, 2> char5E = {
-        0b010,
-        0b101,
+    // 0x5E, ^ CIRCUMFLEX ACCENT
+    static constexpr std::array<uint8_t, 2U> circumflexAccent{
+        0b010U,
+        0b101U,
     };
 
-    static constexpr std::array<std::array<uint8_t, 3>, 3> chars7B = {{
-        // 0x7B, {
+    static constexpr std::array<std::array<uint8_t, 3U>, 3U> leftCurlyBracket_rightCurlyBracket{{
+        // 0x7B, { LEFT CURLY BRACKET
         {
-            0b001,
-            0b110,
-            0b001,
+            0b001U,
+            0b110U,
+            0b001U,
         },
-        // 0x7C, |
+        // 0x7C, | VERTICAL LINE
         {
-            0b1,
-            0b1,
-            0b1,
+            0b1U,
+            0b1U,
+            0b1U,
         },
-        // 0x7D, }
+        // 0x7D, } RIGHT CURLY BRACKET
         {
-            0b100,
-            0b011,
-            0b100,
+            0b100U,
+            0b011U,
+            0b100U,
         },
     }};
 
 public:
-    static constexpr std::string_view name = "Micro";
+    static constexpr std::string_view name{"Micro"};
 
     explicit MicroFont() : FontModule(name) {};
 
-    [[nodiscard]] FontModule::Symbol getChar(uint32_t character) const override;
+    [[nodiscard]] FontModule::Symbol getChar(char32_t character) const override;
 };
 
 #endif // FONT_MICRO

--- a/firmware/include/fonts/MiniFont.h
+++ b/firmware/include/fonts/MiniFont.h
@@ -9,594 +9,594 @@
 class MiniFont final : public FontModule
 {
 private:
-    // 0x2B, +
-    static constexpr std::array<uint8_t, 3> char2B = {
-        0b010,
-        0b111,
-        0b010,
+    // 0x2B, + PLUS SIGN
+    static constexpr std::array<uint8_t, 3U> plusSign{
+        0b010U,
+        0b111U,
+        0b010U,
     };
 
-    // 0x2C, ,
-    static constexpr std::array<uint8_t, 2> char2C = {
-        0b01,
-        0b10,
+    // 0x2C, , COMMA
+    static constexpr std::array<uint8_t, 2U> comma{
+        0b01U,
+        0b10U,
     };
 
-    // 0x2D, -
-    // 0x5F, _
-    static constexpr std::array<uint8_t, 1> char2D = {0b111};
+    // 0x2D, - HYPHEN-MINUS
+    // 0x5F, _ LOW LINE
+    static constexpr std::array<uint8_t, 1U> hyphenMinus{0b111U};
 
-    // 0x2E, .
-    static constexpr std::array<uint8_t, 1> char2E = {0b1};
+    // 0x2E, . FULL STOP
+    static constexpr std::array<uint8_t, 1U> fullStop{0b1U};
 
-    static constexpr std::array<std::array<uint8_t, 5>, 10> chars30 = {{
-        // 0x30, 0
+    static constexpr std::array<std::array<uint8_t, 5U>, 10U> digitZero_digitNine{{
+        // 0x30, 0 DIGIT ZERO
         {
-            0b111,
-            0b101,
-            0b101,
-            0b101,
-            0b111,
+            0b111U,
+            0b101U,
+            0b101U,
+            0b101U,
+            0b111U,
         },
-        // 0x31, 1
+        // 0x31, 1 DIGIT ONE
         {
-            0b010,
-            0b110,
-            0b010,
-            0b010,
-            0b111,
+            0b010U,
+            0b110U,
+            0b010U,
+            0b010U,
+            0b111U,
         },
-        // 0x32, 2
+        // 0x32, 2 DIGIT TWO
         {
-            0b111,
-            0b001,
-            0b111,
-            0b100,
-            0b111,
+            0b111U,
+            0b001U,
+            0b111U,
+            0b100U,
+            0b111U,
         },
-        // 0x33, 3
+        // 0x33, 3 DIGIT THREE
         {
-            0b111,
-            0b001,
-            0b111,
-            0b001,
-            0b111,
+            0b111U,
+            0b001U,
+            0b111U,
+            0b001U,
+            0b111U,
         },
-        // 0x34, 4
+        // 0x34, 4 DIGIT FOUR
         {
-            0b101,
-            0b101,
-            0b111,
-            0b001,
-            0b001,
+            0b101U,
+            0b101U,
+            0b111U,
+            0b001U,
+            0b001U,
         },
-        // 0x35, 5
+        // 0x35, 5 DIGIT FIVE
         {
-            0b111,
-            0b100,
-            0b111,
-            0b001,
-            0b111,
+            0b111U,
+            0b100U,
+            0b111U,
+            0b001U,
+            0b111U,
         },
-        // 0x36, 6
+        // 0x36, 6 DIGIT SIX
         {
-            0b111,
-            0b100,
-            0b111,
-            0b101,
-            0b111,
+            0b111U,
+            0b100U,
+            0b111U,
+            0b101U,
+            0b111U,
         },
-        // 0x37, 7
+        // 0x37, 7 DIGIT SEVEN
         {
-            0b111,
-            0b001,
-            0b001,
-            0b001,
-            0b001,
+            0b111U,
+            0b001U,
+            0b001U,
+            0b001U,
+            0b001U,
         },
-        // 0x38, 8
+        // 0x38, 8 DIGIT EIGHT
         {
-            0b111,
-            0b101,
-            0b111,
-            0b101,
-            0b111,
+            0b111U,
+            0b101U,
+            0b111U,
+            0b101U,
+            0b111U,
         },
-        // 0x39, 9
+        // 0x39, 9 DIGIT NINE
         {
-            0b111,
-            0b101,
-            0b111,
-            0b001,
-            0b111,
+            0b111U,
+            0b101U,
+            0b111U,
+            0b001U,
+            0b111U,
         },
     }};
 
-    // 0x3A, :
-    static constexpr std::array<uint8_t, 3> char3A = {
-        0b1,
-        0b0,
-        0b1,
+    // 0x3A, : COLON
+    static constexpr std::array<uint8_t, 3U> colon{
+        0b1U,
+        0b0U,
+        0b1U,
     };
 
-    // 0x3D, =
-    static constexpr std::array<uint8_t, 3> char3D = {
-        0b111,
-        0b000,
-        0b111,
+    // 0x3D, = EQUALS SIGN
+    static constexpr std::array<uint8_t, 3U> equalsSign{
+        0b111U,
+        0b000U,
+        0b111U,
     };
 
-    static constexpr std::array<std::array<uint8_t, 5>, 29> chars41 = {{
-        // 0x41, A
+    static constexpr std::array<std::array<uint8_t, 5U>, 29U> latinCapitalLetterA_rightSquareBracket{{
+        // 0x41, A LATIN CAPITAL LETTER A
         {
-            0b010,
-            0b101,
-            0b111,
-            0b101,
-            0b101,
+            0b010U,
+            0b101U,
+            0b111U,
+            0b101U,
+            0b101U,
         },
-        // 0x42, B
+        // 0x42, B LATIN CAPITAL LETTER B
         {
-            0b110,
-            0b101,
-            0b110,
-            0b101,
-            0b110,
+            0b110U,
+            0b101U,
+            0b110U,
+            0b101U,
+            0b110U,
         },
-        // 0x43, C
+        // 0x43, C LATIN CAPITAL LETTER C
         {
-            0b111,
-            0b100,
-            0b100,
-            0b100,
-            0b111,
+            0b111U,
+            0b100U,
+            0b100U,
+            0b100U,
+            0b111U,
         },
-        // 0x44, D
+        // 0x44, D LATIN CAPITAL LETTER D
         {
-            0b110,
-            0b101,
-            0b101,
-            0b101,
-            0b110,
+            0b110U,
+            0b101U,
+            0b101U,
+            0b101U,
+            0b110U,
         },
-        // 0x45, E
+        // 0x45, E LATIN CAPITAL LETTER E
         {
-            0b111,
-            0b100,
-            0b110,
-            0b100,
-            0b111,
+            0b111U,
+            0b100U,
+            0b110U,
+            0b100U,
+            0b111U,
         },
-        // 0x46, F
+        // 0x46, F LATIN CAPITAL LETTER F
         {
-            0b111,
-            0b100,
-            0b110,
-            0b100,
-            0b100,
+            0b111U,
+            0b100U,
+            0b110U,
+            0b100U,
+            0b100U,
         },
-        // 0x47, G
+        // 0x47, G LATIN CAPITAL LETTER G
         {
-            0b011,
-            0b100,
-            0b111,
-            0b101,
-            0b110,
+            0b011U,
+            0b100U,
+            0b111U,
+            0b101U,
+            0b110U,
         },
-        // 0x48, H
+        // 0x48, H LATIN CAPITAL LETTER H
         {
-            0b101,
-            0b101,
-            0b111,
-            0b101,
-            0b101,
+            0b101U,
+            0b101U,
+            0b111U,
+            0b101U,
+            0b101U,
         },
-        // 0x49, I
+        // 0x49, I LATIN CAPITAL LETTER I
         {
-            0b1,
-            0b1,
-            0b1,
-            0b1,
-            0b1,
+            0b1U,
+            0b1U,
+            0b1U,
+            0b1U,
+            0b1U,
         },
-        // 0x4A, J
+        // 0x4A, J LATIN CAPITAL LETTER J
         {
-            0b001,
-            0b001,
-            0b001,
-            0b101,
-            0b111,
+            0b001U,
+            0b001U,
+            0b001U,
+            0b101U,
+            0b111U,
         },
-        // 0x4B, K
+        // 0x4B, K LATIN CAPITAL LETTER K
         {
-            0b101,
-            0b101,
-            0b110,
-            0b111,
-            0b101,
+            0b101U,
+            0b101U,
+            0b110U,
+            0b111U,
+            0b101U,
         },
-        // 0x4C, L
+        // 0x4C, L LATIN CAPITAL LETTER L
         {
-            0b100,
-            0b100,
-            0b100,
-            0b100,
-            0b111,
+            0b100U,
+            0b100U,
+            0b100U,
+            0b100U,
+            0b111U,
         },
-        // 0x4D, M
+        // 0x4D, M LATIN CAPITAL LETTER M
         {
-            0b10001,
-            0b11011,
-            0b10101,
-            0b10001,
-            0b10001,
+            0b10001U,
+            0b11011U,
+            0b10101U,
+            0b10001U,
+            0b10001U,
         },
-        // 0x4E, N
+        // 0x4E, N LATIN CAPITAL LETTER N
         {
-            0b10001,
-            0b11001,
-            0b10101,
-            0b10011,
-            0b10001,
+            0b10001U,
+            0b11001U,
+            0b10101U,
+            0b10011U,
+            0b10001U,
         },
-        // 0x4F, O
+        // 0x4F, O LATIN CAPITAL LETTER O
         {
-            0b010,
-            0b101,
-            0b101,
-            0b101,
-            0b010,
+            0b010U,
+            0b101U,
+            0b101U,
+            0b101U,
+            0b010U,
         },
-        // 0x50, P
+        // 0x50, P LATIN CAPITAL LETTER P
         {
-            0b110,
-            0b101,
-            0b110,
-            0b100,
-            0b100,
+            0b110U,
+            0b101U,
+            0b110U,
+            0b100U,
+            0b100U,
         },
-        // 0x51, Q
+        // 0x51, Q LATIN CAPITAL LETTER Q
         {
-            0b010,
-            0b101,
-            0b101,
-            0b111,
-            0b011,
+            0b010U,
+            0b101U,
+            0b101U,
+            0b111U,
+            0b011U,
         },
-        // 0x52, R
+        // 0x52, R LATIN CAPITAL LETTER R
         {
-            0b110,
-            0b101,
-            0b110,
-            0b110,
-            0b101,
+            0b110U,
+            0b101U,
+            0b110U,
+            0b110U,
+            0b101U,
         },
-        // 0x53, S
+        // 0x53, S LATIN CAPITAL LETTER S
         {
-            0b111,
-            0b100,
-            0b111,
-            0b001,
-            0b111,
+            0b111U,
+            0b100U,
+            0b111U,
+            0b001U,
+            0b111U,
         },
-        // 0x54, T
+        // 0x54, T LATIN CAPITAL LETTER T
         {
-            0b111,
-            0b010,
-            0b010,
-            0b010,
-            0b010,
+            0b111U,
+            0b010U,
+            0b010U,
+            0b010U,
+            0b010U,
         },
-        // 0x55, U
+        // 0x55, U LATIN CAPITAL LETTER U
         {
-            0b101,
-            0b101,
-            0b101,
-            0b101,
-            0b111,
+            0b101U,
+            0b101U,
+            0b101U,
+            0b101U,
+            0b111U,
         },
-        // 0x56, V
+        // 0x56, V LATIN CAPITAL LETTER V
         {
-            0b101,
-            0b101,
-            0b101,
-            0b101,
-            0b010,
+            0b101U,
+            0b101U,
+            0b101U,
+            0b101U,
+            0b010U,
         },
-        // 0x57, W
+        // 0x57, W LATIN CAPITAL LETTER W
         {
-            0b10101,
-            0b10101,
-            0b10101,
-            0b10101,
-            0b01010,
+            0b10101U,
+            0b10101U,
+            0b10101U,
+            0b10101U,
+            0b01010U,
         },
-        // 0x58, X
+        // 0x58, X LATIN CAPITAL LETTER X
         {
-            0b101,
-            0b101,
-            0b010,
-            0b101,
-            0b101,
+            0b101U,
+            0b101U,
+            0b010U,
+            0b101U,
+            0b101U,
         },
-        // 0x59, Y
+        // 0x59, Y LATIN CAPITAL LETTER Y
         {
-            0b101,
-            0b101,
-            0b101,
-            0b010,
-            0b010,
+            0b101U,
+            0b101U,
+            0b101U,
+            0b010U,
+            0b010U,
         },
-        // 0x5A, Z
+        // 0x5A, Z LATIN CAPITAL LETTER Z
         {
-            0b111,
-            0b001,
-            0b010,
-            0b100,
-            0b111,
+            0b111U,
+            0b001U,
+            0b010U,
+            0b100U,
+            0b111U,
         },
-        // 0x5B, [
+        // 0x5B, [ LEFT SQUARE BRACKET
         {
-            0b11,
-            0b10,
-            0b10,
-            0b10,
-            0b11,
+            0b11U,
+            0b10U,
+            0b10U,
+            0b10U,
+            0b11U,
         },
         // 0x5C, REVERSE SOLIDUS
         {
-            0b110,
-            0b010,
-            0b010,
-            0b010,
-            0b001,
+            0b110U,
+            0b010U,
+            0b010U,
+            0b010U,
+            0b001U,
         },
-        // 0x5D, ]
+        // 0x5D, ] RIGHT SQUARE BRACKET
         {
-            0b11,
-            0b01,
-            0b01,
-            0b01,
-            0b11,
+            0b11U,
+            0b01U,
+            0b01U,
+            0b01U,
+            0b11U,
         },
     }};
 
-    // 0x61, a
-    static constexpr std::array<uint8_t, 5> char61 = {
-        0b110,
-        0b001,
-        0b011,
-        0b101,
-        0b111,
+    // 0x61, a LATIN SMALL LETTER A
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterA{
+        0b110U,
+        0b001U,
+        0b011U,
+        0b101U,
+        0b111U,
     };
 
-    // 0x62, b
-    static constexpr std::array<uint8_t, 4> char62 = {
-        0b100,
-        0b110,
-        0b101,
-        0b110,
+    // 0x62, b LATIN SMALL LETTER B
+    static constexpr std::array<uint8_t, 4U> latinSmallLetterB{
+        0b100U,
+        0b110U,
+        0b101U,
+        0b110U,
     };
 
-    // 0x63, c
-    static constexpr std::array<uint8_t, 3> char63 = {
-        0b011,
-        0b100,
-        0b011,
+    // 0x63, c LATIN SMALL LETTER C
+    static constexpr std::array<uint8_t, 3U> latinSmallLetterC{
+        0b011U,
+        0b100U,
+        0b011U,
     };
 
-    // 0x64, d
-    static constexpr std::array<uint8_t, 4> char64 = {
-        0b001,
-        0b011,
-        0b101,
-        0b011,
+    // 0x64, d LATIN SMALL LETTER D
+    static constexpr std::array<uint8_t, 4U> latinSmallLetterD{
+        0b001U,
+        0b011U,
+        0b101U,
+        0b011U,
     };
 
-    static constexpr std::array<std::array<uint8_t, 5>, 3> chars65 = {{
-        // 0x65, e
+    static constexpr std::array<std::array<uint8_t, 5U>, 3U> latinSmallLetterE_latinSmallLetterG{{
+        // 0x65, e LATIN SMALL LETTER E
         {
-            0b010,
-            0b101,
-            0b111,
-            0b100,
-            0b011,
+            0b010U,
+            0b101U,
+            0b111U,
+            0b100U,
+            0b011U,
         },
-        // 0x66, f
+        // 0x66, f LATIN SMALL LETTER F
         {
-            0b011,
-            0b010,
-            0b111,
-            0b010,
-            0b010,
+            0b011U,
+            0b010U,
+            0b111U,
+            0b010U,
+            0b010U,
         },
-        // 0x67, g
+        // 0x67, g LATIN SMALL LETTER G
         {
-            0b011,
-            0b101,
-            0b111,
-            0b111,
-            0b010,
+            0b011U,
+            0b101U,
+            0b111U,
+            0b111U,
+            0b010U,
         },
     }};
 
-    static constexpr std::array<std::array<uint8_t, 4>, 2> chars68 = {{
-        // 0x68, h
+    static constexpr std::array<std::array<uint8_t, 4U>, 2U> latinSmallLetterH_latinSmallLetterI{{
+        // 0x68, h LATIN SMALL LETTER H
         {
-            0b100,
-            0b100,
-            0b110,
-            0b101,
+            0b100U,
+            0b100U,
+            0b110U,
+            0b101U,
         },
-        // 0x69, i
+        // 0x69, i LATIN SMALL LETTER I
         {
-            0b1,
-            0b0,
-            0b1,
-            0b1,
-        },
-    }};
-
-    // 0x6A, j
-    static constexpr std::array<uint8_t, 5> char6A = {
-        0b01,
-        0b00,
-        0b01,
-        0b01,
-        0b10,
-    };
-
-    static constexpr std::array<std::array<uint8_t, 4>, 2> chars6B = {{
-        // 0x6B, k
-        {
-            0b101,
-            0b110,
-            0b110,
-            0b101,
-        },
-        // 0x6C, l
-        {
-            0b1,
-            0b1,
-            0b1,
-            0b1,
+            0b1U,
+            0b0U,
+            0b1U,
+            0b1U,
         },
     }};
 
-    static constexpr std::array<std::array<uint8_t, 3>, 2> chars6D = {{
-        // 0x6D, m
+    // 0x6A, j LATIN SMALL LETTER J
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterJ{
+        0b01U,
+        0b00U,
+        0b01U,
+        0b01U,
+        0b10U,
+    };
+
+    static constexpr std::array<std::array<uint8_t, 4U>, 2U> latinSmallLetterK_latinSmallLetterL{{
+        // 0x6B, k LATIN SMALL LETTER K
         {
-            0b01010,
-            0b10101,
-            0b10101,
+            0b101U,
+            0b110U,
+            0b110U,
+            0b101U,
         },
-        // 0x6E, n
+        // 0x6C, l LATIN SMALL LETTER L
         {
-            0b110,
-            0b101,
-            0b101,
+            0b1U,
+            0b1U,
+            0b1U,
+            0b1U,
         },
     }};
 
-    static constexpr std::array<std::array<uint8_t, 4>, 4> chars6F = {{
-        // 0x6F, o
+    static constexpr std::array<std::array<uint8_t, 3U>, 2U> latinSmallLetterM_latinSmallLetterN{{
+        // 0x6D, m LATIN SMALL LETTER M
         {
-            0b010,
-            0b101,
-            0b101,
-            0b010,
+            0b01010U,
+            0b10101U,
+            0b10101U,
         },
-        // 0x70, p
+        // 0x6E, n LATIN SMALL LETTER N
         {
-            0b110,
-            0b101,
-            0b110,
-            0b100,
-        },
-        // 0x71, q
-        {
-            0b011,
-            0b101,
-            0b011,
-            0b011,
-        },
-        // 0x72, r
-        {
-            0b101,
-            0b110,
-            0b100,
-            0b100,
+            0b110U,
+            0b101U,
+            0b101U,
         },
     }};
 
-    // 0x73, s
-    static constexpr std::array<uint8_t, 5> char73 = {
-        0b011,
-        0b100,
-        0b010,
-        0b001,
-        0b110,
-    };
-
-    // 0x74, t
-    static constexpr std::array<uint8_t, 4> char74 = {
-        0b010,
-        0b111,
-        0b010,
-        0b011,
-    };
-
-    static constexpr std::array<std::array<uint8_t, 3>, 4> chars75 = {{
-        // 0x75, u
+    static constexpr std::array<std::array<uint8_t, 4U>, 4U> latinSmallLetterO_latinSmallLetterR{{
+        // 0x6F, o LATIN SMALL LETTER O
         {
-            0b101,
-            0b101,
-            0b011,
+            0b010U,
+            0b101U,
+            0b101U,
+            0b010U,
         },
-        // 0x76, v
+        // 0x70, p LATIN SMALL LETTER P
         {
-            0b101,
-            0b101,
-            0b010,
+            0b110U,
+            0b101U,
+            0b110U,
+            0b100U,
         },
-        // 0x77, w
+        // 0x71, q LATIN SMALL LETTER Q
         {
-            0b10101,
-            0b10101,
-            0b01110,
+            0b011U,
+            0b101U,
+            0b011U,
+            0b011U,
         },
-        // 0x78, x
+        // 0x72, r LATIN SMALL LETTER R
         {
-            0b101,
-            0b111,
-            0b101,
+            0b101U,
+            0b110U,
+            0b100U,
+            0b100U,
         },
     }};
 
-    // 0x79, y
-    static constexpr std::array<uint8_t, 4> char79 = {
-        0b101,
-        0b101,
-        0b010,
-        0b010,
+    // 0x73, s LATIN SMALL LETTER S
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterS{
+        0b011U,
+        0b100U,
+        0b010U,
+        0b001U,
+        0b110U,
     };
 
-    // 0x7A, z
-    static constexpr std::array<uint8_t, 3> char7A = {
-        0b111,
-        0b010,
-        0b111,
+    // 0x74, t LATIN SMALL LETTER T
+    static constexpr std::array<uint8_t, 4U> latinSmallLetterT{
+        0b010U,
+        0b111U,
+        0b010U,
+        0b011U,
     };
 
-    // 0x7C, |
-    static constexpr std::array<uint8_t, 5> char7C = {
-        0b1,
-        0b1,
-        0b1,
-        0b1,
-        0b1,
+    static constexpr std::array<std::array<uint8_t, 3U>, 4U> latinSmallLetterU_latinSmallLetterX{{
+        // 0x75, u LATIN SMALL LETTER U
+        {
+            0b101U,
+            0b101U,
+            0b011U,
+        },
+        // 0x76, v LATIN SMALL LETTER V
+        {
+            0b101U,
+            0b101U,
+            0b010U,
+        },
+        // 0x77, w LATIN SMALL LETTER W
+        {
+            0b10101U,
+            0b10101U,
+            0b01110U,
+        },
+        // 0x78, x LATIN SMALL LETTER X
+        {
+            0b101U,
+            0b111U,
+            0b101U,
+        },
+    }};
+
+    // 0x79, y LATIN SMALL LETTER Y
+    static constexpr std::array<uint8_t, 4U> latinSmallLetterY{
+        0b101U,
+        0b101U,
+        0b010U,
+        0b010U,
+    };
+
+    // 0x7A, z LATIN SMALL LETTER Z
+    static constexpr std::array<uint8_t, 3U> latinSmallLetterZ{
+        0b111U,
+        0b010U,
+        0b111U,
+    };
+
+    // 0x7C, | VERTICAL LINE
+    static constexpr std::array<uint8_t, 5U> verticalLine{
+        0b1U,
+        0b1U,
+        0b1U,
+        0b1U,
+        0b1U,
     };
 
     // 0xB0, ° DEGREE SIGN
-    static constexpr std::array<uint8_t, 2> charB0 = {
-        0b11,
-        0b11,
+    static constexpr std::array<uint8_t, 2U> degreeSign{
+        0b11U,
+        0b11U,
     };
 
     // 0x3C0, π GREEK SMALL LETTER PI
-    static constexpr std::array<uint8_t, 4> char3C0 = {
-        0b11111,
-        0b01010,
-        0b01010,
-        0b01010,
+    static constexpr std::array<uint8_t, 4U> greekSmallLetterPi{
+        0b11111U,
+        0b01010U,
+        0b01010U,
+        0b01010U,
     };
 
 public:
-    static constexpr std::string_view name = "Mini";
+    static constexpr std::string_view name{"Mini"};
 
     explicit MiniFont() : FontModule(name) {};
 
-    [[nodiscard]] FontModule::Symbol getChar(uint32_t character) const override;
+    [[nodiscard]] FontModule::Symbol getChar(char32_t character) const override;
 };
 
 #endif // FONT_MINI

--- a/firmware/include/fonts/MiniFont.h
+++ b/firmware/include/fonts/MiniFont.h
@@ -9,28 +9,28 @@
 class MiniFont final : public FontModule
 {
 private:
-    // 0x2B, + PLUS SIGN
+    // U+002B + PLUS SIGN
     static constexpr std::array<uint8_t, 3U> plusSign{
         0b010U,
         0b111U,
         0b010U,
     };
 
-    // 0x2C, , COMMA
+    // U+002C , COMMA
     static constexpr std::array<uint8_t, 2U> comma{
         0b01U,
         0b10U,
     };
 
-    // 0x2D, - HYPHEN-MINUS
-    // 0x5F, _ LOW LINE
+    // U+002D - HYPHEN-MINUS
+    // U+005F _ LOW LINE
     static constexpr std::array<uint8_t, 1U> hyphenMinus{0b111U};
 
-    // 0x2E, . FULL STOP
+    // U+002E . FULL STOP
     static constexpr std::array<uint8_t, 1U> fullStop{0b1U};
 
     static constexpr std::array<std::array<uint8_t, 5U>, 10U> digitZero_digitNine{{
-        // 0x30, 0 DIGIT ZERO
+        // U+0030 0 DIGIT ZERO
         {
             0b111U,
             0b101U,
@@ -38,7 +38,7 @@ private:
             0b101U,
             0b111U,
         },
-        // 0x31, 1 DIGIT ONE
+        // U+0031 1 DIGIT ONE
         {
             0b010U,
             0b110U,
@@ -46,7 +46,7 @@ private:
             0b010U,
             0b111U,
         },
-        // 0x32, 2 DIGIT TWO
+        // U+0032 2 DIGIT TWO
         {
             0b111U,
             0b001U,
@@ -54,7 +54,7 @@ private:
             0b100U,
             0b111U,
         },
-        // 0x33, 3 DIGIT THREE
+        // U+0033 3 DIGIT THREE
         {
             0b111U,
             0b001U,
@@ -62,7 +62,7 @@ private:
             0b001U,
             0b111U,
         },
-        // 0x34, 4 DIGIT FOUR
+        // U+0034 4 DIGIT FOUR
         {
             0b101U,
             0b101U,
@@ -70,7 +70,7 @@ private:
             0b001U,
             0b001U,
         },
-        // 0x35, 5 DIGIT FIVE
+        // U+0035 5 DIGIT FIVE
         {
             0b111U,
             0b100U,
@@ -78,7 +78,7 @@ private:
             0b001U,
             0b111U,
         },
-        // 0x36, 6 DIGIT SIX
+        // U+0036 6 DIGIT SIX
         {
             0b111U,
             0b100U,
@@ -86,7 +86,7 @@ private:
             0b101U,
             0b111U,
         },
-        // 0x37, 7 DIGIT SEVEN
+        // U+0037 7 DIGIT SEVEN
         {
             0b111U,
             0b001U,
@@ -94,7 +94,7 @@ private:
             0b001U,
             0b001U,
         },
-        // 0x38, 8 DIGIT EIGHT
+        // U+0038 8 DIGIT EIGHT
         {
             0b111U,
             0b101U,
@@ -102,7 +102,7 @@ private:
             0b101U,
             0b111U,
         },
-        // 0x39, 9 DIGIT NINE
+        // U+0039 9 DIGIT NINE
         {
             0b111U,
             0b101U,
@@ -112,14 +112,14 @@ private:
         },
     }};
 
-    // 0x3A, : COLON
+    // U+003A : COLON
     static constexpr std::array<uint8_t, 3U> colon{
         0b1U,
         0b0U,
         0b1U,
     };
 
-    // 0x3D, = EQUALS SIGN
+    // U+003D = EQUALS SIGN
     static constexpr std::array<uint8_t, 3U> equalsSign{
         0b111U,
         0b000U,
@@ -127,7 +127,7 @@ private:
     };
 
     static constexpr std::array<std::array<uint8_t, 5U>, 29U> latinCapitalLetterA_rightSquareBracket{{
-        // 0x41, A LATIN CAPITAL LETTER A
+        // U+0041 A LATIN CAPITAL LETTER A
         {
             0b010U,
             0b101U,
@@ -135,7 +135,7 @@ private:
             0b101U,
             0b101U,
         },
-        // 0x42, B LATIN CAPITAL LETTER B
+        // U+0042 B LATIN CAPITAL LETTER B
         {
             0b110U,
             0b101U,
@@ -143,7 +143,7 @@ private:
             0b101U,
             0b110U,
         },
-        // 0x43, C LATIN CAPITAL LETTER C
+        // U+0043 C LATIN CAPITAL LETTER C
         {
             0b111U,
             0b100U,
@@ -151,7 +151,7 @@ private:
             0b100U,
             0b111U,
         },
-        // 0x44, D LATIN CAPITAL LETTER D
+        // U+0044 D LATIN CAPITAL LETTER D
         {
             0b110U,
             0b101U,
@@ -159,7 +159,7 @@ private:
             0b101U,
             0b110U,
         },
-        // 0x45, E LATIN CAPITAL LETTER E
+        // U+0045 E LATIN CAPITAL LETTER E
         {
             0b111U,
             0b100U,
@@ -167,7 +167,7 @@ private:
             0b100U,
             0b111U,
         },
-        // 0x46, F LATIN CAPITAL LETTER F
+        // U+0046 F LATIN CAPITAL LETTER F
         {
             0b111U,
             0b100U,
@@ -175,7 +175,7 @@ private:
             0b100U,
             0b100U,
         },
-        // 0x47, G LATIN CAPITAL LETTER G
+        // U+0047 G LATIN CAPITAL LETTER G
         {
             0b011U,
             0b100U,
@@ -183,7 +183,7 @@ private:
             0b101U,
             0b110U,
         },
-        // 0x48, H LATIN CAPITAL LETTER H
+        // U+0048 H LATIN CAPITAL LETTER H
         {
             0b101U,
             0b101U,
@@ -191,7 +191,7 @@ private:
             0b101U,
             0b101U,
         },
-        // 0x49, I LATIN CAPITAL LETTER I
+        // U+0049 I LATIN CAPITAL LETTER I
         {
             0b1U,
             0b1U,
@@ -199,7 +199,7 @@ private:
             0b1U,
             0b1U,
         },
-        // 0x4A, J LATIN CAPITAL LETTER J
+        // U+004A J LATIN CAPITAL LETTER J
         {
             0b001U,
             0b001U,
@@ -207,7 +207,7 @@ private:
             0b101U,
             0b111U,
         },
-        // 0x4B, K LATIN CAPITAL LETTER K
+        // U+004B K LATIN CAPITAL LETTER K
         {
             0b101U,
             0b101U,
@@ -215,7 +215,7 @@ private:
             0b111U,
             0b101U,
         },
-        // 0x4C, L LATIN CAPITAL LETTER L
+        // U+004C L LATIN CAPITAL LETTER L
         {
             0b100U,
             0b100U,
@@ -223,7 +223,7 @@ private:
             0b100U,
             0b111U,
         },
-        // 0x4D, M LATIN CAPITAL LETTER M
+        // U+004D M LATIN CAPITAL LETTER M
         {
             0b10001U,
             0b11011U,
@@ -231,7 +231,7 @@ private:
             0b10001U,
             0b10001U,
         },
-        // 0x4E, N LATIN CAPITAL LETTER N
+        // U+004E N LATIN CAPITAL LETTER N
         {
             0b10001U,
             0b11001U,
@@ -239,7 +239,7 @@ private:
             0b10011U,
             0b10001U,
         },
-        // 0x4F, O LATIN CAPITAL LETTER O
+        // U+004F O LATIN CAPITAL LETTER O
         {
             0b010U,
             0b101U,
@@ -247,7 +247,7 @@ private:
             0b101U,
             0b010U,
         },
-        // 0x50, P LATIN CAPITAL LETTER P
+        // U+0050 P LATIN CAPITAL LETTER P
         {
             0b110U,
             0b101U,
@@ -255,7 +255,7 @@ private:
             0b100U,
             0b100U,
         },
-        // 0x51, Q LATIN CAPITAL LETTER Q
+        // U+0051 Q LATIN CAPITAL LETTER Q
         {
             0b010U,
             0b101U,
@@ -263,7 +263,7 @@ private:
             0b111U,
             0b011U,
         },
-        // 0x52, R LATIN CAPITAL LETTER R
+        // U+0052 R LATIN CAPITAL LETTER R
         {
             0b110U,
             0b101U,
@@ -271,7 +271,7 @@ private:
             0b110U,
             0b101U,
         },
-        // 0x53, S LATIN CAPITAL LETTER S
+        // U+0053 S LATIN CAPITAL LETTER S
         {
             0b111U,
             0b100U,
@@ -279,7 +279,7 @@ private:
             0b001U,
             0b111U,
         },
-        // 0x54, T LATIN CAPITAL LETTER T
+        // U+0054 T LATIN CAPITAL LETTER T
         {
             0b111U,
             0b010U,
@@ -287,7 +287,7 @@ private:
             0b010U,
             0b010U,
         },
-        // 0x55, U LATIN CAPITAL LETTER U
+        // U+0055 U LATIN CAPITAL LETTER U
         {
             0b101U,
             0b101U,
@@ -295,7 +295,7 @@ private:
             0b101U,
             0b111U,
         },
-        // 0x56, V LATIN CAPITAL LETTER V
+        // U+0056 V LATIN CAPITAL LETTER V
         {
             0b101U,
             0b101U,
@@ -303,7 +303,7 @@ private:
             0b101U,
             0b010U,
         },
-        // 0x57, W LATIN CAPITAL LETTER W
+        // U+0057 W LATIN CAPITAL LETTER W
         {
             0b10101U,
             0b10101U,
@@ -311,7 +311,7 @@ private:
             0b10101U,
             0b01010U,
         },
-        // 0x58, X LATIN CAPITAL LETTER X
+        // U+0058 X LATIN CAPITAL LETTER X
         {
             0b101U,
             0b101U,
@@ -319,7 +319,7 @@ private:
             0b101U,
             0b101U,
         },
-        // 0x59, Y LATIN CAPITAL LETTER Y
+        // U+0059 Y LATIN CAPITAL LETTER Y
         {
             0b101U,
             0b101U,
@@ -327,7 +327,7 @@ private:
             0b010U,
             0b010U,
         },
-        // 0x5A, Z LATIN CAPITAL LETTER Z
+        // U+005A Z LATIN CAPITAL LETTER Z
         {
             0b111U,
             0b001U,
@@ -335,7 +335,7 @@ private:
             0b100U,
             0b111U,
         },
-        // 0x5B, [ LEFT SQUARE BRACKET
+        // U+005B [ LEFT SQUARE BRACKET
         {
             0b11U,
             0b10U,
@@ -343,7 +343,7 @@ private:
             0b10U,
             0b11U,
         },
-        // 0x5C, REVERSE SOLIDUS
+        // U+005C REVERSE SOLIDUS
         {
             0b110U,
             0b010U,
@@ -351,7 +351,7 @@ private:
             0b010U,
             0b001U,
         },
-        // 0x5D, ] RIGHT SQUARE BRACKET
+        // U+005D ] RIGHT SQUARE BRACKET
         {
             0b11U,
             0b01U,
@@ -361,7 +361,7 @@ private:
         },
     }};
 
-    // 0x61, a LATIN SMALL LETTER A
+    // U+0061 a LATIN SMALL LETTER A
     static constexpr std::array<uint8_t, 5U> latinSmallLetterA{
         0b110U,
         0b001U,
@@ -370,7 +370,7 @@ private:
         0b111U,
     };
 
-    // 0x62, b LATIN SMALL LETTER B
+    // U+0062 b LATIN SMALL LETTER B
     static constexpr std::array<uint8_t, 4U> latinSmallLetterB{
         0b100U,
         0b110U,
@@ -378,14 +378,14 @@ private:
         0b110U,
     };
 
-    // 0x63, c LATIN SMALL LETTER C
+    // U+0063 c LATIN SMALL LETTER C
     static constexpr std::array<uint8_t, 3U> latinSmallLetterC{
         0b011U,
         0b100U,
         0b011U,
     };
 
-    // 0x64, d LATIN SMALL LETTER D
+    // U+0064 d LATIN SMALL LETTER D
     static constexpr std::array<uint8_t, 4U> latinSmallLetterD{
         0b001U,
         0b011U,
@@ -394,7 +394,7 @@ private:
     };
 
     static constexpr std::array<std::array<uint8_t, 5U>, 3U> latinSmallLetterE_latinSmallLetterG{{
-        // 0x65, e LATIN SMALL LETTER E
+        // U+0065 e LATIN SMALL LETTER E
         {
             0b010U,
             0b101U,
@@ -402,7 +402,7 @@ private:
             0b100U,
             0b011U,
         },
-        // 0x66, f LATIN SMALL LETTER F
+        // U+0066 f LATIN SMALL LETTER F
         {
             0b011U,
             0b010U,
@@ -410,7 +410,7 @@ private:
             0b010U,
             0b010U,
         },
-        // 0x67, g LATIN SMALL LETTER G
+        // U+0067 g LATIN SMALL LETTER G
         {
             0b011U,
             0b101U,
@@ -421,14 +421,14 @@ private:
     }};
 
     static constexpr std::array<std::array<uint8_t, 4U>, 2U> latinSmallLetterH_latinSmallLetterI{{
-        // 0x68, h LATIN SMALL LETTER H
+        // U+0068 h LATIN SMALL LETTER H
         {
             0b100U,
             0b100U,
             0b110U,
             0b101U,
         },
-        // 0x69, i LATIN SMALL LETTER I
+        // U+0069 i LATIN SMALL LETTER I
         {
             0b1U,
             0b0U,
@@ -437,7 +437,7 @@ private:
         },
     }};
 
-    // 0x6A, j LATIN SMALL LETTER J
+    // U+006A j LATIN SMALL LETTER J
     static constexpr std::array<uint8_t, 5U> latinSmallLetterJ{
         0b01U,
         0b00U,
@@ -447,14 +447,14 @@ private:
     };
 
     static constexpr std::array<std::array<uint8_t, 4U>, 2U> latinSmallLetterK_latinSmallLetterL{{
-        // 0x6B, k LATIN SMALL LETTER K
+        // U+006B k LATIN SMALL LETTER K
         {
             0b101U,
             0b110U,
             0b110U,
             0b101U,
         },
-        // 0x6C, l LATIN SMALL LETTER L
+        // U+006C l LATIN SMALL LETTER L
         {
             0b1U,
             0b1U,
@@ -464,13 +464,13 @@ private:
     }};
 
     static constexpr std::array<std::array<uint8_t, 3U>, 2U> latinSmallLetterM_latinSmallLetterN{{
-        // 0x6D, m LATIN SMALL LETTER M
+        // U+006D m LATIN SMALL LETTER M
         {
             0b01010U,
             0b10101U,
             0b10101U,
         },
-        // 0x6E, n LATIN SMALL LETTER N
+        // U+006E n LATIN SMALL LETTER N
         {
             0b110U,
             0b101U,
@@ -479,28 +479,28 @@ private:
     }};
 
     static constexpr std::array<std::array<uint8_t, 4U>, 4U> latinSmallLetterO_latinSmallLetterR{{
-        // 0x6F, o LATIN SMALL LETTER O
+        // U+006F o LATIN SMALL LETTER O
         {
             0b010U,
             0b101U,
             0b101U,
             0b010U,
         },
-        // 0x70, p LATIN SMALL LETTER P
+        // U+0070 p LATIN SMALL LETTER P
         {
             0b110U,
             0b101U,
             0b110U,
             0b100U,
         },
-        // 0x71, q LATIN SMALL LETTER Q
+        // U+0071 q LATIN SMALL LETTER Q
         {
             0b011U,
             0b101U,
             0b011U,
             0b011U,
         },
-        // 0x72, r LATIN SMALL LETTER R
+        // U+0072 r LATIN SMALL LETTER R
         {
             0b101U,
             0b110U,
@@ -509,7 +509,7 @@ private:
         },
     }};
 
-    // 0x73, s LATIN SMALL LETTER S
+    // U+0073 s LATIN SMALL LETTER S
     static constexpr std::array<uint8_t, 5U> latinSmallLetterS{
         0b011U,
         0b100U,
@@ -518,7 +518,7 @@ private:
         0b110U,
     };
 
-    // 0x74, t LATIN SMALL LETTER T
+    // U+0074 t LATIN SMALL LETTER T
     static constexpr std::array<uint8_t, 4U> latinSmallLetterT{
         0b010U,
         0b111U,
@@ -527,25 +527,25 @@ private:
     };
 
     static constexpr std::array<std::array<uint8_t, 3U>, 4U> latinSmallLetterU_latinSmallLetterX{{
-        // 0x75, u LATIN SMALL LETTER U
+        // U+0075 u LATIN SMALL LETTER U
         {
             0b101U,
             0b101U,
             0b011U,
         },
-        // 0x76, v LATIN SMALL LETTER V
+        // U+0076 v LATIN SMALL LETTER V
         {
             0b101U,
             0b101U,
             0b010U,
         },
-        // 0x77, w LATIN SMALL LETTER W
+        // U+0077 w LATIN SMALL LETTER W
         {
             0b10101U,
             0b10101U,
             0b01110U,
         },
-        // 0x78, x LATIN SMALL LETTER X
+        // U+0078 x LATIN SMALL LETTER X
         {
             0b101U,
             0b111U,
@@ -553,7 +553,7 @@ private:
         },
     }};
 
-    // 0x79, y LATIN SMALL LETTER Y
+    // U+0079 y LATIN SMALL LETTER Y
     static constexpr std::array<uint8_t, 4U> latinSmallLetterY{
         0b101U,
         0b101U,
@@ -561,14 +561,14 @@ private:
         0b010U,
     };
 
-    // 0x7A, z LATIN SMALL LETTER Z
+    // U+007A z LATIN SMALL LETTER Z
     static constexpr std::array<uint8_t, 3U> latinSmallLetterZ{
         0b111U,
         0b010U,
         0b111U,
     };
 
-    // 0x7C, | VERTICAL LINE
+    // U+007C | VERTICAL LINE
     static constexpr std::array<uint8_t, 5U> verticalLine{
         0b1U,
         0b1U,
@@ -577,13 +577,13 @@ private:
         0b1U,
     };
 
-    // 0xB0, ° DEGREE SIGN
+    // U+00B0 ° DEGREE SIGN
     static constexpr std::array<uint8_t, 2U> degreeSign{
         0b11U,
         0b11U,
     };
 
-    // 0x3C0, π GREEK SMALL LETTER PI
+    // U+03C0 π GREEK SMALL LETTER PI
     static constexpr std::array<uint8_t, 4U> greekSmallLetterPi{
         0b11111U,
         0b01010U,

--- a/firmware/include/fonts/SmallFont.h
+++ b/firmware/include/fonts/SmallFont.h
@@ -9,1031 +9,1031 @@
 class SmallFont final : public FontModule
 {
 private:
-    // 0x21, !
-    static constexpr std::array<uint8_t, 7> char21 = {
-        0b1,
-        0b1,
-        0b1,
-        0b1,
-        0b1,
-        0b0,
-        0b1,
+    // 0x21, ! EXCLAMATION MARK
+    static constexpr std::array<uint8_t, 7U> exclamationMark{
+        0b1U,
+        0b1U,
+        0b1U,
+        0b1U,
+        0b1U,
+        0b0U,
+        0b1U,
     };
 
-    // 0x22, "
-    static constexpr std::array<uint8_t, 3> char22 = {
-        0b101,
-        0b101,
-        0b101,
+    // 0x22, " QUOTATION MARK
+    static constexpr std::array<uint8_t, 3U> quotationMark{
+        0b101U,
+        0b101U,
+        0b101U,
     };
 
-    static constexpr std::array<std::array<uint8_t, 7>, 4> chars23 = {{
-        // 0x23, #
+    static constexpr std::array<std::array<uint8_t, 7U>, 4U> numberSign_ampersand{{
+        // 0x23, # NUMBER SIGN
         {
-            0b01010,
-            0b01010,
-            0b11111,
-            0b01010,
-            0b11111,
-            0b01010,
-            0b01010,
+            0b01010U,
+            0b01010U,
+            0b11111U,
+            0b01010U,
+            0b11111U,
+            0b01010U,
+            0b01010U,
         },
-        // 0x24, $
+        // 0x24, $ DOLLAR SIGN
         {
-            0b00100,
-            0b01111,
-            0b10100,
-            0b01110,
-            0b00101,
-            0b11110,
-            0b00100,
+            0b00100U,
+            0b01111U,
+            0b10100U,
+            0b01110U,
+            0b00101U,
+            0b11110U,
+            0b00100U,
         },
-        // 0x25, %
+        // 0x25, % PERCENT SIGN
         {
-            0b11000,
-            0b11001,
-            0b00010,
-            0b00100,
-            0b01000,
-            0b10011,
-            0b00011,
+            0b11000U,
+            0b11001U,
+            0b00010U,
+            0b00100U,
+            0b01000U,
+            0b10011U,
+            0b00011U,
         },
-        // 0x26, &
+        // 0x26, & AMPERSAND
         {
-            0b0110000,
-            0b1001000,
-            0b1010000,
-            0b0100000,
-            0b1010101,
-            0b1001000,
-            0b0110100,
+            0b0110000U,
+            0b1001000U,
+            0b1010000U,
+            0b0100000U,
+            0b1010101U,
+            0b1001000U,
+            0b0110100U,
         },
     }};
 
-    // 0x27, '
-    static constexpr std::array<uint8_t, 3> char27 = {
-        0b11,
-        0b01,
-        0b10,
+    // 0x27, ' APOSTROPHE
+    static constexpr std::array<uint8_t, 3U> apostrophe{
+        0b11U,
+        0b01U,
+        0b10U,
     };
 
-    static constexpr std::array<std::array<uint8_t, 7>, 2> chars28 = {{
-        // 0x28, (
+    static constexpr std::array<std::array<uint8_t, 7U>, 2U> leftParenthesis_rightParenthesis{{
+        // 0x28, ( LEFT PARENTHESIS
         {
-            0b001,
-            0b010,
-            0b100,
-            0b100,
-            0b100,
-            0b010,
-            0b001,
+            0b001U,
+            0b010U,
+            0b100U,
+            0b100U,
+            0b100U,
+            0b010U,
+            0b001U,
         },
-        // 0x29, )
+        // 0x29, ) RIGHT PARENTHESIS
         {
-            0b100,
-            0b010,
-            0b001,
-            0b001,
-            0b001,
-            0b010,
-            0b100,
+            0b100U,
+            0b010U,
+            0b001U,
+            0b001U,
+            0b001U,
+            0b010U,
+            0b100U,
         },
     }};
 
-    // 0x2A, *
-    static constexpr std::array<uint8_t, 2> char2A = {
-        0b11,
-        0b11,
+    // 0x2A, * ASTERISK
+    static constexpr std::array<uint8_t, 2U> asterisk{
+        0b11U,
+        0b11U,
     };
 
-    // 0x2B, +
-    static constexpr std::array<uint8_t, 5> char2B = {
-        0b00100,
-        0b00100,
-        0b11111,
-        0b00100,
-        0b00100,
+    // 0x2B, + PLUS SIGN
+    static constexpr std::array<uint8_t, 5U> plusSign{
+        0b00100U,
+        0b00100U,
+        0b11111U,
+        0b00100U,
+        0b00100U,
     };
 
-    // 0x2C, ,
-    static constexpr std::array<uint8_t, 2> char2C = {
-        0b01,
-        0b10,
+    // 0x2C, , COMMA
+    static constexpr std::array<uint8_t, 2U> comma{
+        0b01U,
+        0b10U,
     };
 
-    // 0x2D, -
-    // 0x5F, _
-    static constexpr std::array<uint8_t, 1> char2D = {0b11111};
+    // 0x2D, - HYPHEN-MINUS
+    // 0x5F, _ LOW LINE
+    static constexpr std::array<uint8_t, 1U> hyphenMinus{0b11111U};
 
-    // 0x2E, .
-    static constexpr std::array<uint8_t, 2> char2E = {
-        0b11,
-        0b11,
+    // 0x2E, . FULL STOP
+    static constexpr std::array<uint8_t, 2U> fullStop{
+        0b11U,
+        0b11U,
     };
 
-    // 0x2F, /
-    static constexpr std::array<uint8_t, 5> char2F = {
-        0b00001,
-        0b00010,
-        0b00100,
-        0b01000,
-        0b10000,
+    // 0x2F, / SOLIDUS
+    static constexpr std::array<uint8_t, 5U> solidus{
+        0b00001U,
+        0b00010U,
+        0b00100U,
+        0b01000U,
+        0b10000U,
     };
 
-    static constexpr std::array<std::array<uint8_t, 7>, 10> chars30 = {{
-        // 0x30, 0
+    static constexpr std::array<std::array<uint8_t, 7U>, 10U> digitZero_digitNine{{
+        // 0x30, 0 DIGIT ZERO
         {
-            0b0110,
-            0b1111,
-            0b1001,
-            0b1001,
-            0b1001,
-            0b1111,
-            0b0110,
+            0b0110U,
+            0b1111U,
+            0b1001U,
+            0b1001U,
+            0b1001U,
+            0b1111U,
+            0b0110U,
         },
-        // 0x31, 1
+        // 0x31, 1 DIGIT ONE
         {
-            0b011,
-            0b111,
-            0b011,
-            0b011,
-            0b011,
-            0b011,
-            0b011,
+            0b011U,
+            0b111U,
+            0b011U,
+            0b011U,
+            0b011U,
+            0b011U,
+            0b011U,
         },
-        // 0x32, 2
+        // 0x32, 2 DIGIT TWO
         {
-            0b0110,
-            0b1111,
-            0b0001,
-            0b0100,
-            0b1000,
-            0b1111,
-            0b1111,
+            0b0110U,
+            0b1111U,
+            0b0001U,
+            0b0100U,
+            0b1000U,
+            0b1111U,
+            0b1111U,
         },
-        // 0x33, 3
+        // 0x33, 3 DIGIT THREE
         {
-            0b0110,
-            0b1111,
-            0b0001,
-            0b0111,
-            0b0001,
-            0b1111,
-            0b0110,
+            0b0110U,
+            0b1111U,
+            0b0001U,
+            0b0111U,
+            0b0001U,
+            0b1111U,
+            0b0110U,
         },
-        // 0x34, 4
+        // 0x34, 4 DIGIT FOUR
         {
-            0b1001,
-            0b1001,
-            0b1111,
-            0b0111,
-            0b0001,
-            0b0001,
-            0b0001,
+            0b1001U,
+            0b1001U,
+            0b1111U,
+            0b0111U,
+            0b0001U,
+            0b0001U,
+            0b0001U,
         },
-        // 0x35, 5
+        // 0x35, 5 DIGIT FIVE
         {
-            0b1111,
-            0b1111,
-            0b1000,
-            0b1110,
-            0b0001,
-            0b1111,
-            0b1110,
+            0b1111U,
+            0b1111U,
+            0b1000U,
+            0b1110U,
+            0b0001U,
+            0b1111U,
+            0b1110U,
         },
-        // 0x36, 6
+        // 0x36, 6 DIGIT SIX
         {
-            0b0110,
-            0b1111,
-            0b1000,
-            0b1110,
-            0b1001,
-            0b1111,
-            0b0110,
+            0b0110U,
+            0b1111U,
+            0b1000U,
+            0b1110U,
+            0b1001U,
+            0b1111U,
+            0b0110U,
         },
-        // 0x37, 7
+        // 0x37, 7 DIGIT SEVEN
         {
-            0b1111,
-            0b1111,
-            0b0010,
-            0b0100,
-            0b0100,
-            0b0100,
-            0b0100,
+            0b1111U,
+            0b1111U,
+            0b0010U,
+            0b0100U,
+            0b0100U,
+            0b0100U,
+            0b0100U,
         },
-        // 0x38, 8
+        // 0x38, 8 DIGIT EIGHT
         {
-            0b0110,
-            0b1111,
-            0b1001,
-            0b0110,
-            0b1001,
-            0b1111,
-            0b0110,
+            0b0110U,
+            0b1111U,
+            0b1001U,
+            0b0110U,
+            0b1001U,
+            0b1111U,
+            0b0110U,
         },
-        // 0x39, 9
+        // 0x39, 9 DIGIT NINE
         {
-            0b0110,
-            0b1111,
-            0b1001,
-            0b0111,
-            0b0001,
-            0b1111,
-            0b0110,
+            0b0110U,
+            0b1111U,
+            0b1001U,
+            0b0111U,
+            0b0001U,
+            0b1111U,
+            0b0110U,
         },
     }};
 
-    // 0x3A, :
-    static constexpr std::array<uint8_t, 5> char3A = {
-        0b11,
-        0b11,
-        0b00,
-        0b11,
-        0b11,
+    // 0x3A, : COLON
+    static constexpr std::array<uint8_t, 5U> colon{
+        0b11U,
+        0b11U,
+        0b00U,
+        0b11U,
+        0b11U,
     };
 
-    // 0x3B, ;
-    static constexpr std::array<uint8_t, 6> char3B = {
-        0b11,
-        0b11,
-        0b00,
-        0b11,
-        0b01,
-        0b10,
+    // 0x3B, ; SEMICOLON
+    static constexpr std::array<uint8_t, 6U> semicolon{
+        0b11U,
+        0b11U,
+        0b00U,
+        0b11U,
+        0b01U,
+        0b10U,
     };
 
-    // 0x3C, <
-    static constexpr std::array<uint8_t, 7> char3C = {
-        0b0001,
-        0b0010,
-        0b0100,
-        0b1000,
-        0b0100,
-        0b0010,
-        0b0001,
+    // 0x3C, < LESS-THAN SIGN
+    static constexpr std::array<uint8_t, 7U> lessThanSign{
+        0b0001U,
+        0b0010U,
+        0b0100U,
+        0b1000U,
+        0b0100U,
+        0b0010U,
+        0b0001U,
     };
 
-    // 0x3D, =
-    static constexpr std::array<uint8_t, 3> char3D = {
-        0b11111,
-        0b00000,
-        0b11111,
+    // 0x3D, = EQUALS SIGN
+    static constexpr std::array<uint8_t, 3U> equalsSign{
+        0b11111U,
+        0b00000U,
+        0b11111U,
     };
 
-    static constexpr std::array<std::array<uint8_t, 7>, 30> chars3E = {{
-        // 0x3E, >
+    static constexpr std::array<std::array<uint8_t, 7U>, 30U> greaterThanSign_leftSquareBracket{{
+        // 0x3E, > GREATER-THAN SIGN
         {
-            0b1000,
-            0b0100,
-            0b0010,
-            0b0001,
-            0b0010,
-            0b0100,
-            0b1000,
+            0b1000U,
+            0b0100U,
+            0b0010U,
+            0b0001U,
+            0b0010U,
+            0b0100U,
+            0b1000U,
         },
-        // 0x3F, ?
+        // 0x3F, ? QUESTION MARK
         {
-            0b01110,
-            0b10001,
-            0b00001,
-            0b00010,
-            0b00100,
-            0b00000,
-            0b00100,
+            0b01110U,
+            0b10001U,
+            0b00001U,
+            0b00010U,
+            0b00100U,
+            0b00000U,
+            0b00100U,
         },
-        // 0x40, @
+        // 0x40, @ COMMERCIAL AT
         {
-            0b01110,
-            0b10001,
-            0b00001,
-            0b01101,
-            0b10101,
-            0b10101,
-            0b01110,
+            0b01110U,
+            0b10001U,
+            0b00001U,
+            0b01101U,
+            0b10101U,
+            0b10101U,
+            0b01110U,
         },
-        // 0x41, A
+        // 0x41, A LATIN CAPITAL LETTER A
         {
-            0b01110,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b11111,
-            0b10001,
-            0b10001,
+            0b01110U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b11111U,
+            0b10001U,
+            0b10001U,
         },
-        // 0x42, B
+        // 0x42, B LATIN CAPITAL LETTER B
         {
-            0b11110,
-            0b10001,
-            0b10001,
-            0b11110,
-            0b10001,
-            0b10001,
-            0b11110,
+            0b11110U,
+            0b10001U,
+            0b10001U,
+            0b11110U,
+            0b10001U,
+            0b10001U,
+            0b11110U,
         },
-        // 0x43, C
+        // 0x43, C LATIN CAPITAL LETTER C
         {
-            0b01110,
-            0b10001,
-            0b10000,
-            0b10000,
-            0b10000,
-            0b10001,
-            0b01110,
+            0b01110U,
+            0b10001U,
+            0b10000U,
+            0b10000U,
+            0b10000U,
+            0b10001U,
+            0b01110U,
         },
-        // 0x44, D
+        // 0x44, D LATIN CAPITAL LETTER D
         {
-            0b11100,
-            0b10010,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10010,
-            0b11100,
+            0b11100U,
+            0b10010U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10010U,
+            0b11100U,
         },
-        // 0x45, E
+        // 0x45, E LATIN CAPITAL LETTER E
         {
-            0b11111,
-            0b10000,
-            0b10000,
-            0b11110,
-            0b10000,
-            0b10000,
-            0b11111,
+            0b11111U,
+            0b10000U,
+            0b10000U,
+            0b11110U,
+            0b10000U,
+            0b10000U,
+            0b11111U,
         },
-        // 0x46, F
+        // 0x46, F LATIN CAPITAL LETTER F
         {
-            0b11111,
-            0b10000,
-            0b10000,
-            0b11100,
-            0b10000,
-            0b10000,
-            0b10000,
+            0b11111U,
+            0b10000U,
+            0b10000U,
+            0b11100U,
+            0b10000U,
+            0b10000U,
+            0b10000U,
         },
-        // 0x47, G
+        // 0x47, G LATIN CAPITAL LETTER G
         {
-            0b01110,
-            0b10001,
-            0b10000,
-            0b10000,
-            0b10011,
-            0b10001,
-            0b01110,
+            0b01110U,
+            0b10001U,
+            0b10000U,
+            0b10000U,
+            0b10011U,
+            0b10001U,
+            0b01110U,
         },
-        // 0x48, H
+        // 0x48, H LATIN CAPITAL LETTER H
         {
-            0b10001,
-            0b10001,
-            0b10001,
-            0b11111,
-            0b10001,
-            0b10001,
-            0b10001,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b11111U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
         },
-        // 0x49, I
+        // 0x49, I LATIN CAPITAL LETTER I
         {
-            0b111,
-            0b010,
-            0b010,
-            0b010,
-            0b010,
-            0b010,
-            0b111,
+            0b111U,
+            0b010U,
+            0b010U,
+            0b010U,
+            0b010U,
+            0b010U,
+            0b111U,
         },
-        // 0x4A, J
+        // 0x4A, J LATIN CAPITAL LETTER J
         {
-            0b00111,
-            0b00010,
-            0b00010,
-            0b00010,
-            0b00010,
-            0b10010,
-            0b01100,
+            0b00111U,
+            0b00010U,
+            0b00010U,
+            0b00010U,
+            0b00010U,
+            0b10010U,
+            0b01100U,
         },
-        // 0x4B, K
+        // 0x4B, K LATIN CAPITAL LETTER K
         {
-            0b10001,
-            0b10010,
-            0b10100,
-            0b11000,
-            0b10100,
-            0b10010,
-            0b10001,
+            0b10001U,
+            0b10010U,
+            0b10100U,
+            0b11000U,
+            0b10100U,
+            0b10010U,
+            0b10001U,
         },
-        // 0x4C, L
+        // 0x4C, L LATIN CAPITAL LETTER L
         {
-            0b10000,
-            0b10000,
-            0b10000,
-            0b10000,
-            0b10000,
-            0b10000,
-            0b11111,
+            0b10000U,
+            0b10000U,
+            0b10000U,
+            0b10000U,
+            0b10000U,
+            0b10000U,
+            0b11111U,
         },
-        // 0x4D, M
+        // 0x4D, M LATIN CAPITAL LETTER M
         {
-            0b10001,
-            0b11011,
-            0b10101,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10001,
+            0b10001U,
+            0b11011U,
+            0b10101U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
         },
-        // 0x4E, N
+        // 0x4E, N LATIN CAPITAL LETTER N
         {
-            0b10001,
-            0b10001,
-            0b11001,
-            0b10101,
-            0b10011,
-            0b10001,
-            0b10001,
+            0b10001U,
+            0b10001U,
+            0b11001U,
+            0b10101U,
+            0b10011U,
+            0b10001U,
+            0b10001U,
         },
-        // 0x4F, O
+        // 0x4F, O LATIN CAPITAL LETTER O
         {
-            0b01110,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b01110,
+            0b01110U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b01110U,
         },
-        // 0x50, P
+        // 0x50, P LATIN CAPITAL LETTER P
         {
-            0b11110,
-            0b10001,
-            0b10001,
-            0b11110,
-            0b10000,
-            0b10000,
-            0b10000,
+            0b11110U,
+            0b10001U,
+            0b10001U,
+            0b11110U,
+            0b10000U,
+            0b10000U,
+            0b10000U,
         },
-        // 0x51, Q
+        // 0x51, Q LATIN CAPITAL LETTER Q
         {
-            0b01110,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10101,
-            0b10010,
-            0b01101,
+            0b01110U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10101U,
+            0b10010U,
+            0b01101U,
         },
-        // 0x52, R
+        // 0x52, R LATIN CAPITAL LETTER R
         {
-            0b11110,
-            0b10001,
-            0b10001,
-            0b11110,
-            0b10100,
-            0b10010,
-            0b10001,
+            0b11110U,
+            0b10001U,
+            0b10001U,
+            0b11110U,
+            0b10100U,
+            0b10010U,
+            0b10001U,
         },
-        // 0x53, S
+        // 0x53, S LATIN CAPITAL LETTER S
         {
-            0b01111,
-            0b10000,
-            0b10000,
-            0b01110,
-            0b00001,
-            0b00001,
-            0b11110,
+            0b01111U,
+            0b10000U,
+            0b10000U,
+            0b01110U,
+            0b00001U,
+            0b00001U,
+            0b11110U,
         },
-        // 0x54, T
+        // 0x54, T LATIN CAPITAL LETTER T
         {
-            0b11111,
-            0b00100,
-            0b00100,
-            0b00100,
-            0b00100,
-            0b00100,
-            0b00100,
+            0b11111U,
+            0b00100U,
+            0b00100U,
+            0b00100U,
+            0b00100U,
+            0b00100U,
+            0b00100U,
         },
-        // 0x55, U
+        // 0x55, U LATIN CAPITAL LETTER U
         {
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b01110,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b01110U,
         },
-        // 0x56, V
+        // 0x56, V LATIN CAPITAL LETTER V
         {
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b01010,
-            0b00100,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b01010U,
+            0b00100U,
         },
-        // 0x57, W
+        // 0x57, W LATIN CAPITAL LETTER W
         {
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10101,
-            0b10101,
-            0b11011,
-            0b10001,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10101U,
+            0b10101U,
+            0b11011U,
+            0b10001U,
         },
-        // 0x58, X
+        // 0x58, X LATIN CAPITAL LETTER X
         {
-            0b10001,
-            0b10001,
-            0b01010,
-            0b00100,
-            0b01010,
-            0b10001,
-            0b10001,
+            0b10001U,
+            0b10001U,
+            0b01010U,
+            0b00100U,
+            0b01010U,
+            0b10001U,
+            0b10001U,
         },
-        // 0x59, Y
+        // 0x59, Y LATIN CAPITAL LETTER Y
         {
-            0b10001,
-            0b10001,
-            0b01010,
-            0b00100,
-            0b00100,
-            0b00100,
-            0b00100,
+            0b10001U,
+            0b10001U,
+            0b01010U,
+            0b00100U,
+            0b00100U,
+            0b00100U,
+            0b00100U,
         },
-        // 0x5A, Z
+        // 0x5A, Z LATIN CAPITAL LETTER Z
         {
-            0b11111,
-            0b00001,
-            0b00010,
-            0b00100,
-            0b01000,
-            0b10000,
-            0b11111,
+            0b11111U,
+            0b00001U,
+            0b00010U,
+            0b00100U,
+            0b01000U,
+            0b10000U,
+            0b11111U,
         },
-        // 0x5B, [
+        // 0x5B, [ LEFT SQUARE BRACKET
         {
-            0b111,
-            0b100,
-            0b100,
-            0b100,
-            0b100,
-            0b100,
-            0b111,
+            0b111U,
+            0b100U,
+            0b100U,
+            0b100U,
+            0b100U,
+            0b100U,
+            0b111U,
         },
     }};
 
     // 0x5C, REVERSE SOLIDUS
-    static constexpr std::array<uint8_t, 5> char5C = {
-        0b10000,
-        0b01000,
-        0b00100,
-        0b00010,
-        0b00001,
+    static constexpr std::array<uint8_t, 5U> reverseSolidus{
+        0b10000U,
+        0b01000U,
+        0b00100U,
+        0b00010U,
+        0b00001U,
     };
 
-    // 0x5D, ]
-    static constexpr std::array<uint8_t, 7> char5D = {
-        0b111,
-        0b001,
-        0b001,
-        0b001,
-        0b001,
-        0b001,
-        0b111,
+    // 0x5D, ] RIGHT SQUARE BRACKET
+    static constexpr std::array<uint8_t, 7U> rightSquareBracket{
+        0b111U,
+        0b001U,
+        0b001U,
+        0b001U,
+        0b001U,
+        0b001U,
+        0b111U,
     };
 
-    // 0x5E, ^
-    static constexpr std::array<uint8_t, 3> char5E = {
-        0b00100,
-        0b01010,
-        0b10001,
+    // 0x5E, ^ CIRCUMFLEX ACCENT
+    static constexpr std::array<uint8_t, 3U> circumflexAccent{
+        0b00100U,
+        0b01010U,
+        0b10001U,
     };
 
-    // 0x60, `
-    static constexpr std::array<uint8_t, 3> char60 = {
-        0b100,
-        0b010,
-        0b001,
+    // 0x60, ` GRAVE ACCENT
+    static constexpr std::array<uint8_t, 3U> graveAccent{
+        0b100U,
+        0b010U,
+        0b001U,
     };
 
-    // 0x61, a
-    static constexpr std::array<uint8_t, 5> char61 = {
-        0b01110,
-        0b00001,
-        0b01111,
-        0b10001,
-        0b01111,
+    // 0x61, a LATIN SMALL LETTER A
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterA{
+        0b01110U,
+        0b00001U,
+        0b01111U,
+        0b10001U,
+        0b01111U,
     };
 
-    // 0x62, b
-    static constexpr std::array<uint8_t, 7> char62 = {
-        0b10000,
-        0b10000,
-        0b10110,
-        0b11001,
-        0b10001,
-        0b10001,
-        0b11110,
+    // 0x62, b LATIN SMALL LETTER B
+    static constexpr std::array<uint8_t, 7U> latinSmallLetterB{
+        0b10000U,
+        0b10000U,
+        0b10110U,
+        0b11001U,
+        0b10001U,
+        0b10001U,
+        0b11110U,
     };
 
-    // 0x63, c
-    static constexpr std::array<uint8_t, 5> char63 = {
-        0b01110,
-        0b10000,
-        0b10000,
-        0b10001,
-        0b01110,
+    // 0x63, c LATIN SMALL LETTER C
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterC{
+        0b01110U,
+        0b10000U,
+        0b10000U,
+        0b10001U,
+        0b01110U,
     };
 
-    // 0x64, d
-    static constexpr std::array<uint8_t, 7> char64 = {
-        0b00001,
-        0b00001,
-        0b01101,
-        0b10011,
-        0b10001,
-        0b10001,
-        0b01111,
+    // 0x64, d LATIN SMALL LETTER D
+    static constexpr std::array<uint8_t, 7U> latinSmallLetterD{
+        0b00001U,
+        0b00001U,
+        0b01101U,
+        0b10011U,
+        0b10001U,
+        0b10001U,
+        0b01111U,
     };
 
-    // 0x65, e
-    static constexpr std::array<uint8_t, 5> char65 = {
-        0b01110,
-        0b10001,
-        0b11111,
-        0b10000,
-        0b01110,
+    // 0x65, e LATIN SMALL LETTER E
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterE{
+        0b01110U,
+        0b10001U,
+        0b11111U,
+        0b10000U,
+        0b01110U,
     };
 
-    // 0x66, f
-    static constexpr std::array<uint8_t, 7> char66 = {
-        0b00110,
-        0b01001,
-        0b01000,
-        0b11100,
-        0b01000,
-        0b01000,
-        0b01000,
+    // 0x66, f LATIN SMALL LETTER F
+    static constexpr std::array<uint8_t, 7U> latinSmallLetterF{
+        0b00110U,
+        0b01001U,
+        0b01000U,
+        0b11100U,
+        0b01000U,
+        0b01000U,
+        0b01000U,
     };
 
-    // 0x67, g
-    static constexpr std::array<uint8_t, 5> char67 = {
-        0b01111,
-        0b10001,
-        0b01111,
-        0b00001,
-        0b00110,
+    // 0x67, g LATIN SMALL LETTER G
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterG{
+        0b01111U,
+        0b10001U,
+        0b01111U,
+        0b00001U,
+        0b00110U,
     };
 
-    static constexpr std::array<std::array<uint8_t, 7>, 5> chars68 = {{
-        // 0x68, h
+    static constexpr std::array<std::array<uint8_t, 7U>, 5U> latinSmallLetterH_latinSmallLetterL{{
+        // 0x68, h LATIN SMALL LETTER H
         {
-            0b10000,
-            0b10000,
-            0b10110,
-            0b11001,
-            0b10001,
-            0b10001,
-            0b10001,
+            0b10000U,
+            0b10000U,
+            0b10110U,
+            0b11001U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
         },
-        // 0x69, i
+        // 0x69, i LATIN SMALL LETTER I
         {
-            0b010,
-            0b000,
-            0b110,
-            0b010,
-            0b010,
-            0b010,
-            0b111,
+            0b010U,
+            0b000U,
+            0b110U,
+            0b010U,
+            0b010U,
+            0b010U,
+            0b111U,
         },
-        // 0x6A, j
+        // 0x6A, j LATIN SMALL LETTER J
         {
-            0b0001,
-            0b0000,
-            0b0011,
-            0b0001,
-            0b0001,
-            0b1001,
-            0b0110,
+            0b0001U,
+            0b0000U,
+            0b0011U,
+            0b0001U,
+            0b0001U,
+            0b1001U,
+            0b0110U,
         },
-        // 0x6B, k
+        // 0x6B, k LATIN SMALL LETTER K
         {
-            0b10000,
-            0b10000,
-            0b10001,
-            0b10010,
-            0b11100,
-            0b10010,
-            0b10001,
+            0b10000U,
+            0b10000U,
+            0b10001U,
+            0b10010U,
+            0b11100U,
+            0b10010U,
+            0b10001U,
         },
-        // 0x6C, l
+        // 0x6C, l LATIN SMALL LETTER L
         {
-            0b110,
-            0b010,
-            0b010,
-            0b010,
-            0b010,
-            0b010,
-            0b111,
+            0b110U,
+            0b010U,
+            0b010U,
+            0b010U,
+            0b010U,
+            0b010U,
+            0b111U,
         },
     }};
 
-    static constexpr std::array<std::array<uint8_t, 5>, 7> chars6D = {{
-        // 0x6D, m
+    static constexpr std::array<std::array<uint8_t, 5U>, 7U> latinSmallLetterM_latinSmallLetterS{{
+        // 0x6D, m LATIN SMALL LETTER M
         {
-            0b11010,
-            0b10101,
-            0b10101,
-            0b10001,
-            0b10001,
+            0b11010U,
+            0b10101U,
+            0b10101U,
+            0b10001U,
+            0b10001U,
         },
-        // 0x6E, n
+        // 0x6E, n LATIN SMALL LETTER N
         {
-            0b10110,
-            0b11001,
-            0b10001,
-            0b10001,
-            0b10001,
+            0b10110U,
+            0b11001U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
         },
-        // 0x6F, o
+        // 0x6F, o LATIN SMALL LETTER O
         {
-            0b01110,
-            0b10001,
-            0b10001,
-            0b10001,
-            0b01110,
+            0b01110U,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b01110U,
         },
-        // 0x70, p
+        // 0x70, p LATIN SMALL LETTER P
         {
-            0b11110,
-            0b10001,
-            0b11110,
-            0b10000,
-            0b10000,
+            0b11110U,
+            0b10001U,
+            0b11110U,
+            0b10000U,
+            0b10000U,
         },
-        // 0x71, q
+        // 0x71, q LATIN SMALL LETTER Q
         {
-            0b01101,
-            0b10011,
-            0b01111,
-            0b00001,
-            0b00001,
+            0b01101U,
+            0b10011U,
+            0b01111U,
+            0b00001U,
+            0b00001U,
         },
-        // 0x72, r
+        // 0x72, r LATIN SMALL LETTER R
         {
-            0b10110,
-            0b11001,
-            0b10000,
-            0b10000,
-            0b10000,
+            0b10110U,
+            0b11001U,
+            0b10000U,
+            0b10000U,
+            0b10000U,
         },
-        // 0x73, s
+        // 0x73, s LATIN SMALL LETTER S
         {
-            0b01110,
-            0b10000,
-            0b01110,
-            0b00001,
-            0b11110,
+            0b01110U,
+            0b10000U,
+            0b01110U,
+            0b00001U,
+            0b11110U,
         },
     }};
 
-    // 0x74, t
-    static constexpr std::array<uint8_t, 6> char74 = {
-        0b01000,
-        0b01000,
-        0b11100,
-        0b01000,
-        0b01001,
-        0b00110,
+    // 0x74, t LATIN SMALL LETTER T
+    static constexpr std::array<uint8_t, 6U> latinSmallLetterT{
+        0b01000U,
+        0b01000U,
+        0b11100U,
+        0b01000U,
+        0b01001U,
+        0b00110U,
     };
 
-    static constexpr std::array<std::array<uint8_t, 5>, 6> chars75 = {{
-        // 0x75, u
+    static constexpr std::array<std::array<uint8_t, 5U>, 6U> latinSmallLetterU_latinSmallLetterZ{{
+        // 0x75, u LATIN SMALL LETTER U
         {
-            0b10001,
-            0b10001,
-            0b10001,
-            0b10011,
-            0b01101,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b10011U,
+            0b01101U,
         },
-        // 0x76, v
+        // 0x76, v LATIN SMALL LETTER V
         {
-            0b10001,
-            0b10001,
-            0b10001,
-            0b01010,
-            0b00100,
+            0b10001U,
+            0b10001U,
+            0b10001U,
+            0b01010U,
+            0b00100U,
         },
-        // 0x77, w
+        // 0x77, w LATIN SMALL LETTER W
         {
-            0b10001,
-            0b10001,
-            0b10101,
-            0b10101,
-            0b01010,
+            0b10001U,
+            0b10001U,
+            0b10101U,
+            0b10101U,
+            0b01010U,
         },
-        // 0x78, x
+        // 0x78, x LATIN SMALL LETTER X
         {
-            0b10001,
-            0b01010,
-            0b00100,
-            0b01010,
-            0b10001,
+            0b10001U,
+            0b01010U,
+            0b00100U,
+            0b01010U,
+            0b10001U,
         },
-        // 0x79, y
+        // 0x79, y LATIN SMALL LETTER Y
         {
-            0b10001,
-            0b10001,
-            0b01111,
-            0b00001,
-            0b01110,
+            0b10001U,
+            0b10001U,
+            0b01111U,
+            0b00001U,
+            0b01110U,
         },
-        // 0x7A, z
+        // 0x7A, z LATIN SMALL LETTER Z
         {
-            0b11111,
-            0b00010,
-            0b00100,
-            0b01000,
-            0b11111,
-        },
-    }};
-
-    static constexpr std::array<std::array<uint8_t, 7>, 3> chars7B = {{
-        // 0x7B, {
-        {
-            0b001,
-            0b010,
-            0b010,
-            0b100,
-            0b010,
-            0b010,
-            0b001,
-        },
-        // 0x7C, |
-        {
-            0b1,
-            0b1,
-            0b1,
-            0b1,
-            0b1,
-            0b1,
-            0b1,
-        },
-        // 0x7D, }
-        {
-            0b100,
-            0b010,
-            0b010,
-            0b001,
-            0b010,
-            0b010,
-            0b100,
+            0b11111U,
+            0b00010U,
+            0b00100U,
+            0b01000U,
+            0b11111U,
         },
     }};
 
-    // 0xB0, ° DEGREE SIGN
-    static constexpr std::array<uint8_t, 2> charB0 = {
-        0b11,
-        0b11,
+    static constexpr std::array<std::array<uint8_t, 7U>, 3U> leftCurlyBracket_rightCurlyBracket{{
+        // 0x7B, { LEFT CURLY BRACKET
+        {
+            0b001U,
+            0b010U,
+            0b010U,
+            0b100U,
+            0b010U,
+            0b010U,
+            0b001U,
+        },
+        // 0x7C, | VERTICAL LINE
+        {
+            0b1U,
+            0b1U,
+            0b1U,
+            0b1U,
+            0b1U,
+            0b1U,
+            0b1U,
+        },
+        // 0x7D, } RIGHT CURLY BRACKET
+        {
+            0b100U,
+            0b010U,
+            0b010U,
+            0b001U,
+            0b010U,
+            0b010U,
+            0b100U,
+        },
+    }};
+
+    // 0xB0U, ° DEGREE SIGN
+    static constexpr std::array<uint8_t, 2U> degreeSign{
+        0b11U,
+        0b11U,
     };
 
     // 0xC4, Ä LATIN CAPITAL LETTER A WITH DIAERESIS
-    static constexpr std::array<uint8_t, 7> charC4 = {
-        0b10001,
-        0b01110,
-        0b10001,
-        0b10001,
-        0b11111,
-        0b10001,
-        0b10001,
+    static constexpr std::array<uint8_t, 7U> latinCapitalLetterAWithDiaeresis{
+        0b10001U,
+        0b01110U,
+        0b10001U,
+        0b10001U,
+        0b11111U,
+        0b10001U,
+        0b10001U,
     };
 
     // 0xC5, Å LATIN CAPITAL LETTER A WITH RING ABOVE
-    static constexpr std::array<uint8_t, 7> charC5 = {
-        0b01110,
-        0b01110,
-        0b11111,
-        0b10001,
-        0b11111,
-        0b10001,
-        0b10001,
+    static constexpr std::array<uint8_t, 7U> latinCapitalLetterAWithRingAbove{
+        0b01110U,
+        0b01110U,
+        0b11111U,
+        0b10001U,
+        0b11111U,
+        0b10001U,
+        0b10001U,
     };
 
     // 0xC6, Æ LATIN CAPITAL LETTER AE
-    static constexpr std::array<uint8_t, 5> charC6 = {
-        0b011111,
-        0b100100,
-        0b111110,
-        0b100100,
-        0b100111,
+    static constexpr std::array<uint8_t, 5U> latinCapitalLetterAe{
+        0b011111U,
+        0b100100U,
+        0b111110U,
+        0b100100U,
+        0b100111U,
     };
 
     // 0xD6, Ö LATIN CAPITAL LETTER O WITH DIAERESIS
-    static constexpr std::array<uint8_t, 7> charD6 = {
-        0b10001,
-        0b00000,
-        0b11111,
-        0b10001,
-        0b10001,
-        0b10001,
-        0b01110,
+    static constexpr std::array<uint8_t, 7U> latinCapitalLetterOWithDiaeresis{
+        0b10001U,
+        0b00000U,
+        0b11111U,
+        0b10001U,
+        0b10001U,
+        0b10001U,
+        0b01110U,
     };
 
     // 0xD8, Ø LATIN CAPITAL LETTER O WITH STROKE
-    static constexpr std::array<uint8_t, 5> charD8 = {
-        0b01111,
-        0b10011,
-        0b10101,
-        0b11001,
-        0b11110,
+    static constexpr std::array<uint8_t, 5U> latinCapitalLetterOWithStroke{
+        0b01111U,
+        0b10011U,
+        0b10101U,
+        0b11001U,
+        0b11110U,
     };
 
     // 0xDF, ß LATIN SMALL LETTER SHARP S
-    static constexpr std::array<uint8_t, 7> charDF = {
-        0b01110,
-        0b10001,
-        0b10001,
-        0b11111,
-        0b10001,
-        0b10001,
-        0b10111,
+    static constexpr std::array<uint8_t, 7U> latinSmallLetterSharpS{
+        0b01110U,
+        0b10001U,
+        0b10001U,
+        0b11111U,
+        0b10001U,
+        0b10001U,
+        0b10111U,
     };
 
     // 0xE4, ä LATIN SMALL LETTER A WITH DIAERESIS
-    static constexpr std::array<uint8_t, 6> charE4 = {
-        0b10001,
-        0b01110,
-        0b00001,
-        0b01111,
-        0b10001,
-        0b01111,
+    static constexpr std::array<uint8_t, 6U> latinSmallLetterAWithDiaeresis{
+        0b10001U,
+        0b01110U,
+        0b00001U,
+        0b01111U,
+        0b10001U,
+        0b01111U,
     };
 
     // 0xE5, å LATIN SMALL LETTER A WITH RING ABOVE
-    static constexpr std::array<uint8_t, 7> charE5 = {
-        0b01110,
-        0b01110,
-        0b01110,
-        0b00001,
-        0b01111,
-        0b10001,
-        0b01111,
+    static constexpr std::array<uint8_t, 7U> latinSmallLetterAWithRingAbove{
+        0b01110U,
+        0b01110U,
+        0b01110U,
+        0b00001U,
+        0b01111U,
+        0b10001U,
+        0b01111U,
     };
 
     // 0xE6, æ LATIN SMALL LETTER AE
-    static constexpr std::array<uint8_t, 5> charE6 = {
-        0b1111110,
-        0b0001001,
-        0b1111111,
-        0b1001000,
-        0b1111111,
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterAe{
+        0b1111110U,
+        0b0001001U,
+        0b1111111U,
+        0b1001000U,
+        0b1111111U,
     };
 
     // 0xF6, ö LATIN SMALL LETTER O WITH DIAERESIS
-    static constexpr std::array<uint8_t, 6> charF6 = {
-        0b10001,
-        0b01110,
-        0b10001,
-        0b10001,
-        0b10001,
-        0b01110,
+    static constexpr std::array<uint8_t, 6U> latinSmallLetterOWithDiaeresis{
+        0b10001U,
+        0b01110U,
+        0b10001U,
+        0b10001U,
+        0b10001U,
+        0b01110U,
     };
 
     // 0xF8, ø LATIN SMALL LETTER O WITH STROKE
-    static constexpr std::array<uint8_t, 5> charF8 = {
-        0b01110,
-        0b10011,
-        0b10101,
-        0b11001,
-        0b01110,
+    static constexpr std::array<uint8_t, 5U> latinSmallLetterOWithStroke{
+        0b01110U,
+        0b10011U,
+        0b10101U,
+        0b11001U,
+        0b01110U,
     };
 
     // 0xFC, ü LATIN SMALL LETTER U WITH DIAERESIS
-    static constexpr std::array<uint8_t, 6> charFC = {
-        0b10001,
-        0b00000,
-        0b10001,
-        0b10001,
-        0b10011,
-        0b01101,
+    static constexpr std::array<uint8_t, 6U> latinSmallLetterUWithDiaeresis{
+        0b10001U,
+        0b00000U,
+        0b10001U,
+        0b10001U,
+        0b10011U,
+        0b01101U,
     };
 
-    // 0x3C0, π GREEK SMALL LETTER PI
-    static constexpr std::array<uint8_t, 5> char3C0 = {
-        0b11111,
-        0b01010,
-        0b01010,
-        0b01010,
-        0b01010,
+    // 0x3C0U, π GREEK SMALL LETTER PI
+    static constexpr std::array<uint8_t, 5U> greekSmallLetterPi{
+        0b11111U,
+        0b01010U,
+        0b01010U,
+        0b01010U,
+        0b01010U,
     };
 
 public:
-    static constexpr std::string_view name = "Small";
+    static constexpr std::string_view name{"Small"};
 
     explicit SmallFont() : FontModule(name) {};
 
-    [[nodiscard]] FontModule::Symbol getChar(uint32_t character) const override;
+    [[nodiscard]] FontModule::Symbol getChar(char32_t character) const override;
 };
 
 #endif // FONT_SMALL

--- a/firmware/include/fonts/SmallFont.h
+++ b/firmware/include/fonts/SmallFont.h
@@ -9,7 +9,7 @@
 class SmallFont final : public FontModule
 {
 private:
-    // 0x21, ! EXCLAMATION MARK
+    // U+0021 ! EXCLAMATION MARK
     static constexpr std::array<uint8_t, 7U> exclamationMark{
         0b1U,
         0b1U,
@@ -20,7 +20,7 @@ private:
         0b1U,
     };
 
-    // 0x22, " QUOTATION MARK
+    // U+0022 " QUOTATION MARK
     static constexpr std::array<uint8_t, 3U> quotationMark{
         0b101U,
         0b101U,
@@ -28,7 +28,7 @@ private:
     };
 
     static constexpr std::array<std::array<uint8_t, 7U>, 4U> numberSign_ampersand{{
-        // 0x23, # NUMBER SIGN
+        // U+0023 # NUMBER SIGN
         {
             0b01010U,
             0b01010U,
@@ -38,7 +38,7 @@ private:
             0b01010U,
             0b01010U,
         },
-        // 0x24, $ DOLLAR SIGN
+        // U+0024 $ DOLLAR SIGN
         {
             0b00100U,
             0b01111U,
@@ -48,7 +48,7 @@ private:
             0b11110U,
             0b00100U,
         },
-        // 0x25, % PERCENT SIGN
+        // U+0025 % PERCENT SIGN
         {
             0b11000U,
             0b11001U,
@@ -58,7 +58,7 @@ private:
             0b10011U,
             0b00011U,
         },
-        // 0x26, & AMPERSAND
+        // U+0026 & AMPERSAND
         {
             0b0110000U,
             0b1001000U,
@@ -70,7 +70,7 @@ private:
         },
     }};
 
-    // 0x27, ' APOSTROPHE
+    // U+0027 ' APOSTROPHE
     static constexpr std::array<uint8_t, 3U> apostrophe{
         0b11U,
         0b01U,
@@ -78,7 +78,7 @@ private:
     };
 
     static constexpr std::array<std::array<uint8_t, 7U>, 2U> leftParenthesis_rightParenthesis{{
-        // 0x28, ( LEFT PARENTHESIS
+        // U+0028 ( LEFT PARENTHESIS
         {
             0b001U,
             0b010U,
@@ -88,7 +88,7 @@ private:
             0b010U,
             0b001U,
         },
-        // 0x29, ) RIGHT PARENTHESIS
+        // U+0029 ) RIGHT PARENTHESIS
         {
             0b100U,
             0b010U,
@@ -100,13 +100,13 @@ private:
         },
     }};
 
-    // 0x2A, * ASTERISK
+    // U+002A * ASTERISK
     static constexpr std::array<uint8_t, 2U> asterisk{
         0b11U,
         0b11U,
     };
 
-    // 0x2B, + PLUS SIGN
+    // U+002B + PLUS SIGN
     static constexpr std::array<uint8_t, 5U> plusSign{
         0b00100U,
         0b00100U,
@@ -115,23 +115,23 @@ private:
         0b00100U,
     };
 
-    // 0x2C, , COMMA
+    // U+002C , COMMA
     static constexpr std::array<uint8_t, 2U> comma{
         0b01U,
         0b10U,
     };
 
-    // 0x2D, - HYPHEN-MINUS
-    // 0x5F, _ LOW LINE
+    // U+002D - HYPHEN-MINUS
+    // U+005F _ LOW LINE
     static constexpr std::array<uint8_t, 1U> hyphenMinus{0b11111U};
 
-    // 0x2E, . FULL STOP
+    // U+002E . FULL STOP
     static constexpr std::array<uint8_t, 2U> fullStop{
         0b11U,
         0b11U,
     };
 
-    // 0x2F, / SOLIDUS
+    // U+002F / SOLIDUS
     static constexpr std::array<uint8_t, 5U> solidus{
         0b00001U,
         0b00010U,
@@ -141,7 +141,7 @@ private:
     };
 
     static constexpr std::array<std::array<uint8_t, 7U>, 10U> digitZero_digitNine{{
-        // 0x30, 0 DIGIT ZERO
+        // U+0030 0 DIGIT ZERO
         {
             0b0110U,
             0b1111U,
@@ -151,7 +151,7 @@ private:
             0b1111U,
             0b0110U,
         },
-        // 0x31, 1 DIGIT ONE
+        // U+0031 1 DIGIT ONE
         {
             0b011U,
             0b111U,
@@ -161,7 +161,7 @@ private:
             0b011U,
             0b011U,
         },
-        // 0x32, 2 DIGIT TWO
+        // U+0032 2 DIGIT TWO
         {
             0b0110U,
             0b1111U,
@@ -171,7 +171,7 @@ private:
             0b1111U,
             0b1111U,
         },
-        // 0x33, 3 DIGIT THREE
+        // U+0033 3 DIGIT THREE
         {
             0b0110U,
             0b1111U,
@@ -181,7 +181,7 @@ private:
             0b1111U,
             0b0110U,
         },
-        // 0x34, 4 DIGIT FOUR
+        // U+0034 4 DIGIT FOUR
         {
             0b1001U,
             0b1001U,
@@ -191,7 +191,7 @@ private:
             0b0001U,
             0b0001U,
         },
-        // 0x35, 5 DIGIT FIVE
+        // U+0035 5 DIGIT FIVE
         {
             0b1111U,
             0b1111U,
@@ -201,7 +201,7 @@ private:
             0b1111U,
             0b1110U,
         },
-        // 0x36, 6 DIGIT SIX
+        // U+0036 6 DIGIT SIX
         {
             0b0110U,
             0b1111U,
@@ -211,7 +211,7 @@ private:
             0b1111U,
             0b0110U,
         },
-        // 0x37, 7 DIGIT SEVEN
+        // U+0037 7 DIGIT SEVEN
         {
             0b1111U,
             0b1111U,
@@ -221,7 +221,7 @@ private:
             0b0100U,
             0b0100U,
         },
-        // 0x38, 8 DIGIT EIGHT
+        // U+0038 8 DIGIT EIGHT
         {
             0b0110U,
             0b1111U,
@@ -231,7 +231,7 @@ private:
             0b1111U,
             0b0110U,
         },
-        // 0x39, 9 DIGIT NINE
+        // U+0039 9 DIGIT NINE
         {
             0b0110U,
             0b1111U,
@@ -243,7 +243,7 @@ private:
         },
     }};
 
-    // 0x3A, : COLON
+    // U+003A : COLON
     static constexpr std::array<uint8_t, 5U> colon{
         0b11U,
         0b11U,
@@ -252,7 +252,7 @@ private:
         0b11U,
     };
 
-    // 0x3B, ; SEMICOLON
+    // U+003B ; SEMICOLON
     static constexpr std::array<uint8_t, 6U> semicolon{
         0b11U,
         0b11U,
@@ -262,7 +262,7 @@ private:
         0b10U,
     };
 
-    // 0x3C, < LESS-THAN SIGN
+    // U+003C < LESS-THAN SIGN
     static constexpr std::array<uint8_t, 7U> lessThanSign{
         0b0001U,
         0b0010U,
@@ -273,7 +273,7 @@ private:
         0b0001U,
     };
 
-    // 0x3D, = EQUALS SIGN
+    // U+003D = EQUALS SIGN
     static constexpr std::array<uint8_t, 3U> equalsSign{
         0b11111U,
         0b00000U,
@@ -281,7 +281,7 @@ private:
     };
 
     static constexpr std::array<std::array<uint8_t, 7U>, 30U> greaterThanSign_leftSquareBracket{{
-        // 0x3E, > GREATER-THAN SIGN
+        // U+003E > GREATER-THAN SIGN
         {
             0b1000U,
             0b0100U,
@@ -291,7 +291,7 @@ private:
             0b0100U,
             0b1000U,
         },
-        // 0x3F, ? QUESTION MARK
+        // U+003F ? QUESTION MARK
         {
             0b01110U,
             0b10001U,
@@ -301,7 +301,7 @@ private:
             0b00000U,
             0b00100U,
         },
-        // 0x40, @ COMMERCIAL AT
+        // U+0040 @ COMMERCIAL AT
         {
             0b01110U,
             0b10001U,
@@ -311,7 +311,7 @@ private:
             0b10101U,
             0b01110U,
         },
-        // 0x41, A LATIN CAPITAL LETTER A
+        // U+0041 A LATIN CAPITAL LETTER A
         {
             0b01110U,
             0b10001U,
@@ -321,7 +321,7 @@ private:
             0b10001U,
             0b10001U,
         },
-        // 0x42, B LATIN CAPITAL LETTER B
+        // U+0042 B LATIN CAPITAL LETTER B
         {
             0b11110U,
             0b10001U,
@@ -331,7 +331,7 @@ private:
             0b10001U,
             0b11110U,
         },
-        // 0x43, C LATIN CAPITAL LETTER C
+        // U+0043 C LATIN CAPITAL LETTER C
         {
             0b01110U,
             0b10001U,
@@ -341,7 +341,7 @@ private:
             0b10001U,
             0b01110U,
         },
-        // 0x44, D LATIN CAPITAL LETTER D
+        // U+0044 D LATIN CAPITAL LETTER D
         {
             0b11100U,
             0b10010U,
@@ -351,7 +351,7 @@ private:
             0b10010U,
             0b11100U,
         },
-        // 0x45, E LATIN CAPITAL LETTER E
+        // U+0045 E LATIN CAPITAL LETTER E
         {
             0b11111U,
             0b10000U,
@@ -361,7 +361,7 @@ private:
             0b10000U,
             0b11111U,
         },
-        // 0x46, F LATIN CAPITAL LETTER F
+        // U+0046 F LATIN CAPITAL LETTER F
         {
             0b11111U,
             0b10000U,
@@ -371,7 +371,7 @@ private:
             0b10000U,
             0b10000U,
         },
-        // 0x47, G LATIN CAPITAL LETTER G
+        // U+0047 G LATIN CAPITAL LETTER G
         {
             0b01110U,
             0b10001U,
@@ -381,7 +381,7 @@ private:
             0b10001U,
             0b01110U,
         },
-        // 0x48, H LATIN CAPITAL LETTER H
+        // U+0048 H LATIN CAPITAL LETTER H
         {
             0b10001U,
             0b10001U,
@@ -391,7 +391,7 @@ private:
             0b10001U,
             0b10001U,
         },
-        // 0x49, I LATIN CAPITAL LETTER I
+        // U+0049 I LATIN CAPITAL LETTER I
         {
             0b111U,
             0b010U,
@@ -401,7 +401,7 @@ private:
             0b010U,
             0b111U,
         },
-        // 0x4A, J LATIN CAPITAL LETTER J
+        // U+004A J LATIN CAPITAL LETTER J
         {
             0b00111U,
             0b00010U,
@@ -411,7 +411,7 @@ private:
             0b10010U,
             0b01100U,
         },
-        // 0x4B, K LATIN CAPITAL LETTER K
+        // U+004B K LATIN CAPITAL LETTER K
         {
             0b10001U,
             0b10010U,
@@ -421,7 +421,7 @@ private:
             0b10010U,
             0b10001U,
         },
-        // 0x4C, L LATIN CAPITAL LETTER L
+        // U+004C L LATIN CAPITAL LETTER L
         {
             0b10000U,
             0b10000U,
@@ -431,7 +431,7 @@ private:
             0b10000U,
             0b11111U,
         },
-        // 0x4D, M LATIN CAPITAL LETTER M
+        // U+004D M LATIN CAPITAL LETTER M
         {
             0b10001U,
             0b11011U,
@@ -441,7 +441,7 @@ private:
             0b10001U,
             0b10001U,
         },
-        // 0x4E, N LATIN CAPITAL LETTER N
+        // U+004E N LATIN CAPITAL LETTER N
         {
             0b10001U,
             0b10001U,
@@ -451,7 +451,7 @@ private:
             0b10001U,
             0b10001U,
         },
-        // 0x4F, O LATIN CAPITAL LETTER O
+        // U+004F O LATIN CAPITAL LETTER O
         {
             0b01110U,
             0b10001U,
@@ -461,7 +461,7 @@ private:
             0b10001U,
             0b01110U,
         },
-        // 0x50, P LATIN CAPITAL LETTER P
+        // U+0050 P LATIN CAPITAL LETTER P
         {
             0b11110U,
             0b10001U,
@@ -471,7 +471,7 @@ private:
             0b10000U,
             0b10000U,
         },
-        // 0x51, Q LATIN CAPITAL LETTER Q
+        // U+0051 Q LATIN CAPITAL LETTER Q
         {
             0b01110U,
             0b10001U,
@@ -481,7 +481,7 @@ private:
             0b10010U,
             0b01101U,
         },
-        // 0x52, R LATIN CAPITAL LETTER R
+        // U+0052 R LATIN CAPITAL LETTER R
         {
             0b11110U,
             0b10001U,
@@ -491,7 +491,7 @@ private:
             0b10010U,
             0b10001U,
         },
-        // 0x53, S LATIN CAPITAL LETTER S
+        // U+0053 S LATIN CAPITAL LETTER S
         {
             0b01111U,
             0b10000U,
@@ -501,7 +501,7 @@ private:
             0b00001U,
             0b11110U,
         },
-        // 0x54, T LATIN CAPITAL LETTER T
+        // U+0054 T LATIN CAPITAL LETTER T
         {
             0b11111U,
             0b00100U,
@@ -511,7 +511,7 @@ private:
             0b00100U,
             0b00100U,
         },
-        // 0x55, U LATIN CAPITAL LETTER U
+        // U+0055 U LATIN CAPITAL LETTER U
         {
             0b10001U,
             0b10001U,
@@ -521,7 +521,7 @@ private:
             0b10001U,
             0b01110U,
         },
-        // 0x56, V LATIN CAPITAL LETTER V
+        // U+0056 V LATIN CAPITAL LETTER V
         {
             0b10001U,
             0b10001U,
@@ -531,7 +531,7 @@ private:
             0b01010U,
             0b00100U,
         },
-        // 0x57, W LATIN CAPITAL LETTER W
+        // U+0057 W LATIN CAPITAL LETTER W
         {
             0b10001U,
             0b10001U,
@@ -541,7 +541,7 @@ private:
             0b11011U,
             0b10001U,
         },
-        // 0x58, X LATIN CAPITAL LETTER X
+        // U+0058 X LATIN CAPITAL LETTER X
         {
             0b10001U,
             0b10001U,
@@ -551,7 +551,7 @@ private:
             0b10001U,
             0b10001U,
         },
-        // 0x59, Y LATIN CAPITAL LETTER Y
+        // U+0059 Y LATIN CAPITAL LETTER Y
         {
             0b10001U,
             0b10001U,
@@ -561,7 +561,7 @@ private:
             0b00100U,
             0b00100U,
         },
-        // 0x5A, Z LATIN CAPITAL LETTER Z
+        // U+005A Z LATIN CAPITAL LETTER Z
         {
             0b11111U,
             0b00001U,
@@ -571,7 +571,7 @@ private:
             0b10000U,
             0b11111U,
         },
-        // 0x5B, [ LEFT SQUARE BRACKET
+        // U+005B [ LEFT SQUARE BRACKET
         {
             0b111U,
             0b100U,
@@ -583,7 +583,7 @@ private:
         },
     }};
 
-    // 0x5C, REVERSE SOLIDUS
+    // U+005C REVERSE SOLIDUS
     static constexpr std::array<uint8_t, 5U> reverseSolidus{
         0b10000U,
         0b01000U,
@@ -592,7 +592,7 @@ private:
         0b00001U,
     };
 
-    // 0x5D, ] RIGHT SQUARE BRACKET
+    // U+005D ] RIGHT SQUARE BRACKET
     static constexpr std::array<uint8_t, 7U> rightSquareBracket{
         0b111U,
         0b001U,
@@ -603,21 +603,21 @@ private:
         0b111U,
     };
 
-    // 0x5E, ^ CIRCUMFLEX ACCENT
+    // U+005E ^ CIRCUMFLEX ACCENT
     static constexpr std::array<uint8_t, 3U> circumflexAccent{
         0b00100U,
         0b01010U,
         0b10001U,
     };
 
-    // 0x60, ` GRAVE ACCENT
+    // U+0060 ` GRAVE ACCENT
     static constexpr std::array<uint8_t, 3U> graveAccent{
         0b100U,
         0b010U,
         0b001U,
     };
 
-    // 0x61, a LATIN SMALL LETTER A
+    // U+0061 a LATIN SMALL LETTER A
     static constexpr std::array<uint8_t, 5U> latinSmallLetterA{
         0b01110U,
         0b00001U,
@@ -626,7 +626,7 @@ private:
         0b01111U,
     };
 
-    // 0x62, b LATIN SMALL LETTER B
+    // U+0062 b LATIN SMALL LETTER B
     static constexpr std::array<uint8_t, 7U> latinSmallLetterB{
         0b10000U,
         0b10000U,
@@ -637,7 +637,7 @@ private:
         0b11110U,
     };
 
-    // 0x63, c LATIN SMALL LETTER C
+    // U+0063 c LATIN SMALL LETTER C
     static constexpr std::array<uint8_t, 5U> latinSmallLetterC{
         0b01110U,
         0b10000U,
@@ -646,7 +646,7 @@ private:
         0b01110U,
     };
 
-    // 0x64, d LATIN SMALL LETTER D
+    // U+0064 d LATIN SMALL LETTER D
     static constexpr std::array<uint8_t, 7U> latinSmallLetterD{
         0b00001U,
         0b00001U,
@@ -657,7 +657,7 @@ private:
         0b01111U,
     };
 
-    // 0x65, e LATIN SMALL LETTER E
+    // U+0065 e LATIN SMALL LETTER E
     static constexpr std::array<uint8_t, 5U> latinSmallLetterE{
         0b01110U,
         0b10001U,
@@ -666,7 +666,7 @@ private:
         0b01110U,
     };
 
-    // 0x66, f LATIN SMALL LETTER F
+    // U+0066 f LATIN SMALL LETTER F
     static constexpr std::array<uint8_t, 7U> latinSmallLetterF{
         0b00110U,
         0b01001U,
@@ -677,7 +677,7 @@ private:
         0b01000U,
     };
 
-    // 0x67, g LATIN SMALL LETTER G
+    // U+0067 g LATIN SMALL LETTER G
     static constexpr std::array<uint8_t, 5U> latinSmallLetterG{
         0b01111U,
         0b10001U,
@@ -687,7 +687,7 @@ private:
     };
 
     static constexpr std::array<std::array<uint8_t, 7U>, 5U> latinSmallLetterH_latinSmallLetterL{{
-        // 0x68, h LATIN SMALL LETTER H
+        // U+0068 h LATIN SMALL LETTER H
         {
             0b10000U,
             0b10000U,
@@ -697,7 +697,7 @@ private:
             0b10001U,
             0b10001U,
         },
-        // 0x69, i LATIN SMALL LETTER I
+        // U+0069 i LATIN SMALL LETTER I
         {
             0b010U,
             0b000U,
@@ -707,7 +707,7 @@ private:
             0b010U,
             0b111U,
         },
-        // 0x6A, j LATIN SMALL LETTER J
+        // U+006A j LATIN SMALL LETTER J
         {
             0b0001U,
             0b0000U,
@@ -717,7 +717,7 @@ private:
             0b1001U,
             0b0110U,
         },
-        // 0x6B, k LATIN SMALL LETTER K
+        // U+006B k LATIN SMALL LETTER K
         {
             0b10000U,
             0b10000U,
@@ -727,7 +727,7 @@ private:
             0b10010U,
             0b10001U,
         },
-        // 0x6C, l LATIN SMALL LETTER L
+        // U+006C l LATIN SMALL LETTER L
         {
             0b110U,
             0b010U,
@@ -740,7 +740,7 @@ private:
     }};
 
     static constexpr std::array<std::array<uint8_t, 5U>, 7U> latinSmallLetterM_latinSmallLetterS{{
-        // 0x6D, m LATIN SMALL LETTER M
+        // U+006D m LATIN SMALL LETTER M
         {
             0b11010U,
             0b10101U,
@@ -748,7 +748,7 @@ private:
             0b10001U,
             0b10001U,
         },
-        // 0x6E, n LATIN SMALL LETTER N
+        // U+006E n LATIN SMALL LETTER N
         {
             0b10110U,
             0b11001U,
@@ -756,7 +756,7 @@ private:
             0b10001U,
             0b10001U,
         },
-        // 0x6F, o LATIN SMALL LETTER O
+        // U+006F o LATIN SMALL LETTER O
         {
             0b01110U,
             0b10001U,
@@ -764,7 +764,7 @@ private:
             0b10001U,
             0b01110U,
         },
-        // 0x70, p LATIN SMALL LETTER P
+        // U+0070 p LATIN SMALL LETTER P
         {
             0b11110U,
             0b10001U,
@@ -772,7 +772,7 @@ private:
             0b10000U,
             0b10000U,
         },
-        // 0x71, q LATIN SMALL LETTER Q
+        // U+0071 q LATIN SMALL LETTER Q
         {
             0b01101U,
             0b10011U,
@@ -780,7 +780,7 @@ private:
             0b00001U,
             0b00001U,
         },
-        // 0x72, r LATIN SMALL LETTER R
+        // U+0072 r LATIN SMALL LETTER R
         {
             0b10110U,
             0b11001U,
@@ -788,7 +788,7 @@ private:
             0b10000U,
             0b10000U,
         },
-        // 0x73, s LATIN SMALL LETTER S
+        // U+0073 s LATIN SMALL LETTER S
         {
             0b01110U,
             0b10000U,
@@ -798,7 +798,7 @@ private:
         },
     }};
 
-    // 0x74, t LATIN SMALL LETTER T
+    // U+0074 t LATIN SMALL LETTER T
     static constexpr std::array<uint8_t, 6U> latinSmallLetterT{
         0b01000U,
         0b01000U,
@@ -809,7 +809,7 @@ private:
     };
 
     static constexpr std::array<std::array<uint8_t, 5U>, 6U> latinSmallLetterU_latinSmallLetterZ{{
-        // 0x75, u LATIN SMALL LETTER U
+        // U+0075 u LATIN SMALL LETTER U
         {
             0b10001U,
             0b10001U,
@@ -817,7 +817,7 @@ private:
             0b10011U,
             0b01101U,
         },
-        // 0x76, v LATIN SMALL LETTER V
+        // U+0076 v LATIN SMALL LETTER V
         {
             0b10001U,
             0b10001U,
@@ -825,7 +825,7 @@ private:
             0b01010U,
             0b00100U,
         },
-        // 0x77, w LATIN SMALL LETTER W
+        // U+0077 w LATIN SMALL LETTER W
         {
             0b10001U,
             0b10001U,
@@ -833,7 +833,7 @@ private:
             0b10101U,
             0b01010U,
         },
-        // 0x78, x LATIN SMALL LETTER X
+        // U+0078 x LATIN SMALL LETTER X
         {
             0b10001U,
             0b01010U,
@@ -841,7 +841,7 @@ private:
             0b01010U,
             0b10001U,
         },
-        // 0x79, y LATIN SMALL LETTER Y
+        // U+0079 y LATIN SMALL LETTER Y
         {
             0b10001U,
             0b10001U,
@@ -849,7 +849,7 @@ private:
             0b00001U,
             0b01110U,
         },
-        // 0x7A, z LATIN SMALL LETTER Z
+        // U+007A z LATIN SMALL LETTER Z
         {
             0b11111U,
             0b00010U,
@@ -860,7 +860,7 @@ private:
     }};
 
     static constexpr std::array<std::array<uint8_t, 7U>, 3U> leftCurlyBracket_rightCurlyBracket{{
-        // 0x7B, { LEFT CURLY BRACKET
+        // U+007B { LEFT CURLY BRACKET
         {
             0b001U,
             0b010U,
@@ -870,7 +870,7 @@ private:
             0b010U,
             0b001U,
         },
-        // 0x7C, | VERTICAL LINE
+        // U+007C | VERTICAL LINE
         {
             0b1U,
             0b1U,
@@ -880,7 +880,7 @@ private:
             0b1U,
             0b1U,
         },
-        // 0x7D, } RIGHT CURLY BRACKET
+        // U+007D } RIGHT CURLY BRACKET
         {
             0b100U,
             0b010U,
@@ -892,13 +892,13 @@ private:
         },
     }};
 
-    // 0xB0U, ° DEGREE SIGN
+    // U+00B0 ° DEGREE SIGN
     static constexpr std::array<uint8_t, 2U> degreeSign{
         0b11U,
         0b11U,
     };
 
-    // 0xC4, Ä LATIN CAPITAL LETTER A WITH DIAERESIS
+    // U+00C4 Ä LATIN CAPITAL LETTER A WITH DIAERESIS
     static constexpr std::array<uint8_t, 7U> latinCapitalLetterAWithDiaeresis{
         0b10001U,
         0b01110U,
@@ -909,7 +909,7 @@ private:
         0b10001U,
     };
 
-    // 0xC5, Å LATIN CAPITAL LETTER A WITH RING ABOVE
+    // U+00C5 Å LATIN CAPITAL LETTER A WITH RING ABOVE
     static constexpr std::array<uint8_t, 7U> latinCapitalLetterAWithRingAbove{
         0b01110U,
         0b01110U,
@@ -920,7 +920,7 @@ private:
         0b10001U,
     };
 
-    // 0xC6, Æ LATIN CAPITAL LETTER AE
+    // U+00C6 Æ LATIN CAPITAL LETTER AE
     static constexpr std::array<uint8_t, 5U> latinCapitalLetterAe{
         0b011111U,
         0b100100U,
@@ -929,7 +929,7 @@ private:
         0b100111U,
     };
 
-    // 0xD6, Ö LATIN CAPITAL LETTER O WITH DIAERESIS
+    // U+00D6 Ö LATIN CAPITAL LETTER O WITH DIAERESIS
     static constexpr std::array<uint8_t, 7U> latinCapitalLetterOWithDiaeresis{
         0b10001U,
         0b00000U,
@@ -940,7 +940,7 @@ private:
         0b01110U,
     };
 
-    // 0xD8, Ø LATIN CAPITAL LETTER O WITH STROKE
+    // U+00D8 Ø LATIN CAPITAL LETTER O WITH STROKE
     static constexpr std::array<uint8_t, 5U> latinCapitalLetterOWithStroke{
         0b01111U,
         0b10011U,
@@ -949,7 +949,7 @@ private:
         0b11110U,
     };
 
-    // 0xDF, ß LATIN SMALL LETTER SHARP S
+    // U+00DF ß LATIN SMALL LETTER SHARP S
     static constexpr std::array<uint8_t, 7U> latinSmallLetterSharpS{
         0b01110U,
         0b10001U,
@@ -960,7 +960,7 @@ private:
         0b10111U,
     };
 
-    // 0xE4, ä LATIN SMALL LETTER A WITH DIAERESIS
+    // U+00E4 ä LATIN SMALL LETTER A WITH DIAERESIS
     static constexpr std::array<uint8_t, 6U> latinSmallLetterAWithDiaeresis{
         0b10001U,
         0b01110U,
@@ -970,7 +970,7 @@ private:
         0b01111U,
     };
 
-    // 0xE5, å LATIN SMALL LETTER A WITH RING ABOVE
+    // U+00E5 å LATIN SMALL LETTER A WITH RING ABOVE
     static constexpr std::array<uint8_t, 7U> latinSmallLetterAWithRingAbove{
         0b01110U,
         0b01110U,
@@ -981,7 +981,7 @@ private:
         0b01111U,
     };
 
-    // 0xE6, æ LATIN SMALL LETTER AE
+    // U+00E6 æ LATIN SMALL LETTER AE
     static constexpr std::array<uint8_t, 5U> latinSmallLetterAe{
         0b1111110U,
         0b0001001U,
@@ -990,7 +990,7 @@ private:
         0b1111111U,
     };
 
-    // 0xF6, ö LATIN SMALL LETTER O WITH DIAERESIS
+    // U+00F6 ö LATIN SMALL LETTER O WITH DIAERESIS
     static constexpr std::array<uint8_t, 6U> latinSmallLetterOWithDiaeresis{
         0b10001U,
         0b01110U,
@@ -1000,7 +1000,7 @@ private:
         0b01110U,
     };
 
-    // 0xF8, ø LATIN SMALL LETTER O WITH STROKE
+    // U+00F8 ø LATIN SMALL LETTER O WITH STROKE
     static constexpr std::array<uint8_t, 5U> latinSmallLetterOWithStroke{
         0b01110U,
         0b10011U,
@@ -1009,7 +1009,7 @@ private:
         0b01110U,
     };
 
-    // 0xFC, ü LATIN SMALL LETTER U WITH DIAERESIS
+    // U+00FC ü LATIN SMALL LETTER U WITH DIAERESIS
     static constexpr std::array<uint8_t, 6U> latinSmallLetterUWithDiaeresis{
         0b10001U,
         0b00000U,
@@ -1019,7 +1019,7 @@ private:
         0b01101U,
     };
 
-    // 0x3C0U, π GREEK SMALL LETTER PI
+    // U+03C0 π GREEK SMALL LETTER PI
     static constexpr std::array<uint8_t, 5U> greekSmallLetterPi{
         0b11111U,
         0b01010U,

--- a/firmware/include/handlers/TextHandler.h
+++ b/firmware/include/handlers/TextHandler.h
@@ -21,9 +21,9 @@ public:
 private:
     const FontModule *font;
 
-    uint8_t height = 0;
-    uint8_t tracking = 1;
-    uint8_t width = 0;
+    uint8_t height{0U};
+    uint8_t tracking{1U};
+    uint8_t width{0U};
 
     std::string text{};
 
@@ -31,7 +31,7 @@ private:
         requires std::is_unsigned_v<T>
     [[nodiscard]] uint8_t calcMsbMax(std::span<const T> bitmap) const;
 
-    bool nextCodepoint(size_t &index, uint32_t &out) const;
+    bool nextCodepoint(size_t &index, char32_t &out) const;
 
-    static std::array<char, 5> encode(uint32_t codepoint);
+    static std::array<char, 5U> encode(char32_t codepoint);
 };

--- a/firmware/include/modules/FontModule.h
+++ b/firmware/include/modules/FontModule.h
@@ -23,14 +23,16 @@ public:
 
     const std::string_view name{};
 
-    [[nodiscard]] virtual Symbol getChar(uint32_t character) const = 0;
+    [[nodiscard]] virtual Symbol getChar(char32_t character) const = 0;
 
 protected:
     explicit FontModule(std::string_view name) : name(name) {};
 
-    template <typename T, std::size_t N>
+    template <typename T, size_t N> [[nodiscard]] Symbol toSymbol(const std::array<T, N> &bitmap) const;
+    template <typename T, size_t N> [[nodiscard]] Symbol toSymbol(const std::array<T, N> &bitmap, int8_t offsetY) const;
+    template <typename T, size_t N>
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-    [[nodiscard]] Symbol toSymbol(const std::array<T, N> &bitmap, uint8_t offsetX = 0, int8_t offsetY = 0) const;
+    [[nodiscard]] Symbol toSymbol(const std::array<T, N> &bitmap, uint8_t offsetX, int8_t offsetY) const;
 
     [[nodiscard]] Symbol whitespace(uint8_t offsetX) const;
 };

--- a/firmware/include/modules/FontModule.tpp
+++ b/firmware/include/modules/FontModule.tpp
@@ -1,6 +1,17 @@
 #include "modules/FontModule.h"
 
-template <typename T, std::size_t N>
+template <typename T, size_t N> FontModule::Symbol FontModule::toSymbol(const std::array<T, N> &bitmap) const
+{
+    return {bitmap, 0U, 0};
+}
+
+template <typename T, size_t N>
+FontModule::Symbol FontModule::toSymbol(const std::array<T, N> &bitmap, int8_t offsetY) const
+{
+    return {bitmap, 0U, offsetY};
+}
+
+template <typename T, size_t N>
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 FontModule::Symbol FontModule::toSymbol(const std::array<T, N> &bitmap, uint8_t offsetX, int8_t offsetY) const
 {

--- a/firmware/src/fonts/BrailleFont.cpp
+++ b/firmware/src/fonts/BrailleFont.cpp
@@ -47,47 +47,50 @@ FontModule::Symbol BrailleFont::getChar(char32_t character) const
 {
     if (character >= '1' && character <= '9')
     {
+        // U+0031-U+0039
         return toSymbol(latinLetterA_latinLetterZtterA_latinLetterZ[character - '1']);
     }
     if (character >= 'A' && character <= 'Z')
     {
+        // U+0041-U+005A
         return toSymbol(latinLetterA_latinLetterZ[character - 'A']);
     }
     if (character >= 'a' && character <= 'z')
     {
+        // U+0061-U+007A
         return toSymbol(latinLetterA_latinLetterZ[character - 'a']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case ' ': // SPACE
+    case ' ': // U+0020 SPACE
         return whitespace(2U);
-    case '!': // EXCLAMATION MARK
+    case '!': // U+0021 EXCLAMATION MARK
         return toSymbol(0b00'11'10U);
-    case '\'': // APOSTROPHE
+    case '\'': // U+0027 APOSTROPHE
         return toSymbol(0b00'00'10U);
-    case '(': // LEFT PARENTHESIS
-    case ')': // RIGHT PARENTHESIS
-    case '[': // LEFT SQUARE BRACKET
-    case ']': // RIGHT SQUARE BRACKET
-    case '{': // LEFT CURLY BRACKET
-    case '}': // RIGHT CURLY BRACKET
+    case '(': // U+0028 LEFT PARENTHESIS
+    case ')': // U+0029 RIGHT PARENTHESIS
+    case '[': // U+005B LEFT SQUARE BRACKET
+    case ']': // U+005D RIGHT SQUARE BRACKET
+    case '{': // U+007B LEFT CURLY BRACKET
+    case '}': // U+007D RIGHT CURLY BRACKET
         return toSymbol(0b00'11'11U);
-    case ',': // COMMA
+    case ',': // U+002C COMMA
         return toSymbol(0b00'10'00U);
-    case '-': // HYPHEN-MINUS
+    case '-': // U+002D HYPHEN-MINUS
         return toSymbol(0b00'00'11U);
-    case '.': // FULL STOP
+    case '.': // U+002E FULL STOP
         return toSymbol(0b00'11'01U);
-    case '/': // SOLIDUS
+    case '/': // U+002F SOLIDUS
         return toSymbol(0b01'00'10U);
-    case '0': // DIGIT ZERO
+    case '0': // U+0030 DIGIT ZERO
         return toSymbol(latinLetterA_latinLetterZ[9U]);
-    case ':': // COLON
+    case ':': // U+003A COLON
         return toSymbol(0b00'11'00U);
-    case ';': // SEMICOLON
+    case ';': // U+003B SEMICOLON
         return toSymbol(0b00'10'10U);
-    case '?': // QUESTION MARK
+    case '?': // U+003F QUESTION MARK
         return toSymbol(0b00'10'11U);
     default:
         return {};

--- a/firmware/src/fonts/BrailleFont.cpp
+++ b/firmware/src/fonts/BrailleFont.cpp
@@ -89,9 +89,10 @@ FontModule::Symbol BrailleFont::getChar(char32_t character) const
         return toSymbol(0b00'10'10U);
     case '?': // QUESTION MARK
         return toSymbol(0b00'10'11U);
+    default:
+        return {};
     }
     // NOLINTEND(bugprone-branch-clone)
-    return {};
 }
 
 #endif // FONT_BRAILLE

--- a/firmware/src/fonts/BrailleFont.cpp
+++ b/firmware/src/fonts/BrailleFont.cpp
@@ -11,9 +11,9 @@ static_assert(GRID_ROWS >= 3U, __STRING(FONT_BRAILLE) " is not compatible with t
 
 FontModule::Symbol BrailleFont::toSymbol(uint8_t bits) const
 {
-    const uint8_t row1{bits & 0b11U};
-    const uint8_t row2{(bits >> (0b1U << 1U)) & 0b11U};
-    const uint8_t row3{(bits >> (0b1U << 2U)) & 0b11U};
+    const uint8_t row1{static_cast<uint8_t>(bits & 0b11U)};
+    const uint8_t row2{static_cast<uint8_t>((bits >> 2U) & 0b11U)};
+    const uint8_t row3{static_cast<uint8_t>((bits >> 4U) & 0b11U)};
     int8_t size{0};
     if (row3)
     {
@@ -31,16 +31,18 @@ FontModule::Symbol BrailleFont::toSymbol(uint8_t bits) const
     if (size)
     {
         bitmap[0U] = row1;
+        if (size >= 2)
+        {
+            bitmap[1U] = row2;
+            if (size == 3)
+            {
+                bitmap[2U] = row3;
+            }
+        }
     }
-    if (size >= 2)
-    {
-        bitmap[1U] = row2;
-    }
-    if (size == 3)
-    {
-        bitmap[2U] = row3;
-    }
-    return {bitmap, ((row1 | row2 | row3) & (0b1U << 1U)) ? 0U : 1U, static_cast<int8_t>(3 - size)};
+    return {bitmap,
+            static_cast<uint8_t>(((row1 | row2 | row3) & (0b1U << 1U)) != 0U ? 0U : 1U),
+            static_cast<int8_t>(3 - size)};
 }
 
 FontModule::Symbol BrailleFont::getChar(char32_t character) const
@@ -48,7 +50,7 @@ FontModule::Symbol BrailleFont::getChar(char32_t character) const
     if (character >= '1' && character <= '9')
     {
         // U+0031-U+0039
-        return toSymbol(latinLetterA_latinLetterZtterA_latinLetterZ[character - '1']);
+        return toSymbol(latinLetterA_latinLetterZ[character - '1']);
     }
     if (character >= 'A' && character <= 'Z')
     {

--- a/firmware/src/fonts/BrailleFont.cpp
+++ b/firmware/src/fonts/BrailleFont.cpp
@@ -2,14 +2,19 @@
 
 #include "fonts/BrailleFont.h"
 
+#include "config/constants.h" // NOLINT(misc-include-cleaner)
+
 #include <vector>
+
+static_assert(GRID_COLUMNS >= 2U, __STRING(FONT_BRAILLE) " is not compatible with this device's display size.");
+static_assert(GRID_ROWS >= 3U, __STRING(FONT_BRAILLE) " is not compatible with this device's display size.");
 
 FontModule::Symbol BrailleFont::toSymbol(uint8_t bits) const
 {
-    const uint8_t row1 = bits & 0x03;
-    const uint8_t row2 = (bits >> 2) & 0x03;
-    const uint8_t row3 = (bits >> 4) & 0x03;
-    int8_t size = 0;
+    const uint8_t row1{bits & 0b11U};
+    const uint8_t row2{(bits >> (0b1U << 1U)) & 0b11U};
+    const uint8_t row3{(bits >> (0b1U << 2U)) & 0b11U};
+    int8_t size{0};
     if (row3)
     {
         size = 3;
@@ -25,65 +30,65 @@ FontModule::Symbol BrailleFont::toSymbol(uint8_t bits) const
     std::vector<uint8_t> bitmap(size);
     if (size)
     {
-        bitmap[0] = row1;
+        bitmap[0U] = row1;
     }
     if (size >= 2)
     {
-        bitmap[1] = row2;
+        bitmap[1U] = row2;
     }
     if (size == 3)
     {
-        bitmap[2] = row3;
+        bitmap[2U] = row3;
     }
-    return {bitmap, static_cast<uint8_t>(((row1 | row2 | row3) & 0x02) ? 0 : 1), static_cast<int8_t>(3 - size)};
+    return {bitmap, ((row1 | row2 | row3) & (0b1U << 1U)) ? 0U : 1U, static_cast<int8_t>(3 - size)};
 }
 
-FontModule::Symbol BrailleFont::getChar(uint32_t character) const
+FontModule::Symbol BrailleFont::getChar(char32_t character) const
 {
-    if (character >= 0x31 && character <= 0x39)
+    if (character >= '1' && character <= '9')
     {
-        return toSymbol(chars41[character - 0x31]);
+        return toSymbol(latinLetterA_latinLetterZtterA_latinLetterZ[character - '1']);
     }
-    if (character >= 0x41 && character <= 0x5A)
+    if (character >= 'A' && character <= 'Z')
     {
-        return toSymbol(chars41[character - 0x41]);
+        return toSymbol(latinLetterA_latinLetterZ[character - 'A']);
     }
-    if (character >= 0x61 && character <= 0x7A)
+    if (character >= 'a' && character <= 'z')
     {
-        return toSymbol(chars41[character - 0x61]);
+        return toSymbol(latinLetterA_latinLetterZ[character - 'a']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case 0x20: // SPACE
-        return whitespace(2);
-    case 0x21: // !
-        return toSymbol(0b1110);
-    case 0x27: // '
-        return toSymbol(0b10);
-    case 0x28: // (
-    case 0x29: // )
-    case 0x5B: // [
-    case 0x5D: // ]
-    case 0x7B: // {
-    case 0x7D: // }
-        return toSymbol(0b1111);
-    case 0x2C: // ,
-        return toSymbol(0b1000);
-    case 0x2D: // -
-        return toSymbol(0b11);
-    case 0x2E: // .
-        return toSymbol(0b1101);
-    case 0x2F: // /
-        return toSymbol(0b10010);
-    case 0x30: // 0
-        return toSymbol(chars41[9]);
-    case 0x3A: // :
-        return toSymbol(0b1100);
-    case 0x3B: // ;
-        return toSymbol(0b1010);
-    case 0x3F: // ?
-        return toSymbol(0b1011);
+    case ' ': // SPACE
+        return whitespace(2U);
+    case '!': // EXCLAMATION MARK
+        return toSymbol(0b00'11'10U);
+    case '\'': // APOSTROPHE
+        return toSymbol(0b00'00'10U);
+    case '(': // LEFT PARENTHESIS
+    case ')': // RIGHT PARENTHESIS
+    case '[': // LEFT SQUARE BRACKET
+    case ']': // RIGHT SQUARE BRACKET
+    case '{': // LEFT CURLY BRACKET
+    case '}': // RIGHT CURLY BRACKET
+        return toSymbol(0b00'11'11U);
+    case ',': // COMMA
+        return toSymbol(0b00'10'00U);
+    case '-': // HYPHEN-MINUS
+        return toSymbol(0b00'00'11U);
+    case '.': // FULL STOP
+        return toSymbol(0b00'11'01U);
+    case '/': // SOLIDUS
+        return toSymbol(0b01'00'10U);
+    case '0': // DIGIT ZERO
+        return toSymbol(latinLetterA_latinLetterZ[9U]);
+    case ':': // COLON
+        return toSymbol(0b00'11'00U);
+    case ';': // SEMICOLON
+        return toSymbol(0b00'10'10U);
+    case '?': // QUESTION MARK
+        return toSymbol(0b00'10'11U);
     }
     // NOLINTEND(bugprone-branch-clone)
     return {};

--- a/firmware/src/fonts/LargeFont.cpp
+++ b/firmware/src/fonts/LargeFont.cpp
@@ -2,23 +2,28 @@
 
 #include "fonts/LargeFont.h"
 
-FontModule::Symbol LargeFont::getChar(uint32_t character) const
+#include "config/constants.h" // NOLINT(misc-include-cleaner)
+
+static_assert(GRID_COLUMNS >= 8U, __STRING(FONT_LARGE) " is not compatible with this device's display size.");
+static_assert(GRID_ROWS >= 8U, __STRING(FONT_LARGE) " is not compatible with this device's display size.");
+
+FontModule::Symbol LargeFont::getChar(char32_t character) const
 {
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case 0x20: // SPACE
-        return whitespace(6);
-    case 0x21: // !
-        return toSymbol(char21);
-    case 0x49: // I
-        return toSymbol(char49);
-    case 0x52: // R
-        return toSymbol(char52);
-    case 0x55: // U
-        return toSymbol(char55);
-    case 0x3C0: // π GREEK SMALL LETTER PI
-        return toSymbol(char3C0);
+    case ' ': // SPACE
+        return whitespace(6U);
+    case '!': // EXCLAMATION MARK
+        return toSymbol(exclamationMark);
+    case 'I': // LATIN CAPITAL LETTER I
+        return toSymbol(latinCapitalLetterI);
+    case 'R': // LATIN CAPITAL LETTER R
+        return toSymbol(latinCapitalLetterR);
+    case 'U': // LATIN CAPITAL LETTER U
+        return toSymbol(latinCapitalLetterU);
+    case U'π': // GREEK SMALL LETTER PI
+        return toSymbol(greekSmallLetterPi);
     }
     // NOLINTEND(bugprone-branch-clone)
     return {};

--- a/firmware/src/fonts/LargeFont.cpp
+++ b/firmware/src/fonts/LargeFont.cpp
@@ -12,17 +12,17 @@ FontModule::Symbol LargeFont::getChar(char32_t character) const
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case ' ': // SPACE
+    case ' ': // U+0020 SPACE
         return whitespace(6U);
-    case '!': // EXCLAMATION MARK
+    case '!': // U+0021 EXCLAMATION MARK
         return toSymbol(exclamationMark);
-    case 'I': // LATIN CAPITAL LETTER I
+    case 'I': // U+0049 LATIN CAPITAL LETTER I
         return toSymbol(latinCapitalLetterI);
-    case 'R': // LATIN CAPITAL LETTER R
+    case 'R': // U+0052 LATIN CAPITAL LETTER R
         return toSymbol(latinCapitalLetterR);
-    case 'U': // LATIN CAPITAL LETTER U
+    case 'U': // U+0055 LATIN CAPITAL LETTER U
         return toSymbol(latinCapitalLetterU);
-    case U'π': // GREEK SMALL LETTER PI
+    case U'π': // U+03C0 GREEK SMALL LETTER PI
         return toSymbol(greekSmallLetterPi);
     default:
         return {};

--- a/firmware/src/fonts/LargeFont.cpp
+++ b/firmware/src/fonts/LargeFont.cpp
@@ -24,9 +24,10 @@ FontModule::Symbol LargeFont::getChar(char32_t character) const
         return toSymbol(latinCapitalLetterU);
     case U'π': // GREEK SMALL LETTER PI
         return toSymbol(greekSmallLetterPi);
+    default:
+        return {};
     }
     // NOLINTEND(bugprone-branch-clone)
-    return {};
 }
 
 #endif // FONT_LARGE

--- a/firmware/src/fonts/MediumBoldFont.cpp
+++ b/firmware/src/fonts/MediumBoldFont.cpp
@@ -2,23 +2,28 @@
 
 #include "fonts/MediumBoldFont.h"
 
-FontModule::Symbol MediumBoldFont::getChar(uint32_t character) const
+#include "config/constants.h" // NOLINT(misc-include-cleaner)
+
+static_assert(GRID_COLUMNS >= 6U, __STRING(FONT_MEDIUMBOLD) " is not compatible with this device's display size.");
+static_assert(GRID_ROWS >= 7U, __STRING(FONT_MEDIUMBOLD) " is not compatible with this device's display size.");
+
+FontModule::Symbol MediumBoldFont::getChar(char32_t character) const
 {
-    if (character >= 0x30 && character <= 0x39)
+    if (character >= '0' && character <= '9')
     {
-        return toSymbol(chars30[character - 0x30]);
+        return toSymbol(digitZero_digitNine[character - '0']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case 0x20: // SPACE
-        return whitespace(6);
-    case 0x49: // I
-        return toSymbol(char49);
-    case 0x4F: // O
-        return toSymbol(char4F);
-    case 0x6F: // o
-        return toSymbol(char6F);
+    case ' ': // SPACE
+        return whitespace(6U);
+    case 'I': // LATIN CAPITAL LETTER I
+        return toSymbol(latinCapitalLetterI);
+    case 'O': // LATIN CAPITAL LETTER O
+        return toSymbol(latinCapitalLetterO);
+    case 'o': // LATIN SMALL LETTER O
+        return toSymbol(latinSmallLetterO);
     }
     // NOLINTEND(bugprone-branch-clone)
     return {};

--- a/firmware/src/fonts/MediumBoldFont.cpp
+++ b/firmware/src/fonts/MediumBoldFont.cpp
@@ -24,9 +24,10 @@ FontModule::Symbol MediumBoldFont::getChar(char32_t character) const
         return toSymbol(latinCapitalLetterO);
     case 'o': // LATIN SMALL LETTER O
         return toSymbol(latinSmallLetterO);
+    default:
+        return {};
     }
     // NOLINTEND(bugprone-branch-clone)
-    return {};
 }
 
 #endif // FONT_MEDIUMBOLD

--- a/firmware/src/fonts/MediumBoldFont.cpp
+++ b/firmware/src/fonts/MediumBoldFont.cpp
@@ -11,18 +11,19 @@ FontModule::Symbol MediumBoldFont::getChar(char32_t character) const
 {
     if (character >= '0' && character <= '9')
     {
+        // U+0030-U+0039
         return toSymbol(digitZero_digitNine[character - '0']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case ' ': // SPACE
+    case ' ': // U+0020 SPACE
         return whitespace(6U);
-    case 'I': // LATIN CAPITAL LETTER I
+    case 'I': // U+0049 LATIN CAPITAL LETTER I
         return toSymbol(latinCapitalLetterI);
-    case 'O': // LATIN CAPITAL LETTER O
+    case 'O': // U+004F LATIN CAPITAL LETTER O
         return toSymbol(latinCapitalLetterO);
-    case 'o': // LATIN SMALL LETTER O
+    case 'o': // U+006F LATIN SMALL LETTER O
         return toSymbol(latinSmallLetterO);
     default:
         return {};

--- a/firmware/src/fonts/MediumFont.cpp
+++ b/firmware/src/fonts/MediumFont.cpp
@@ -2,23 +2,28 @@
 
 #include "fonts/MediumFont.h"
 
-FontModule::Symbol MediumFont::getChar(uint32_t character) const
+#include "config/constants.h" // NOLINT(misc-include-cleaner)
+
+static_assert(GRID_COLUMNS >= 6U, __STRING(FONT_MEDIUM) " is not compatible with this device's display size.");
+static_assert(GRID_ROWS >= 7U, __STRING(FONT_MEDIUM) " is not compatible with this device's display size.");
+
+FontModule::Symbol MediumFont::getChar(char32_t character) const
 {
-    if (character >= 0x30 && character <= 0x39)
+    if (character >= '0' && character <= '9')
     {
-        return toSymbol(chars30[character - 0x30]);
+        return toSymbol(digitZero_digitNine[character - '0']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case 0x20: // SPACE
-        return whitespace(6);
-    case 0x49: // I
-        return toSymbol(char49);
-    case 0x4F: // O
-        return toSymbol(char4F);
-    case 0x6F: // o
-        return toSymbol(char6F);
+    case ' ': // SPACE
+        return whitespace(6U);
+    case 'I': // LATIN CAPITAL LETTER I
+        return toSymbol(latinCapitalLetterI);
+    case 'O': // LATIN CAPITAL LETTER O
+        return toSymbol(latinCapitalLetterO);
+    case 'o': // LATIN SMALL LETTER O
+        return toSymbol(latinSmallLetterO);
     }
     // NOLINTEND(bugprone-branch-clone)
     return {};

--- a/firmware/src/fonts/MediumFont.cpp
+++ b/firmware/src/fonts/MediumFont.cpp
@@ -24,9 +24,10 @@ FontModule::Symbol MediumFont::getChar(char32_t character) const
         return toSymbol(latinCapitalLetterO);
     case 'o': // LATIN SMALL LETTER O
         return toSymbol(latinSmallLetterO);
+    default:
+        return {};
     }
     // NOLINTEND(bugprone-branch-clone)
-    return {};
 }
 
 #endif // FONT_MEDIUM

--- a/firmware/src/fonts/MediumFont.cpp
+++ b/firmware/src/fonts/MediumFont.cpp
@@ -11,18 +11,19 @@ FontModule::Symbol MediumFont::getChar(char32_t character) const
 {
     if (character >= '0' && character <= '9')
     {
+        // U+0030-U+0039
         return toSymbol(digitZero_digitNine[character - '0']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case ' ': // SPACE
+    case ' ': // U+0020 SPACE
         return whitespace(6U);
-    case 'I': // LATIN CAPITAL LETTER I
+    case 'I': // U+0049 LATIN CAPITAL LETTER I
         return toSymbol(latinCapitalLetterI);
-    case 'O': // LATIN CAPITAL LETTER O
+    case 'O': // U+004F LATIN CAPITAL LETTER O
         return toSymbol(latinCapitalLetterO);
-    case 'o': // LATIN SMALL LETTER O
+    case 'o': // U+006F LATIN SMALL LETTER O
         return toSymbol(latinSmallLetterO);
     default:
         return {};

--- a/firmware/src/fonts/MediumWideFont.cpp
+++ b/firmware/src/fonts/MediumWideFont.cpp
@@ -11,18 +11,19 @@ FontModule::Symbol MediumWideFont::getChar(char32_t character) const
 {
     if (character >= '0' && character <= '9')
     {
+        // U+0030-U+0039
         return toSymbol(digitZero_digitNine[character - '0']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case ' ': // SPACE
+    case ' ': // U+0020 SPACE
         return whitespace(6U);
-    case 'I': // LATIN CAPITAL LETTER I
+    case 'I': // U+0049 LATIN CAPITAL LETTER I
         return toSymbol(latinCapitalLetterI);
-    case 'O': // LATIN CAPITAL LETTER O
+    case 'O': // U+004F LATIN CAPITAL LETTER O
         return toSymbol(latinCapitalLetterO);
-    case 'o': // LATIN SMALL LETTER O
+    case 'o': // U+006F LATIN SMALL LETTER O
         return toSymbol(latinSmallLetterO);
     default:
         return {};

--- a/firmware/src/fonts/MediumWideFont.cpp
+++ b/firmware/src/fonts/MediumWideFont.cpp
@@ -2,23 +2,28 @@
 
 #include "fonts/MediumWideFont.h"
 
-FontModule::Symbol MediumWideFont::getChar(uint32_t character) const
+#include "config/constants.h" // NOLINT(misc-include-cleaner)
+
+static_assert(GRID_COLUMNS >= 7U, __STRING(FONT_MEDIUMWIDE) " is not compatible with this device's display size.");
+static_assert(GRID_ROWS >= 7U, __STRING(FONT_MEDIUMWIDE) " is not compatible with this device's display size.");
+
+FontModule::Symbol MediumWideFont::getChar(char32_t character) const
 {
-    if (character >= 0x30 && character <= 0x39)
+    if (character >= '0' && character <= '9')
     {
-        return toSymbol(chars30[character - 0x30]);
+        return toSymbol(digitZero_digitNine[character - '0']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case 0x20: // SPACE
-        return whitespace(6);
-    case 0x49: // I
-        return toSymbol(char49);
-    case 0x4F: // O
-        return toSymbol(char4F);
-    case 0x6F: // o
-        return toSymbol(char6F);
+    case ' ': // SPACE
+        return whitespace(6U);
+    case 'I': // LATIN CAPITAL LETTER I
+        return toSymbol(latinCapitalLetterI);
+    case 'O': // LATIN CAPITAL LETTER O
+        return toSymbol(latinCapitalLetterO);
+    case 'o': // LATIN SMALL LETTER O
+        return toSymbol(latinSmallLetterO);
     }
     // NOLINTEND(bugprone-branch-clone)
     return {};

--- a/firmware/src/fonts/MediumWideFont.cpp
+++ b/firmware/src/fonts/MediumWideFont.cpp
@@ -24,9 +24,10 @@ FontModule::Symbol MediumWideFont::getChar(char32_t character) const
         return toSymbol(latinCapitalLetterO);
     case 'o': // LATIN SMALL LETTER O
         return toSymbol(latinSmallLetterO);
+    default:
+        return {};
     }
     // NOLINTEND(bugprone-branch-clone)
-    return {};
 }
 
 #endif // FONT_MEDIUMWIDE

--- a/firmware/src/fonts/MicroFont.cpp
+++ b/firmware/src/fonts/MicroFont.cpp
@@ -11,50 +11,56 @@ FontModule::Symbol MicroFont::getChar(char32_t character) const
 {
     if (character == '(' || character == ')')
     {
+        // U+0028-U+0029
         return toSymbol(leftParenthesis_rightParenthesis[character - '(']);
     }
     if (character >= '/' && character <= '>')
     {
+        // U+002F-U+003E
         return toSymbol(solidus_greaterThanSign[character - '/']);
     }
     if (character >= 'A' && character <= 'Z')
     {
+        // U+0041-U+005A
         return toSymbol(latinLetterA_latinLetterZ[character - 'A']);
     }
     if (character >= 'X' && character <= ']')
     {
+        // U+0058-U+005D
         return toSymbol(leftSquareBracket_rightSquareBracket[character - 'X']);
     }
     if (character >= 'a' && character <= 'z')
     {
+        // U+0061-U+007A
         return toSymbol(latinLetterA_latinLetterZ[character - 'a']);
     }
     if (character >= '{' && character <= '}')
     {
+        // U+007B-U+007D
         return toSymbol(leftCurlyBracket_rightCurlyBracket[character - '{']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case ' ': // SPACE
+    case ' ': // U+0020 SPACE
         return whitespace(3U);
-    case '"': // QUOTATION MARK
+    case '"': // U+0022 QUOTATION MARK
         return toSymbol(quotationMark, 2);
-    case '\'': // APOSTROPHE
-    case '*':  // ASTERISK
-    case '`':  // GRAVE ACCENT
-    case U'°': // DEGREE SIGN
+    case '\'': // U+0027 APOSTROPHE
+    case '*':  // U+002A ASTERISK
+    case '`':  // U+0060 GRAVE ACCENT
+    case U'°': // U+00B0 DEGREE SIGN
         return toSymbol(apostrophe, 2);
-    case '+': // PLUS SIGN
+    case '+': // U+002B PLUS SIGN
         return toSymbol(plusSign);
-    case ',': // COMMA
-    case '.': // FULL STOP
+    case ',': // U+002C COMMA
+    case '.': // U+002E FULL STOP
         return toSymbol(apostrophe);
-    case '-': // HYPHEN-MINUS
+    case '-': // U+002D HYPHEN-MINUS
         return toSymbol(hyphenMinus, 1);
-    case '^': // CIRCUMFLEX ACCENT
+    case '^': // U+005E CIRCUMFLEX ACCENT
         return toSymbol(circumflexAccent, 1);
-    case '_': // LOW LINE
+    case '_': // U+005F LOW LINE
         return toSymbol(hyphenMinus);
     default:
         return {};

--- a/firmware/src/fonts/MicroFont.cpp
+++ b/firmware/src/fonts/MicroFont.cpp
@@ -2,55 +2,60 @@
 
 #include "fonts/MicroFont.h"
 
-FontModule::Symbol MicroFont::getChar(uint32_t character) const
+#include "config/constants.h" // NOLINT(misc-include-cleaner)
+
+static_assert(GRID_COLUMNS >= 3U, __STRING(FONT_MICRO) " is not compatible with this device's display size.");
+static_assert(GRID_ROWS >= 3U, __STRING(FONT_MICRO) " is not compatible with this device's display size.");
+
+FontModule::Symbol MicroFont::getChar(char32_t character) const
 {
-    if (character == 0x28 || character == 0x29)
+    if (character == '(' || character == ')')
     {
-        return toSymbol(chars28[character - 0x28]);
+        return toSymbol(leftParenthesis_rightParenthesis[character - '(']);
     }
-    if (character >= 0x2F && character <= 0x3E)
+    if (character >= '/' && character <= '>')
     {
-        return toSymbol(chars2F[character - 0x2F]);
+        return toSymbol(solidus_greaterThanSign[character - '/']);
     }
-    if (character >= 0x41 && character <= 0x5A)
+    if (character >= 'A' && character <= 'Z')
     {
-        return toSymbol(chars41[character - 0x41]);
+        return toSymbol(latinLetterA_latinLetterZ[character - 'A']);
     }
-    if (character >= 0x5B && character <= 0x5D)
+    if (character >= 'X' && character <= ']')
     {
-        return toSymbol(chars5B[character - 0x5B]);
+        return toSymbol(leftSquareBracket_rightSquareBracket[character - 'X']);
     }
-    if (character >= 0x61 && character <= 0x7A)
+    if (character >= 'a' && character <= 'z')
     {
-        return toSymbol(chars41[character - 0x61]);
+        return toSymbol(latinLetterA_latinLetterZ[character - 'a']);
     }
-    if (character >= 0x7B && character <= 0x7D)
+    if (character >= '{' && character <= '}')
     {
-        return toSymbol(chars7B[character - 0x7B]);
+        return toSymbol(leftCurlyBracket_rightCurlyBracket[character - '{']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case 0x20: // SPACE
-        return whitespace(3);
-    case 0x22: // "
-        return toSymbol(char22, 0, 2);
-    case 0x27: // '
-    case 0x2A: // *
-    case 0x60: // `
-    case 0xB0: // ° DEGREE SIGN
-        return toSymbol(char27, 0, 2);
-    case 0x2B: // +
-        return toSymbol(char2B);
-    case 0x2C: // ,
-    case 0x2E: // .
-        return toSymbol(char27);
-    case 0x2D: // -
-        return toSymbol(char2D, 0, 1);
-    case 0x5E: // ^
-        return toSymbol(char5E, 0, 1);
-    case 0x5F: // _
-        return toSymbol(char2D);
+    case ' ': // SPACE
+        return whitespace(3U);
+    case '"': // QUOTATION MARK
+        return toSymbol(quotationMark, 2);
+    case '\'': // APOSTROPHE
+    case '*':  // ASTERISK
+    case '`':  // GRAVE ACCENT
+    case U'°': // DEGREE SIGN
+        return toSymbol(apostrophe, 2);
+    case '+': // PLUS SIGN
+        return toSymbol(plusSign);
+    case ',': // COMMA
+    case '.': // FULL STOP
+        return toSymbol(apostrophe);
+    case '-': // HYPHEN-MINUS
+        return toSymbol(hyphenMinus, 1);
+    case '^': // CIRCUMFLEX ACCENT
+        return toSymbol(circumflexAccent, 1);
+    case '_': // LOW LINE
+        return toSymbol(hyphenMinus);
     }
     // NOLINTEND(bugprone-branch-clone)
     return {};

--- a/firmware/src/fonts/MicroFont.cpp
+++ b/firmware/src/fonts/MicroFont.cpp
@@ -56,9 +56,10 @@ FontModule::Symbol MicroFont::getChar(char32_t character) const
         return toSymbol(circumflexAccent, 1);
     case '_': // LOW LINE
         return toSymbol(hyphenMinus);
+    default:
+        return {};
     }
     // NOLINTEND(bugprone-branch-clone)
-    return {};
 }
 
 #endif // FONT_MICRO

--- a/firmware/src/fonts/MiniFont.cpp
+++ b/firmware/src/fonts/MiniFont.cpp
@@ -2,83 +2,88 @@
 
 #include "fonts/MiniFont.h"
 
-FontModule::Symbol MiniFont::getChar(uint32_t character) const
+#include "config/constants.h" // NOLINT(misc-include-cleaner)
+
+static_assert(GRID_COLUMNS >= 5U, __STRING(FONT_MINI) " is not compatible with this device's display size.");
+static_assert(GRID_ROWS >= 5U, __STRING(FONT_MINI) " is not compatible with this device's display size.");
+
+FontModule::Symbol MiniFont::getChar(char32_t character) const
 {
-    if (character >= 0x30 && character <= 0x39)
+    if (character >= '0' && character <= '9')
     {
-        return toSymbol(chars30[character - 0x30]);
+        return toSymbol(digitZero_digitNine[character - '0']);
     }
-    if (character >= 0x41 && character <= 0x5D)
+    if (character >= 'A' && character <= ']')
     {
-        return toSymbol(chars41[character - 0x41]);
+        return toSymbol(latinCapitalLetterA_rightSquareBracket[character - 'A']);
     }
-    if (character >= 0x65 && character <= 0x67)
+    if (character >= 'e' && character <= 'g')
     {
-        return toSymbol(chars65[character - 0x65]);
+        return toSymbol(latinSmallLetterE_latinSmallLetterG[character - 'e']);
     }
-    if (character == 0x68 || character == 0x69)
+    if (character == 'h' || character == 'i')
     {
-        return toSymbol(chars68[character - 0x68]);
+        return toSymbol(latinSmallLetterH_latinSmallLetterI[character - 'h']);
     }
-    if (character == 0x6B || character == 0x6C)
+    if (character == 'k' || character == 'l')
     {
-        return toSymbol(chars6B[character - 0x6B]);
+        return toSymbol(latinSmallLetterK_latinSmallLetterL[character - 'k']);
     }
-    if (character == 0x6D || character == 0x6E)
+    if (character == 'm' || character == 'n')
     {
-        return toSymbol(chars6D[character - 0x6D]);
+        return toSymbol(latinSmallLetterM_latinSmallLetterN[character - 'm']);
     }
-    if (character >= 0x6F && character <= 0x72)
+    if (character >= 'o' && character <= 'r')
     {
-        return toSymbol(chars6F[character - 0x6F]);
+        return toSymbol(latinSmallLetterO_latinSmallLetterR[character - 'o']);
     }
-    if (character >= 0x75 && character <= 0x78)
+    if (character >= 'u' && character <= 'x')
     {
-        return toSymbol(chars75[character - 0x75]);
+        return toSymbol(latinSmallLetterU_latinSmallLetterX[character - 'u']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case 0x20: // SPACE
-        return whitespace(3);
-    case 0x2B: // +
-        return toSymbol(char2B, 0, 1);
-    case 0x2C: // ,
-        return toSymbol(char2C);
-    case 0x2D: // -
-        return toSymbol(char2D, 0, 2);
-    case 0x2E: // .
-        return toSymbol(char2E);
-    case 0x3A: // :
-        return toSymbol(char3A, 0, 1);
-    case 0x3D: // =
-        return toSymbol(char3D, 0, 1);
-    case 0x5F: // _
-        return toSymbol(char2D);
-    case 0x61: // a
-        return toSymbol(char61);
-    case 0x62: // b
-        return toSymbol(char62);
-    case 0x63: // c
-        return toSymbol(char63);
-    case 0x64: // d
-        return toSymbol(char64);
-    case 0x6A: // j
-        return toSymbol(char6A);
-    case 0x73: // s
-        return toSymbol(char73);
-    case 0x74: // t
-        return toSymbol(char74);
-    case 0x79: // y
-        return toSymbol(char79);
-    case 0x7A: // z
-        return toSymbol(char7A);
-    case 0x7C: // |
-        return toSymbol(char7C);
-    case 0xB0: // ° DEGREE SIGN
-        return toSymbol(charB0, 0, 3);
-    case 0x3C0: // π GREEK SMALL LETTER PI
-        return toSymbol(char3C0);
+    case ' ': // SPACE
+        return whitespace(3U);
+    case '+': // PLUS SIGN
+        return toSymbol(plusSign, 1);
+    case ',': // COMMA
+        return toSymbol(comma);
+    case '-': // HYPHEN-MINUS
+        return toSymbol(hyphenMinus, 2);
+    case '.': // FULL STOP
+        return toSymbol(fullStop);
+    case ':': // COLON
+        return toSymbol(colon, 1);
+    case '=': // EQUALS SIGN
+        return toSymbol(equalsSign, 1);
+    case '_': // LOW LINE
+        return toSymbol(hyphenMinus);
+    case 'a': // LATIN SMALL LETTER A
+        return toSymbol(latinSmallLetterA);
+    case 'b': // LATIN SMALL LETTER B
+        return toSymbol(latinSmallLetterB);
+    case 'c': // LATIN SMALL LETTER C
+        return toSymbol(latinSmallLetterC);
+    case 'd': // LATIN SMALL LETTER D
+        return toSymbol(latinSmallLetterD);
+    case 'j': // LATIN SMALL LETTER J
+        return toSymbol(latinSmallLetterJ);
+    case 's': // LATIN SMALL LETTER S
+        return toSymbol(latinSmallLetterS);
+    case 't': // LATIN SMALL LETTER T
+        return toSymbol(latinSmallLetterT);
+    case 'y': // LATIN SMALL LETTER Y
+        return toSymbol(latinSmallLetterY);
+    case 'z': // LATIN SMALL LETTER Z
+        return toSymbol(latinSmallLetterZ);
+    case '|': // VERTICAL LINE
+        return toSymbol(verticalLine);
+    case U'°': // DEGREE SIGN
+        return toSymbol(degreeSign, 3);
+    case U'π': // GREEK SMALL LETTER PI
+        return toSymbol(greekSmallLetterPi);
     }
     // NOLINTEND(bugprone-branch-clone)
     return {};

--- a/firmware/src/fonts/MiniFont.cpp
+++ b/firmware/src/fonts/MiniFont.cpp
@@ -11,78 +11,86 @@ FontModule::Symbol MiniFont::getChar(char32_t character) const
 {
     if (character >= '0' && character <= '9')
     {
+        // U+0030-U+0039
         return toSymbol(digitZero_digitNine[character - '0']);
     }
     if (character >= 'A' && character <= ']')
     {
+        // U+0041-U+005D
         return toSymbol(latinCapitalLetterA_rightSquareBracket[character - 'A']);
     }
     if (character >= 'e' && character <= 'g')
     {
+        // U+0065-U+0067
         return toSymbol(latinSmallLetterE_latinSmallLetterG[character - 'e']);
     }
     if (character == 'h' || character == 'i')
     {
+        // U+0068-U+0069
         return toSymbol(latinSmallLetterH_latinSmallLetterI[character - 'h']);
     }
     if (character == 'k' || character == 'l')
     {
+        // U+006B-U+006C
         return toSymbol(latinSmallLetterK_latinSmallLetterL[character - 'k']);
     }
     if (character == 'm' || character == 'n')
     {
+        // U+006D-U+006E
         return toSymbol(latinSmallLetterM_latinSmallLetterN[character - 'm']);
     }
     if (character >= 'o' && character <= 'r')
     {
+        // U+006F-U+0072
         return toSymbol(latinSmallLetterO_latinSmallLetterR[character - 'o']);
     }
     if (character >= 'u' && character <= 'x')
     {
+        // U+0075-U+0078
         return toSymbol(latinSmallLetterU_latinSmallLetterX[character - 'u']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case ' ': // SPACE
+    case ' ': // U+0020 SPACE
         return whitespace(3U);
-    case '+': // PLUS SIGN
+    case '+': // U+002B PLUS SIGN
         return toSymbol(plusSign, 1);
-    case ',': // COMMA
+    case ',': // U+002C COMMA
         return toSymbol(comma);
-    case '-': // HYPHEN-MINUS
+    case '-': // U+002D HYPHEN-MINUS
         return toSymbol(hyphenMinus, 2);
-    case '.': // FULL STOP
+    case '.': // U+002E FULL STOP
         return toSymbol(fullStop);
-    case ':': // COLON
+    case ':': // U+003A COLON
         return toSymbol(colon, 1);
-    case '=': // EQUALS SIGN
+    case '=': // U+003D EQUALS SIGN
         return toSymbol(equalsSign, 1);
-    case '_': // LOW LINE
+    case '_': // U+005F LOW LINE
         return toSymbol(hyphenMinus);
-    case 'a': // LATIN SMALL LETTER A
+    case 'a': // U+0061 LATIN SMALL LETTER A
         return toSymbol(latinSmallLetterA);
-    case 'b': // LATIN SMALL LETTER B
+    case 'b': // U+0062 LATIN SMALL LETTER B
         return toSymbol(latinSmallLetterB);
-    case 'c': // LATIN SMALL LETTER C
+    case 'c': // U+0063 LATIN SMALL LETTER C
         return toSymbol(latinSmallLetterC);
-    case 'd': // LATIN SMALL LETTER D
+    case 'd': // U+0064 LATIN SMALL LETTER D
         return toSymbol(latinSmallLetterD);
-    case 'j': // LATIN SMALL LETTER J
+    case 'j': // U+006A LATIN SMALL LETTER J
         return toSymbol(latinSmallLetterJ);
-    case 's': // LATIN SMALL LETTER S
+    case 's': // U+0073 LATIN SMALL LETTER S
         return toSymbol(latinSmallLetterS);
-    case 't': // LATIN SMALL LETTER T
+    case 't': // U+0074 LATIN SMALL LETTER T
         return toSymbol(latinSmallLetterT);
-    case 'y': // LATIN SMALL LETTER Y
+    case 'y': // U+0079 LATIN SMALL LETTER Y
         return toSymbol(latinSmallLetterY);
-    case 'z': // LATIN SMALL LETTER Z
+    case 'z': // U+007A LATIN SMALL LETTER Z
         return toSymbol(latinSmallLetterZ);
-    case '|': // VERTICAL LINE
+    case '|': // U+007C VERTICAL LINE
         return toSymbol(verticalLine);
-    case U'°': // DEGREE SIGN
+    case U'°': // U+00B0 DEGREE SIGN
         return toSymbol(degreeSign, 3);
-    case U'π': // GREEK SMALL LETTER PI
+    case U'π': // U+03C0 GREEK SMALL LETTER PI
         return toSymbol(greekSmallLetterPi);
     default:
         return {};

--- a/firmware/src/fonts/MiniFont.cpp
+++ b/firmware/src/fonts/MiniFont.cpp
@@ -84,9 +84,10 @@ FontModule::Symbol MiniFont::getChar(char32_t character) const
         return toSymbol(degreeSign, 3);
     case U'π': // GREEK SMALL LETTER PI
         return toSymbol(greekSmallLetterPi);
+    default:
+        return {};
     }
     // NOLINTEND(bugprone-branch-clone)
-    return {};
 }
 
 #endif // FONT_MINI

--- a/firmware/src/fonts/SmallFont.cpp
+++ b/firmware/src/fonts/SmallFont.cpp
@@ -11,120 +11,128 @@ FontModule::Symbol SmallFont::getChar(char32_t character) const
 {
     if (character >= '#' && character <= '&')
     {
+        // U+0023-U+0026
         return toSymbol(numberSign_ampersand[character - '#']);
     }
     if (character == '(' || character == ')')
     {
+        // U+0028-U+0029
         return toSymbol(leftParenthesis_rightParenthesis[character - '(']);
     }
     if (character >= '0' && character <= '9')
     {
+        // U+0030-U+0039
         return toSymbol(digitZero_digitNine[character - '0']);
     }
     if (character >= '>' && character <= 'X')
     {
+        // U+003E-U+0058
         return toSymbol(greaterThanSign_leftSquareBracket[character - '>']);
     }
     if (character >= 'h' && character <= 'l')
     {
+        // U+0068-U+006C
         return toSymbol(latinSmallLetterH_latinSmallLetterL[character - 'h']);
     }
     if (character >= 'm' && character <= 's')
     {
+        // U+006D-U+0073
         return toSymbol(latinSmallLetterM_latinSmallLetterS[character - 'm']);
     }
     if (character >= 'u' && character <= 'z')
     {
+        // U+0075-U+007A
         return toSymbol(latinSmallLetterU_latinSmallLetterZ[character - 'u']);
     }
     if (character >= '{' && character <= '}')
     {
+        // U+007B-U+007D
         return toSymbol(leftCurlyBracket_rightCurlyBracket[character - '{']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case ' ': // SPACE
+    case ' ': // U+0020 SPACE
         return whitespace(3);
-    case '!': // EXCLAMATION MARK
+    case '!': // U+0021 EXCLAMATION MARK
         return toSymbol(exclamationMark);
-    case '"': // QUOTATION MARK
+    case '"': // U+0022 QUOTATION MARK
         return toSymbol(quotationMark, 3);
-    case '\'': // APOSTROPHE
+    case '\'': // U+0027 APOSTROPHE
         return toSymbol(apostrophe, 3);
-    case '*': // ASTERISK
+    case '*': // U+002A ASTERISK
         return toSymbol(asterisk, 4);
-    case '+': // PLUS SIGN
+    case '+': // U+002B PLUS SIGN
         return toSymbol(plusSign, 1);
-    case ',': // COMMA
+    case ',': // U+002C COMMA
         return toSymbol(comma);
-    case '-': // HYPHEN-MINUS
+    case '-': // U+002D HYPHEN-MINUS
         return toSymbol(hyphenMinus, 2);
-    case '.': // FULL STOP
+    case '.': // U+002E FULL STOP
         return toSymbol(fullStop);
-    case '/': // SOLIDUS
+    case '/': // U+002F SOLIDUS
         return toSymbol(solidus);
-    case ':': // COLON
+    case ':': // U+003A COLON
         return toSymbol(colon);
-    case ';': // SEMICOLON
+    case ';': // U+003B SEMICOLON
         return toSymbol(semicolon);
-    case '<': // LESS-THAN SIGN
+    case '<': // U+003C LESS-THAN SIGN
         return toSymbol(lessThanSign);
-    case '=': // EQUALS SIGN
+    case '=': // U+003D EQUALS SIGN
         return toSymbol(equalsSign, 1);
-    case '\\': // REVERSE SOLIDUS
+    case '\\': // U+005C REVERSE SOLIDUS
         return toSymbol(reverseSolidus);
-    case ']': // RIGHT SQUARE BRACKET
+    case ']': // U+005D RIGHT SQUARE BRACKET
         return toSymbol(rightSquareBracket);
-    case '^': // CIRCUMFLEX ACCENT
+    case '^': // U+005E CIRCUMFLEX ACCENT
         return toSymbol(circumflexAccent, 3);
-    case '_': // LOW LINE
+    case '_': // U+005F LOW LINE
         return toSymbol(hyphenMinus);
-    case '`': // GRAVE ACCENT
+    case '`': // U+0060 GRAVE ACCENT
         return toSymbol(graveAccent, 3);
-    case 'a': // LATIN SMALL LETTER A
+    case 'a': // U+0061 LATIN SMALL LETTER A
         return toSymbol(latinSmallLetterA);
-    case 'b': // LATIN SMALL LETTER B
+    case 'b': // U+0062 LATIN SMALL LETTER B
         return toSymbol(latinSmallLetterB);
-    case 'c': // LATIN SMALL LETTER C
+    case 'c': // U+0063 LATIN SMALL LETTER C
         return toSymbol(latinSmallLetterC);
-    case 'd': // LATIN SMALL LETTER D
+    case 'd': // U+0064 LATIN SMALL LETTER D
         return toSymbol(latinSmallLetterD);
-    case 'e': // LATIN SMALL LETTER E
+    case 'e': // U+0065 LATIN SMALL LETTER E
         return toSymbol(latinSmallLetterE);
-    case 'f': // LATIN SMALL LETTER F
+    case 'f': // U+0066 LATIN SMALL LETTER F
         return toSymbol(latinSmallLetterF);
-    case 'g': // LATIN SMALL LETTER G
+    case 'g': // U+0067 LATIN SMALL LETTER G
         return toSymbol(latinSmallLetterG);
-    case 't': // LATIN SMALL LETTER T
+    case 't': // U+0074 LATIN SMALL LETTER T
         return toSymbol(latinSmallLetterT);
-    case U'°': // DEGREE SIGN
+    case U'°': // U+00B0 DEGREE SIGN
         return toSymbol(degreeSign, 4);
-    case U'Ä': // LATIN CAPITAL LETTER A WITH DIAERESIS
+    case U'Ä': // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
         return toSymbol(latinCapitalLetterAWithDiaeresis);
-    case U'Å': // LATIN CAPITAL LETTER A WITH RING ABOVE
+    case U'Å': // U+00C5 LATIN CAPITAL LETTER A WITH RING ABOVE
         return toSymbol(latinCapitalLetterAWithRingAbove);
-    case U'Æ': // LATIN CAPITAL LETTER AE
+    case U'Æ': // U+00C6 LATIN CAPITAL LETTER AE
         return toSymbol(latinCapitalLetterAe);
-    case U'Ö': // LATIN CAPITAL LETTER O WITH DIAERESIS
+    case U'Ö': // U+00D6 LATIN CAPITAL LETTER O WITH DIAERESIS
         return toSymbol(latinCapitalLetterOWithDiaeresis);
-    case U'Ø': // LATIN CAPITAL LETTER O WITH STROKE
+    case U'Ø': // U+00D8 LATIN CAPITAL LETTER O WITH STROKE
         return toSymbol(latinCapitalLetterOWithStroke);
-    case U'ß': // LATIN SMALL LETTER SHARP S
+    case U'ß': // U+00DF LATIN SMALL LETTER SHARP S
         return toSymbol(latinSmallLetterSharpS);
-    case U'ä': // LATIN SMALL LETTER A WITH DIAERESIS
+    case U'ä': // U+00E4 LATIN SMALL LETTER A WITH DIAERESIS
         return toSymbol(latinSmallLetterAWithDiaeresis);
-    case U'å': // LATIN SMALL LETTER A WITH RING ABOVE
+    case U'å': // U+00E5 LATIN SMALL LETTER A WITH RING ABOVE
         return toSymbol(latinSmallLetterAWithRingAbove);
-    case U'æ': // LATIN SMALL LETTER AE
+    case U'æ': // U+00E6 LATIN SMALL LETTER AE
         return toSymbol(latinSmallLetterAe);
-    case U'ö': // LATIN SMALL LETTER O WITH DIAERESIS
+    case U'ö': // U+00F6 LATIN SMALL LETTER O WITH DIAERESIS
         return toSymbol(latinSmallLetterOWithDiaeresis);
-    case U'ø': // LATIN SMALL LETTER O WITH STROKE
+    case U'ø': // U+00F8 LATIN SMALL LETTER O WITH STROKE
         return toSymbol(latinSmallLetterOWithStroke);
-    case U'ü': // LATIN SMALL LETTER U WITH DIAERESIS
+    case U'ü': // U+00FC LATIN SMALL LETTER U WITH DIAERESIS
         return toSymbol(latinSmallLetterUWithDiaeresis);
-    case U'π': // GREEK SMALL LETTER PI
+    case U'π': // U+03C0 GREEK SMALL LETTER PI
         return toSymbol(greekSmallLetterPi);
     default:
         return {};

--- a/firmware/src/fonts/SmallFont.cpp
+++ b/firmware/src/fonts/SmallFont.cpp
@@ -2,125 +2,130 @@
 
 #include "fonts/SmallFont.h"
 
-FontModule::Symbol SmallFont::getChar(uint32_t character) const
+#include "config/constants.h" // NOLINT(misc-include-cleaner)
+
+static_assert(GRID_COLUMNS >= 7U, __STRING(FONT_SMALL) " is not compatible with this device's display size.");
+static_assert(GRID_ROWS >= 7U, __STRING(FONT_SMALL) " is not compatible with this device's display size.");
+
+FontModule::Symbol SmallFont::getChar(char32_t character) const
 {
-    if (character >= 0x23 && character <= 0x26)
+    if (character >= '#' && character <= '&')
     {
-        return toSymbol(chars23[character - 0x23]);
+        return toSymbol(numberSign_ampersand[character - '#']);
     }
-    if (character == 0x28 || character == 0x29)
+    if (character == '(' || character == ')')
     {
-        return toSymbol(chars28[character - 0x28]);
+        return toSymbol(leftParenthesis_rightParenthesis[character - '(']);
     }
-    if (character >= 0x30 && character <= 0x39)
+    if (character >= '0' && character <= '9')
     {
-        return toSymbol(chars30[character - 0x30]);
+        return toSymbol(digitZero_digitNine[character - '0']);
     }
-    if (character >= 0x3E && character <= 0x5B)
+    if (character >= '>' && character <= 'X')
     {
-        return toSymbol(chars3E[character - 0x3E]);
+        return toSymbol(greaterThanSign_leftSquareBracket[character - '>']);
     }
-    if (character >= 0x68 && character <= 0x6C)
+    if (character >= 'h' && character <= 'l')
     {
-        return toSymbol(chars68[character - 0x68]);
+        return toSymbol(latinSmallLetterH_latinSmallLetterL[character - 'h']);
     }
-    if (character >= 0x6D && character <= 0x73)
+    if (character >= 'm' && character <= 's')
     {
-        return toSymbol(chars6D[character - 0x6D]);
+        return toSymbol(latinSmallLetterM_latinSmallLetterS[character - 'm']);
     }
-    if (character >= 0x75 && character <= 0x7A)
+    if (character >= 'u' && character <= 'z')
     {
-        return toSymbol(chars75[character - 0x75]);
+        return toSymbol(latinSmallLetterU_latinSmallLetterZ[character - 'u']);
     }
-    if (character >= 0x7B && character <= 0x7D)
+    if (character >= '{' && character <= '}')
     {
-        return toSymbol(chars7B[character - 0x7B]);
+        return toSymbol(leftCurlyBracket_rightCurlyBracket[character - '{']);
     }
     // NOLINTBEGIN(bugprone-branch-clone)
     switch (character)
     {
-    case 0x20: // SPACE
+    case ' ': // SPACE
         return whitespace(3);
-    case 0x21: // !
-        return toSymbol(char21);
-    case 0x22: // "
-        return toSymbol(char22, 0, 3);
-    case 0x27: // '
-        return toSymbol(char27, 0, 3);
-    case 0x2A: // *
-        return toSymbol(char2A, 0, 4);
-    case 0x2B: // +
-        return toSymbol(char2B, 0, 1);
-    case 0x2C: // ,
-        return toSymbol(char2C);
-    case 0x2D: // -
-        return toSymbol(char2D, 0, 2);
-    case 0x2E: // .
-        return toSymbol(char2E);
-    case 0x2F: // /
-        return toSymbol(char2F);
-    case 0x3A: // :
-        return toSymbol(char3A);
-    case 0x3B: // ;
-        return toSymbol(char3B);
-    case 0x3C: // <
-        return toSymbol(char3C);
-    case 0x3D: // =
-        return toSymbol(char3D, 0, 1);
-    case 0x5C: // REVERSE SOLIDUS
-        return toSymbol(char5C);
-    case 0x5D: // ]
-        return toSymbol(char5D);
-    case 0x5E: // ^
-        return toSymbol(char5E, 0, 3);
-    case 0x5F: // _
-        return toSymbol(char2D);
-    case 0x60: // `
-        return toSymbol(char60, 0, 3);
-    case 0x61: // a
-        return toSymbol(char61);
-    case 0x62: // b
-        return toSymbol(char62);
-    case 0x63: // c
-        return toSymbol(char63);
-    case 0x64: // d
-        return toSymbol(char64);
-    case 0x65: // e
-        return toSymbol(char65);
-    case 0x66: // f
-        return toSymbol(char66);
-    case 0x67: // g
-        return toSymbol(char67);
-    case 0x74: // t
-        return toSymbol(char74);
-    case 0xB0: // ° DEGREE SIGN
-        return toSymbol(charB0, 0, 4);
-    case 0xC4: // Ä LATIN CAPITAL LETTER A WITH DIAERESIS
-        return toSymbol(charC4);
-    case 0xC5: // Å LATIN CAPITAL LETTER A WITH RING ABOVE
-        return toSymbol(charC5);
-    case 0xC6: // Æ LATIN CAPITAL LETTER AE
-        return toSymbol(charC6);
-    case 0xD7: // Ö LATIN CAPITAL LETTER O WITH DIAERESIS
-        return toSymbol(charD6);
-    case 0xD8: // Ø LATIN CAPITAL LETTER O WITH STROKE
-        return toSymbol(charD8);
-    case 0xDF: // ß LATIN SMALL LETTER SHARP S
-        return toSymbol(charDF);
-    case 0xE4: // ä LATIN SMALL LETTER A WITH DIAERESIS
-        return toSymbol(charE4);
-    case 0xE5: // å LATIN SMALL LETTER A WITH RING ABOVE
-        return toSymbol(charE5);
-    case 0xE6: // æ LATIN SMALL LETTER AE
-        return toSymbol(charE6);
-    case 0xF6: // ö LATIN SMALL LETTER O WITH DIAERESIS
-        return toSymbol(charF6);
-    case 0xF8: // ø LATIN SMALL LETTER O WITH STROKE
-        return toSymbol(charF8);
-    case 0xFC: // ü LATIN SMALL LETTER U WITH DIAERESIS
-        return toSymbol(charFC);
-    case 0x3C0: // π GREEK SMALL LETTER PI
-        return toSymbol(char3C0);
+    case '!': // EXCLAMATION MARK
+        return toSymbol(exclamationMark);
+    case '"': // QUOTATION MARK
+        return toSymbol(quotationMark, 3);
+    case '\'': // APOSTROPHE
+        return toSymbol(apostrophe, 3);
+    case '*': // ASTERISK
+        return toSymbol(asterisk, 4);
+    case '+': // PLUS SIGN
+        return toSymbol(plusSign, 1);
+    case ',': // COMMA
+        return toSymbol(comma);
+    case '-': // HYPHEN-MINUS
+        return toSymbol(hyphenMinus, 2);
+    case '.': // FULL STOP
+        return toSymbol(fullStop);
+    case '/': // SOLIDUS
+        return toSymbol(solidus);
+    case ':': // COLON
+        return toSymbol(colon);
+    case ';': // SEMICOLON
+        return toSymbol(semicolon);
+    case '<': // LESS-THAN SIGN
+        return toSymbol(lessThanSign);
+    case '=': // EQUALS SIGN
+        return toSymbol(equalsSign, 1);
+    case '\\': // REVERSE SOLIDUS
+        return toSymbol(reverseSolidus);
+    case ']': // RIGHT SQUARE BRACKET
+        return toSymbol(rightSquareBracket);
+    case '^': // CIRCUMFLEX ACCENT
+        return toSymbol(circumflexAccent, 3);
+    case '_': // LOW LINE
+        return toSymbol(hyphenMinus);
+    case '`': // GRAVE ACCENT
+        return toSymbol(graveAccent, 3);
+    case 'a': // LATIN SMALL LETTER A
+        return toSymbol(latinSmallLetterA);
+    case 'b': // LATIN SMALL LETTER B
+        return toSymbol(latinSmallLetterB);
+    case 'c': // LATIN SMALL LETTER C
+        return toSymbol(latinSmallLetterC);
+    case 'd': // LATIN SMALL LETTER D
+        return toSymbol(latinSmallLetterD);
+    case 'e': // LATIN SMALL LETTER E
+        return toSymbol(latinSmallLetterE);
+    case 'f': // LATIN SMALL LETTER F
+        return toSymbol(latinSmallLetterF);
+    case 'g': // LATIN SMALL LETTER G
+        return toSymbol(latinSmallLetterG);
+    case 't': // LATIN SMALL LETTER T
+        return toSymbol(latinSmallLetterT);
+    case U'°': // DEGREE SIGN
+        return toSymbol(degreeSign, 4);
+    case U'Ä': // LATIN CAPITAL LETTER A WITH DIAERESIS
+        return toSymbol(latinCapitalLetterAWithDiaeresis);
+    case U'Å': // LATIN CAPITAL LETTER A WITH RING ABOVE
+        return toSymbol(latinCapitalLetterAWithRingAbove);
+    case U'Æ': // LATIN CAPITAL LETTER AE
+        return toSymbol(latinCapitalLetterAe);
+    case U'Ö': // LATIN CAPITAL LETTER O WITH DIAERESIS
+        return toSymbol(latinCapitalLetterOWithDiaeresis);
+    case U'Ø': // LATIN CAPITAL LETTER O WITH STROKE
+        return toSymbol(latinCapitalLetterOWithStroke);
+    case U'ß': // LATIN SMALL LETTER SHARP S
+        return toSymbol(latinSmallLetterSharpS);
+    case U'ä': // LATIN SMALL LETTER A WITH DIAERESIS
+        return toSymbol(latinSmallLetterAWithDiaeresis);
+    case U'å': // LATIN SMALL LETTER A WITH RING ABOVE
+        return toSymbol(latinSmallLetterAWithRingAbove);
+    case U'æ': // LATIN SMALL LETTER AE
+        return toSymbol(latinSmallLetterAe);
+    case U'ö': // LATIN SMALL LETTER O WITH DIAERESIS
+        return toSymbol(latinSmallLetterOWithDiaeresis);
+    case U'ø': // LATIN SMALL LETTER O WITH STROKE
+        return toSymbol(latinSmallLetterOWithStroke);
+    case U'ü': // LATIN SMALL LETTER U WITH DIAERESIS
+        return toSymbol(latinSmallLetterUWithDiaeresis);
+    case U'π': // GREEK SMALL LETTER PI
+        return toSymbol(greekSmallLetterPi);
     }
     // NOLINTEND(bugprone-branch-clone)
     return {};

--- a/firmware/src/fonts/SmallFont.cpp
+++ b/firmware/src/fonts/SmallFont.cpp
@@ -126,9 +126,10 @@ FontModule::Symbol SmallFont::getChar(char32_t character) const
         return toSymbol(latinSmallLetterUWithDiaeresis);
     case U'π': // GREEK SMALL LETTER PI
         return toSymbol(greekSmallLetterPi);
+    default:
+        return {};
     }
     // NOLINTEND(bugprone-branch-clone)
-    return {};
 }
 
 #endif // FONT_SMALL

--- a/firmware/src/handlers/TextHandler.cpp
+++ b/firmware/src/handlers/TextHandler.cpp
@@ -8,10 +8,11 @@ TextHandler::TextHandler(std::string text, const FontModule &font) : text(text),
     if (text.length())
     {
         {
-            size_t index{0U}; // NOLINT(misc-const-correctness)
-            int8_t yMax{0};   // NOLINT(misc-const-correctness)
+            char32_t codepoint{0U};
+            int8_t yMax{0};
             int8_t yMin{0};
-            for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);) // NOLINT(misc-const-correctness)
+            size_t index{0U};
+            while (nextCodepoint(index, codepoint))
             {
                 const FontModule::Symbol character{font.getChar(codepoint)};
                 std::visit(
@@ -30,8 +31,9 @@ TextHandler::TextHandler(std::string text, const FontModule &font) : text(text),
         tracking = static_cast<uint8_t>(ceilf(height / Display.getRatio() / 10.0F));
         {
             width = 0U;
-            size_t index{0U};                                              // NOLINT(misc-const-correctness)
-            for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);) // NOLINT(misc-const-correctness)
+            char32_t codepoint{0U};
+            size_t index{0U};
+            while (nextCodepoint(index, codepoint))
             {
                 const FontModule::Symbol character{font.getChar(codepoint)};
                 std::visit(
@@ -67,8 +69,9 @@ void TextHandler::draw(uint8_t brightness) const
 
 void TextHandler::draw(int16_t x, int8_t y, uint8_t brightness) const
 {
-    size_t index{0U};                                              // NOLINT(misc-const-correctness)
-    for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);) // NOLINT(misc-const-correctness)
+    char32_t codepoint{0U};
+    size_t index{0U};
+    while (nextCodepoint(index, codepoint))
     {
         const FontModule::Symbol character{font->getChar(codepoint)};
         std::visit(
@@ -116,45 +119,63 @@ bool TextHandler::nextCodepoint(size_t &index, char32_t &buffer) const
     {
         return false;
     }
-    const uint8_t byte{static_cast<uint8_t>(text[index])}; // NOLINT(cppcoreguidelines-init-variables)
-    index++;
-    if (byte < (0b1U << 7U))
+    const uint8_t first{static_cast<uint8_t>(text[index])};
+    ++index;
+    if (first < 0x80U)
     {
-        buffer = byte;
+        buffer = first;
         return true;
     }
-    uint8_t bytes{0U};
-    if ((byte & (0b111U << 5U)) == 0b11U << 6U)
+    char32_t codepoint{};
+    char32_t minimum{};
+    uint8_t remaining{};
+    if ((first & 0xE0U) == 0xC0U)
     {
-        buffer = byte & 0b1'1111U;
-        bytes = 1U;
+        codepoint = first & 0x1FU;
+        minimum = 0x80U;
+        remaining = 1U;
     }
-    else if ((byte & (0b1111U << 4U)) == 0b111U << 5U)
+    else if ((first & 0xF0U) == 0xE0U)
     {
-        buffer = byte & 0b1111U;
-        bytes = 2U;
+        codepoint = first & 0x0FU;
+        minimum = 0x800U;
+        remaining = 2U;
     }
-    else if ((byte & (0b1'1111U << 3U)) == 0b1111U << 4U)
+    else if ((first & 0xF8U) == 0xF0U)
     {
-        buffer = byte & 0b111U;
-        bytes = 3U;
+        codepoint = first & 0x07U;
+        minimum = 0x10000U;
+        remaining = 3U;
     }
     else
     {
-        buffer = 0b1111'1111'1111'1101U;
+        buffer = U'\uFFFD';
         return true;
     }
-    while (bytes-- && index < text.length())
+    if (index + remaining > text.length())
     {
-        const uint8_t _byte{static_cast<uint8_t>(text[index])}; // NOLINT(cppcoreguidelines-init-variables)
-        index++;
-        if ((_byte & (0b11U << 6U)) != 0b1U << 7U)
-        {
-            buffer = 0b1111'1111'1111'1101U;
-            break;
-        }
-        buffer = (buffer << 6U) | (_byte & 0b11'1111U);
+        index = text.length();
+        buffer = U'\uFFFD';
+        return true;
     }
+    while (remaining > 0U)
+    {
+        const uint8_t next{static_cast<uint8_t>(text[index])};
+        if ((next & 0xC0U) != 0x80U)
+        {
+            buffer = U'\uFFFD';
+            return true;
+        }
+        ++index;
+        codepoint = (codepoint << 6U) | (next & 0x3FU);
+        --remaining;
+    }
+    if (codepoint < minimum || codepoint > 0x10FFFFU || (codepoint >= 0xD800U && codepoint <= 0xDFFFU))
+    {
+        buffer = U'\uFFFD';
+        return true;
+    }
+    buffer = codepoint;
     return true;
 }
 
@@ -176,27 +197,30 @@ uint8_t TextHandler::calcMsbMax(std::span<const T> bitmap) const
 std::array<char, 5U> TextHandler::encode(char32_t codepoint)
 {
     std::array<char, 5U> out{};
-    if (codepoint < (0b1U << 7U))
+    if (codepoint < 0x110000U && (codepoint < 0xD800U || codepoint > 0xDFFFU))
     {
-        out.at(0U) = static_cast<char>(codepoint);
-    }
-    else if (codepoint < (0b1U << 11U))
-    {
-        out.at(0U) = static_cast<char>((0b11U << 6U) | (codepoint >> (0b11U << 1U)));
-        out.at(1U) = static_cast<char>((0b1U << 7U) | (codepoint & 0b11'1111U));
-    }
-    else if (codepoint < (0b1U << 16U))
-    {
-        out.at(0U) = static_cast<char>((0b111U << 5U) | (codepoint >> (0b11U << 2U)));
-        out.at(1U) = static_cast<char>((0b1U << 7U) | ((codepoint >> (0b11U << 1U)) & 0b11'1111U));
-        out.at(2U) = static_cast<char>((0b1U << 7U) | (codepoint & 0b11'1111U));
-    }
-    else if (codepoint < (0b10001U << 16U))
-    {
-        out.at(0U) = static_cast<char>((0b1U << 7U) | (codepoint >> (0b1'001U << 1U)));
-        out.at(1U) = static_cast<char>((0b1U << 7U) | ((codepoint >> (0b11U << 2U)) & 0b11'1111U));
-        out.at(2U) = static_cast<char>((0b1U << 7U) | ((codepoint >> (0b11U << 1U)) & 0b11'1111U));
-        out.at(3U) = static_cast<char>((0b1U << 7U) | (codepoint & 0b11'1111U));
+        if (codepoint < 0x80U)
+        {
+            out[0U] = static_cast<char>(codepoint);
+        }
+        else if (codepoint < 0x800U)
+        {
+            out[0U] = static_cast<char>(0xC0U | (codepoint >> 6U));
+            out[1U] = static_cast<char>(0x80U | (codepoint & 0x3FU));
+        }
+        else if (codepoint < 0x10000U)
+        {
+            out[0U] = static_cast<char>(0xE0U | (codepoint >> 12U));
+            out[1U] = static_cast<char>(0x80U | ((codepoint >> 6U) & 0x3FU));
+            out[2U] = static_cast<char>(0x80U | (codepoint & 0x3FU));
+        }
+        else
+        {
+            out[0U] = static_cast<char>(0xF0U | (codepoint >> 18U));
+            out[1U] = static_cast<char>(0x80U | ((codepoint >> 12U) & 0x3FU));
+            out[2U] = static_cast<char>(0x80U | ((codepoint >> 6U) & 0x3FU));
+            out[3U] = static_cast<char>(0x80U | (codepoint & 0x3FU));
+        }
     }
     return out;
 }

--- a/firmware/src/handlers/TextHandler.cpp
+++ b/firmware/src/handlers/TextHandler.cpp
@@ -8,10 +8,10 @@ TextHandler::TextHandler(std::string text, const FontModule &font) : text(text),
     if (text.length())
     {
         {
-            size_t index = 0; // NOLINT(misc-const-correctness)
-            int8_t yMax = 0;  // NOLINT(misc-const-correctness)
-            int8_t yMin = 0;
-            for (uint32_t codepoint = 0; nextCodepoint(index, codepoint);)
+            size_t index{0U}; // NOLINT(misc-const-correctness)
+            int8_t yMax{0};   // NOLINT(misc-const-correctness)
+            int8_t yMin{0};
+            for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);)
             {
                 FontModule::Symbol character{font.getChar(codepoint)};
                 std::visit(
@@ -29,9 +29,9 @@ TextHandler::TextHandler(std::string text, const FontModule &font) : text(text),
         }
         tracking = static_cast<uint8_t>(ceilf(height / Display.getRatio() / 10.0F));
         {
-            width = 0;
-            size_t index = 0; // NOLINT(misc-const-correctness)
-            for (uint32_t codepoint = 0; nextCodepoint(index, codepoint);)
+            width = 0U;
+            size_t index{0U}; // NOLINT(misc-const-correctness)
+            for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);)
             {
                 FontModule::Symbol character{font.getChar(codepoint)};
                 std::visit(
@@ -39,9 +39,9 @@ TextHandler::TextHandler(std::string text, const FontModule &font) : text(text),
                     {
                         if (!bitmap.empty())
                         {
-                            width += calcMsbMax(bitmap) + 1 + character.offsetX + tracking;
+                            width += calcMsbMax(bitmap) + 1U + character.offsetX + tracking;
                         }
-                        else if (character.offsetX > 0)
+                        else if (character.offsetX != 0U)
                         {
                             width += character.offsetX + tracking;
                         }
@@ -62,30 +62,30 @@ TextHandler::TextHandler(std::string text, const FontModule &font) : text(text),
 
 void TextHandler::draw(uint8_t brightness) const
 {
-    draw(max(0, (GRID_COLUMNS - width) / 2), (GRID_ROWS - height) / 2, brightness);
+    draw(max(0U, (GRID_COLUMNS - width) / 2U), (GRID_ROWS - height) / 2U, brightness);
 }
 
 void TextHandler::draw(int16_t x, int8_t y, uint8_t brightness) const
 {
-    size_t index = 0; // NOLINT(misc-const-correctness)
-    for (uint32_t codepoint = 0; nextCodepoint(index, codepoint);)
+    size_t index{0U}; // NOLINT(misc-const-correctness)
+    for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);)
     {
         FontModule::Symbol character{font->getChar(codepoint)};
         std::visit(
             [&](auto &&bitmap)
             {
-                const uint8_t _height = bitmap.size();
-                if (_height != 0)
+                const uint8_t _height{static_cast<uint8_t>(bitmap.size())};
+                if (_height != 0U)
                 {
                     const uint8_t msbMax{calcMsbMax(bitmap)};
-                    for (uint16_t _x = 0; _x <= msbMax; ++_x)
+                    for (uint16_t _x{0U}; _x <= msbMax; ++_x)
                     {
-                        for (uint8_t _y = 0; _y < _height; ++_y)
+                        for (uint8_t _y{0U}; _y < _height; ++_y)
                         {
-                            if ((x + character.offsetX + _x) >= 0 && (x + character.offsetX + _x) < GRID_COLUMNS &&
+                            if ((x + character.offsetX + _x) >= 0U && (x + character.offsetX + _x) < GRID_COLUMNS &&
                                 (int16_t)(y + height - _height - character.offsetY + _y) >= 0 &&
                                 (int16_t)(y + height - _height - character.offsetY + _y) < GRID_ROWS &&
-                                (bitmap[_y] >> (msbMax - _x)) & 1)
+                                (bitmap[_y] >> (msbMax - _x)) & 0b1U)
                             {
                                 Display.setPixel(x + character.offsetX + _x,
                                                  y + height - _height - character.offsetY + _y,
@@ -95,7 +95,7 @@ void TextHandler::draw(int16_t x, int8_t y, uint8_t brightness) const
                     }
                     x += msbMax + 1 + character.offsetX + tracking;
                 }
-                else if (character.offsetX > 0)
+                else if (character.offsetX != 0U)
                 {
                     x += character.offsetX + tracking;
                 }
@@ -108,7 +108,7 @@ uint8_t TextHandler::getHeight() const { return height; }
 
 uint8_t TextHandler::getWidth() const { return width; }
 
-bool TextHandler::nextCodepoint(size_t &index, uint32_t &buffer) const
+bool TextHandler::nextCodepoint(size_t &index, char32_t &buffer) const
 {
     if (index >= text.length())
     {
@@ -116,42 +116,42 @@ bool TextHandler::nextCodepoint(size_t &index, uint32_t &buffer) const
     }
     const uint8_t byte{static_cast<uint8_t>(text[index])}; // NOLINT(cppcoreguidelines-init-variables)
     index++;
-    if (byte <= 0x7F)
+    if (byte < (0b1U << 7U))
     {
         buffer = byte;
         return true;
     }
-    uint8_t bytes = 0;
-    if ((byte & 0xE0U) == 0xC0U)
+    uint8_t bytes{0U};
+    if ((byte & (0b111U << 5U)) == 0b11U << 6U)
     {
-        buffer = byte & 0x1FU;
-        bytes = 1;
+        buffer = byte & 0b1'1111U;
+        bytes = 1U;
     }
-    else if ((byte & 0xF0U) == 0xE0U)
+    else if ((byte & (0b1111U << 4U)) == 0b111U << 5U)
     {
-        buffer = byte & 0x0FU;
-        bytes = 2;
+        buffer = byte & 0b1111U;
+        bytes = 2U;
     }
-    else if ((byte & 0xF8U) == 0xF0U)
+    else if ((byte & (0b1'1111U << 3U)) == 0b1111U << 4U)
     {
-        buffer = byte & 0x07U;
-        bytes = 3;
+        buffer = byte & 0b111U;
+        bytes = 3U;
     }
     else
     {
-        buffer = 0xFFFDU;
+        buffer = 0b1111'1111'1111'1101U;
         return true;
     }
     while (bytes-- && index < text.length())
     {
         const uint8_t _byte{static_cast<uint8_t>(text[index])}; // NOLINT(cppcoreguidelines-init-variables)
         index++;
-        if ((_byte & 0xC0U) != 0x80U)
+        if ((_byte & (0b11U << 6U)) != 0b1U << 7U)
         {
-            buffer = 0xFFFDU;
+            buffer = 0b1111'1111'1111'1101U;
             break;
         }
-        buffer = (buffer << 6U) | (_byte & 0x3FU);
+        buffer = (buffer << 6U) | (_byte & 0b11'1111U);
     }
     return true;
 }
@@ -160,10 +160,10 @@ template <typename T>
     requires std::is_unsigned_v<T>
 uint8_t TextHandler::calcMsbMax(std::span<const T> bitmap) const
 {
-    uint8_t msbMax = 0; // NOLINT(misc-const-correctness)
+    uint8_t msbMax{0U}; // NOLINT(misc-const-correctness)
     for (const T bitset : bitmap)
     {
-        if (bitset != 0)
+        if (bitset != 0U)
         {
             msbMax = max(msbMax, static_cast<uint8_t>(std::bit_width(bitset) - 1));
         }
@@ -171,30 +171,30 @@ uint8_t TextHandler::calcMsbMax(std::span<const T> bitmap) const
     return msbMax;
 }
 
-std::array<char, 5> TextHandler::encode(uint32_t codepoint)
+std::array<char, 5U> TextHandler::encode(char32_t codepoint)
 {
-    std::array<char, 5> out{};
-    if (codepoint <= 0x7F)
+    std::array<char, 5U> out{};
+    if (codepoint < (0b1U << 7U))
     {
-        out.at(0) = static_cast<char>(codepoint);
+        out.at(0U) = static_cast<char>(codepoint);
     }
-    else if (codepoint <= 0x7FF)
+    else if (codepoint < (0b1U << 11U))
     {
-        out.at(0) = static_cast<char>(0xC0 | (codepoint >> 6U));
-        out.at(1) = static_cast<char>(0x80 | (codepoint & 0x3FU));
+        out.at(0U) = static_cast<char>((0b11U << 6U) | (codepoint >> (0b11U << 1U)));
+        out.at(1U) = static_cast<char>((0b1U << 7U) | (codepoint & 0b11'1111U));
     }
-    else if (codepoint <= 0xFFFF)
+    else if (codepoint < (0b1U << 16U))
     {
-        out.at(0) = static_cast<char>(0xE0 | (codepoint >> 12U));
-        out.at(1) = static_cast<char>(0x80 | ((codepoint >> 6U) & 0x3FU));
-        out.at(2) = static_cast<char>(0x80 | (codepoint & 0x3FU));
+        out.at(0U) = static_cast<char>((0b111U << 5U) | (codepoint >> (0b11U << 2U)));
+        out.at(1U) = static_cast<char>((0b1U << 7U) | ((codepoint >> (0b11U << 1U)) & 0b11'1111U));
+        out.at(2U) = static_cast<char>((0b1U << 7U) | (codepoint & 0b11'1111U));
     }
-    else if (codepoint <= 0x10FFFF)
+    else if (codepoint < (0b10001U << 16U))
     {
-        out.at(0) = static_cast<char>(0xF0 | (codepoint >> 18U));
-        out.at(1) = static_cast<char>(0x80 | ((codepoint >> 12U) & 0x3FU));
-        out.at(2) = static_cast<char>(0x80 | ((codepoint >> 6U) & 0x3FU));
-        out.at(3) = static_cast<char>(0x80 | (codepoint & 0x3FU));
+        out.at(0U) = static_cast<char>((0b1U << 7U) | (codepoint >> (0b1'001U << 1U)));
+        out.at(1U) = static_cast<char>((0b1U << 7U) | ((codepoint >> (0b11U << 2U)) & 0b11'1111U));
+        out.at(2U) = static_cast<char>((0b1U << 7U) | ((codepoint >> (0b11U << 1U)) & 0b11'1111U));
+        out.at(3U) = static_cast<char>((0b1U << 7U) | (codepoint & 0b11'1111U));
     }
     return out;
 }

--- a/firmware/src/handlers/TextHandler.cpp
+++ b/firmware/src/handlers/TextHandler.cpp
@@ -8,10 +8,10 @@ TextHandler::TextHandler(std::string text, const FontModule &font) : text(text),
     if (text.length())
     {
         {
-            char32_t codepoint{0U};
+            char32_t codepoint{0U}; // NOLINT(misc-const-correctness)
             int8_t yMax{0};
             int8_t yMin{0};
-            size_t index{0U};
+            size_t index{0U}; // NOLINT(misc-const-correctness)
             while (nextCodepoint(index, codepoint))
             {
                 const FontModule::Symbol character{font.getChar(codepoint)};
@@ -31,8 +31,8 @@ TextHandler::TextHandler(std::string text, const FontModule &font) : text(text),
         tracking = static_cast<uint8_t>(ceilf(height / Display.getRatio() / 10.0F));
         {
             width = 0U;
-            char32_t codepoint{0U};
-            size_t index{0U};
+            char32_t codepoint{0U}; // NOLINT(misc-const-correctness)
+            size_t index{0U};       // NOLINT(misc-const-correctness)
             while (nextCodepoint(index, codepoint))
             {
                 const FontModule::Symbol character{font.getChar(codepoint)};
@@ -69,8 +69,8 @@ void TextHandler::draw(uint8_t brightness) const
 
 void TextHandler::draw(int16_t x, int8_t y, uint8_t brightness) const
 {
-    char32_t codepoint{0U};
-    size_t index{0U};
+    char32_t codepoint{0U}; // NOLINT(misc-const-correctness)
+    size_t index{0U};       // NOLINT(misc-const-correctness)
     while (nextCodepoint(index, codepoint))
     {
         const FontModule::Symbol character{font->getChar(codepoint)};

--- a/firmware/src/handlers/TextHandler.cpp
+++ b/firmware/src/handlers/TextHandler.cpp
@@ -11,9 +11,9 @@ TextHandler::TextHandler(std::string text, const FontModule &font) : text(text),
             size_t index{0U}; // NOLINT(misc-const-correctness)
             int8_t yMax{0};   // NOLINT(misc-const-correctness)
             int8_t yMin{0};
-            for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);)
+            for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);) // NOLINT(misc-const-correctness)
             {
-                FontModule::Symbol character{font.getChar(codepoint)};
+                const FontModule::Symbol character{font.getChar(codepoint)};
                 std::visit(
                     [&](auto &&bitmap)
                     {
@@ -30,10 +30,10 @@ TextHandler::TextHandler(std::string text, const FontModule &font) : text(text),
         tracking = static_cast<uint8_t>(ceilf(height / Display.getRatio() / 10.0F));
         {
             width = 0U;
-            size_t index{0U}; // NOLINT(misc-const-correctness)
-            for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);)
+            size_t index{0U};                                              // NOLINT(misc-const-correctness)
+            for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);) // NOLINT(misc-const-correctness)
             {
-                FontModule::Symbol character{font.getChar(codepoint)};
+                const FontModule::Symbol character{font.getChar(codepoint)};
                 std::visit(
                     [&](auto &&bitmap)
                     {
@@ -67,10 +67,10 @@ void TextHandler::draw(uint8_t brightness) const
 
 void TextHandler::draw(int16_t x, int8_t y, uint8_t brightness) const
 {
-    size_t index{0U}; // NOLINT(misc-const-correctness)
-    for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);)
+    size_t index{0U};                                              // NOLINT(misc-const-correctness)
+    for (char32_t codepoint{0U}; nextCodepoint(index, codepoint);) // NOLINT(misc-const-correctness)
     {
-        FontModule::Symbol character{font->getChar(codepoint)};
+        const FontModule::Symbol character{font->getChar(codepoint)};
         std::visit(
             [&](auto &&bitmap)
             {
@@ -82,14 +82,16 @@ void TextHandler::draw(int16_t x, int8_t y, uint8_t brightness) const
                     {
                         for (uint8_t _y{0U}; _y < _height; ++_y)
                         {
-                            if ((x + character.offsetX + _x) >= 0U && (x + character.offsetX + _x) < GRID_COLUMNS &&
-                                (int16_t)(y + height - _height - character.offsetY + _y) >= 0 &&
-                                (int16_t)(y + height - _height - character.offsetY + _y) < GRID_ROWS &&
-                                (bitmap[_y] >> (msbMax - _x)) & 0b1U)
+                            const int pixelX{static_cast<int>(x) + static_cast<int>(character.offsetX) +
+                                             static_cast<int>(_x)};
+                            const int pixelY{static_cast<int>(y) + static_cast<int>(height) -
+                                             static_cast<int>(_height) - static_cast<int>(character.offsetY) +
+                                             static_cast<int>(_y)};
+                            if (pixelX >= 0 && pixelX < GRID_COLUMNS && pixelY >= 0 && pixelY < GRID_ROWS &&
+                                (((bitmap[_y] >> (msbMax - _x)) & 0b1U) != 0U))
                             {
-                                Display.setPixel(x + character.offsetX + _x,
-                                                 y + height - _height - character.offsetY + _y,
-                                                 brightness);
+                                Display.setPixel(
+                                    static_cast<uint8_t>(pixelX), static_cast<uint8_t>(pixelY), brightness);
                             }
                         }
                     }


### PR DESCRIPTION
Refactor the font handling code to make character lookup, generated font output, and bitmap definitions easier to read and maintain.

### Key changes

- Updated font character handling from `uint32_t` to `char32_t` to better represent Unicode code points.
- Replaced numeric codepoint comparisons such as `0x41` with character literals where practical.
- Updated Unicode character cases to use `U'…'` literals for non-ASCII characters.
- Renamed generated bitmap variables from hex-based names like `char41` / `chars30` to descriptive names based on Unicode character names.
- Standardized character comments to use `U+XXXX` notation with Unicode names.
- Added unsigned suffixes to generated array sizes and bitmap literals.
- Changed font `name` declarations and member initialization to use uniform initialization.
- Added explicit `default` cases in font lookup switches.
- Added static display-size compatibility checks for each font implementation.
- Split `FontModule::toSymbol()` into clearer overloads for common offset combinations.
- Cleaned up `TextHandler` codepoint parsing, UTF-8 encoding, drawing bounds checks, and integer conversions.
- Updated the font generator to emit the new naming, comment, literal, and signature style.

### Impact

This is primarily a readability and maintainability refactor. The rendered font data and existing font behavior are intended to remain unchanged, while the source code should now be easier to inspect, regenerate, and extend.

The changes also make font lookup code more type-appropriate for Unicode handling and reduce ambiguity around numeric literals, offsets, and generated bitmap identifiers.
