### PR TITLE
Yr weather provider, Fahrenheit and Kelvin unit support

### DIFF
--- a/firmware/include/middlewares/YrMiddleware.h
+++ b/firmware/include/middlewares/YrMiddleware.h
@@ -13,7 +13,7 @@ class YrMiddleware final : public WeatherHandler
 {
 private:
     // https://github.com/metno/weathericons/tree/main/weather
-    static constexpr std::array<std::string_view, 6> codesClear{
+    static constexpr std::array<std::string_view, 6U> codesClear{
         "clearsky_day",
         "clearsky_night",
         "clearsky_polartwilight",
@@ -21,18 +21,18 @@ private:
         "fair_night",
         "fair_polartwilight",
     };
-    static constexpr std::array<std::string_view, 1> codesCloudy{
+    static constexpr std::array<std::string_view, 1U> codesCloudy{
         "cloudy",
     };
-    static constexpr std::array<std::string_view, 3> codesCloudyPartly{
+    static constexpr std::array<std::string_view, 3U> codesCloudyPartly{
         "partlycloudy_day",
         "partlycloudy_night",
         "partlycloudy_polartwilight",
     };
-    static constexpr std::array<std::string_view, 1> codesFog{
+    static constexpr std::array<std::string_view, 1U> codesFog{
         "fog",
     };
-    static constexpr std::array<std::string_view, 12> codesRain{
+    static constexpr std::array<std::string_view, 12U> codesRain{
         "heavyrain",
         "heavyrainshowers_day",
         "heavyrainshowers_night",
@@ -46,7 +46,7 @@ private:
         "rainshowers_night",
         "rainshowers_polartwilight",
     };
-    static constexpr std::array<std::string_view, 24> codesSnow{
+    static constexpr std::array<std::string_view, 24U> codesSnow{
         "heavysleet",
         "heavysleetshowers_day",
         "heavysleetshowers_night",
@@ -72,7 +72,7 @@ private:
         "snowshowers_night",
         "snowshowers_polartwilight",
     };
-    static constexpr std::array<std::string_view, 42> codesThunder{
+    static constexpr std::array<std::string_view, 42U> codesThunder{
         "heavyrainandthunder",
         "heavyrainshowersandthunder_day",
         "heavyrainshowersandthunder_night",
@@ -117,7 +117,7 @@ private:
         "snowshowersandthunder_polartwilight",
     };
 
-    static constexpr std::array<Codeset, 7> codesets{{
+    static constexpr std::array<Codeset, 7U> codesets{{
         {Conditions::CLEAR, codesClear},
         {Conditions::CLOUDY, codesCloudy},
         {Conditions::CLOUDY_PARTLY, codesCloudyPartly},
@@ -137,7 +137,7 @@ private:
 public:
     static constexpr std::string_view name{"Yr"};
 
-    explicit YrMiddleware() : WeatherHandler(name, 1U << 19U)
+    explicit YrMiddleware() : WeatherHandler(name, 0b1U << 19U)
     {
         host = "api.met.no";
         query = "lat=" LATITUDE "&lon=" LONGITUDE;

--- a/firmware/src/middlewares/YrMiddleware.cpp
+++ b/firmware/src/middlewares/YrMiddleware.cpp
@@ -14,34 +14,45 @@ void YrMiddleware::update(std::optional<WeatherHandler::Conditions> &condition, 
     }
     path = paths.back();
     std::vector<char> body;
-    const int status = fetch(body, lastMillis);
+    const int status{fetch(body, lastMillis)};
     if (status != 200)
     {
         if (status >= 400 && status < 500)
         {
             paths.pop_back();
-            lastMillis = millis() - interval + (1U << 12U);
+            lastMillis = millis() - interval + (0b1U << 12U);
         }
         return;
     }
     JsonDocument filter; // NOLINT(misc-const-correctness)
-    filter["properties"]["timeseries"][0]["data"]["instant"]["details"]["air_temperature"].set(true);
-    filter["properties"]["timeseries"][0]["data"]["next_1_hours"]["summary"]["symbol_code"].set(true);
+    filter["properties"]["timeseries"][0U]["data"]["instant"]["details"]["air_temperature"].set(true);
+    filter["properties"]["timeseries"][0U]["data"]["next_1_hours"]["summary"]["symbol_code"].set(true);
     JsonDocument doc; // NOLINT(misc-const-correctness)
     if (deserializeJson(doc, body.data(), DeserializationOption::Filter(filter)) == DeserializationError::Code::Ok &&
-        doc["properties"]["timeseries"][0]["data"]["instant"]["details"]["air_temperature"].is<float>() &&
-        doc["properties"]["timeseries"][0]["data"]["next_1_hours"]["summary"]["symbol_code"].is<std::string_view>())
+        doc["properties"]["timeseries"][0U]["data"]["instant"]["details"]["air_temperature"].is<float>() &&
+        doc["properties"]["timeseries"][0U]["data"]["next_1_hours"]["summary"]["symbol_code"].is<std::string_view>())
     {
-        condition = getCondition(
-            doc["properties"]["timeseries"][0]["data"]["next_1_hours"]["summary"]["symbol_code"].as<std::string_view>(),
-            codesets);
+        condition = getCondition(doc["properties"]["timeseries"][0U]["data"]["next_1_hours"]["summary"]["symbol_code"]
+                                     .as<std::string_view>(),
+                                 codesets);
+#if TEMPERATURE_FAHRENHEIT
         temperature = static_cast<int16_t>(
-            lroundf(doc["properties"]["timeseries"][0]["data"]["instant"]["details"]["air_temperature"].as<float>()));
+            lroundf(doc["properties"]["timeseries"][0U]["data"]["instant"]["details"]["air_temperature"].as<float>() *
+                    9.0F / 5.0F) +
+            32);
+#elif TEMPERATURE_KELVIN
+        temperature = static_cast<int16_t>(
+            lroundf(273.15F +
+                    doc["properties"]["timeseries"][0U]["data"]["instant"]["details"]["air_temperature"].as<float>()));
+#else
+        temperature = static_cast<int16_t>(
+            lroundf(doc["properties"]["timeseries"][0U]["data"]["instant"]["details"]["air_temperature"].as<float>()));
+#endif // TEMPERATURE_FAHRENHEIT
         return;
     }
     paths.pop_back();
     ESP_LOGD("Response", "unsupported format"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-    lastMillis = millis() - interval + (1U << 13U);
+    lastMillis = millis() - interval + (0b1U << 13U);
 }
 
 #endif // WEATHER_YR


### PR DESCRIPTION
This update introduces support for Fahrenheit and Kelvin temperature units in the Yr weather provider middleware, enhancing its functionality for users who prefer these measurement systems.

### Key changes
- Implemented conditional temperature conversions based on defined macros for Fahrenheit and Kelvin.
- Refactored code for improved clarity and consistency.

### Impact
These changes allow users to receive temperature data in their preferred unit, improving usability. The refactoring also enhances code maintainability without altering existing functionality.