### PR TITLE
Kelvin support for multiple weather providers

### DIFF
--- a/firmware/include/middlewares/GoogleWeatherMiddleware.h
+++ b/firmware/include/middlewares/GoogleWeatherMiddleware.h
@@ -13,18 +13,18 @@ class GoogleWeatherMiddleware final : public WeatherHandler
 {
 private:
     // https://developers.google.com/maps/documentation/weather/weather-condition-icons
-    static constexpr std::array<std::string_view, 2> codesClear{
+    static constexpr std::array<std::string_view, 2U> codesClear{
         "CLEAR",
         "MOSTLY_CLEAR",
     };
-    static constexpr std::array<std::string_view, 1> codesCloudy{
+    static constexpr std::array<std::string_view, 1U> codesCloudy{
         "CLOUDY",
     };
-    static constexpr std::array<std::string_view, 2> codesCloudyPartly{
+    static constexpr std::array<std::string_view, 2U> codesCloudyPartly{
         "MOSTLY_CLOUDY",
         "PARTLY_CLOUDY",
     };
-    static constexpr std::array<std::string_view, 11> codesRain{
+    static constexpr std::array<std::string_view, 11U> codesRain{
         "CHANCE_OF_SHOWERS",
         "HEAVY_RAIN",
         "HEAVY_RAIN_SHOWERS",
@@ -37,7 +37,7 @@ private:
         "RAIN_SHOWERS",
         "SCATTERED_SHOWERS",
     };
-    static constexpr std::array<std::string_view, 14> codesSnow{
+    static constexpr std::array<std::string_view, 14U> codesSnow{
         "CHANCE_OF_SNOW_SHOWERS",
         "HAIL",
         "HAIL_SHOWERS",
@@ -53,7 +53,7 @@ private:
         "SNOW_PERIODICALLY_HEAVY",
         "SNOW_SHOWERS",
     };
-    static constexpr std::array<std::string_view, 7> codesThunder{
+    static constexpr std::array<std::string_view, 7U> codesThunder{
         "HEAVY_SNOW_STORM",
         "HEAVY_THUNDERSTORM",
         "LIGHT_THUNDERSTORM_RAIN",
@@ -62,13 +62,13 @@ private:
         "THUNDERSHOWER",
         "THUNDERSTORM",
     };
-    static constexpr std::array<std::string_view, 3> codesWind{
+    static constexpr std::array<std::string_view, 3U> codesWind{
         "BLOWING_SNOW",
         "WIND_AND_RAIN",
         "WINDY",
     };
 
-    static constexpr std::array<WeatherHandler::Codeset, 7> codesets{{
+    static constexpr std::array<WeatherHandler::Codeset, 7U> codesets{{
         {WeatherHandler::Conditions::CLEAR, codesClear},
         {WeatherHandler::Conditions::CLOUDY, codesCloudy},
         {WeatherHandler::Conditions::CLOUDY_PARTLY, codesCloudyPartly},
@@ -80,12 +80,13 @@ private:
 
     // https://developers.google.com/maps/documentation/weather
     static inline std::vector<const char *> queries{
-        "location.latitude=" LATITUDE "&location.longitude=" LONGITUDE "&key=" GOOGLEWEATHER_KEY,
-#if TEMPERATURE_CELSIUS
+#if TEMPERATURE_CELSIUS || TEMPERATURE_KELVIN
         "location.latitude=" LATITUDE "&location.longitude=" LONGITUDE "&unitsSystem=METRIC&key=" GOOGLEWEATHER_KEY,
 #elif TEMPERATURE_FAHRENHEIT
         "location.latitude=" LATITUDE "&location.longitude=" LONGITUDE "&unitsSystem=IMPERIAL&key=" GOOGLEWEATHER_KEY,
-#endif // TEMPERATURE_CELSIUS
+#else
+        "location.latitude=" LATITUDE "&location.longitude=" LONGITUDE "&key=" GOOGLEWEATHER_KEY,
+#endif // TEMPERATURE_CELSIUS || TEMPERATURE_KELVIN
     };
 
 public:

--- a/firmware/include/middlewares/OpenMeteoMiddleware.h
+++ b/firmware/include/middlewares/OpenMeteoMiddleware.h
@@ -13,15 +13,16 @@ class OpenMeteoMiddleware final : public WeatherHandler
 {
 private:
     // https://open-meteo.com/en/docs#weather_variable_documentation
-    static constexpr std::array<uint8_t, 1> codesClear{0};
-    static constexpr std::array<uint8_t, 1> codesCloudy{3};
-    static constexpr std::array<uint8_t, 2> codesCloudyPartly{1, 2};
-    static constexpr std::array<uint8_t, 2> codesFog{45, 48};
-    static constexpr std::array<uint8_t, 13> codesRain{51, 53, 55, 56, 57, 61, 63, 65, 66, 67, 80, 81, 82};
-    static constexpr std::array<uint8_t, 6> codesSnow{71, 73, 75, 77, 85, 86};
-    static constexpr std::array<uint8_t, 3> codesThunder{95, 96, 99};
+    static constexpr std::array<uint8_t, 1U> codesClear{0U};
+    static constexpr std::array<uint8_t, 1U> codesCloudy{3U};
+    static constexpr std::array<uint8_t, 2U> codesCloudyPartly{1U, 2U};
+    static constexpr std::array<uint8_t, 2U> codesFog{45U, 48U};
+    static constexpr std::array<uint8_t, 13U> codesRain{
+        51U, 53U, 55U, 56U, 57U, 61U, 63U, 65U, 66U, 67U, 80U, 81U, 82U};
+    static constexpr std::array<uint8_t, 6U> codesSnow{71U, 73U, 75U, 77U, 85U, 86U};
+    static constexpr std::array<uint8_t, 3U> codesThunder{95U, 96U, 99U};
 
-    static constexpr std::array<WeatherHandler::Codeset8, 7> codesets{{
+    static constexpr std::array<WeatherHandler::Codeset8, 7U> codesets{{
         {WeatherHandler::Conditions::CLEAR, codesClear},
         {WeatherHandler::Conditions::CLOUDY, codesCloudy},
         {WeatherHandler::Conditions::CLOUDY_PARTLY, codesCloudyPartly},
@@ -33,11 +34,7 @@ private:
 
     // https://open-meteo.com/en/docs#api-documentation
     static inline std::vector<std::pair<const char *, const char *>> parts{
-        {
-            "api.open-meteo.com",
-            "latitude=" LATITUDE "&longitude=" LONGITUDE "&current=temperature_2m,weather_code",
-        },
-#if TEMPERATURE_CELSIUS
+#if TEMPERATURE_CELSIUS || TEMPERATURE_KELVIN
         {
             "api.open-meteo.com",
             "latitude=" LATITUDE "&longitude=" LONGITUDE
@@ -49,14 +46,13 @@ private:
             "latitude=" LATITUDE "&longitude=" LONGITUDE
             "&current=temperature_2m,weather_code&temperature_unit=fahrenheit",
         },
-#endif // TEMPERATURE_CELSIUS
-#ifdef OPENMETEO_KEY
+#else
         {
-            "customer-api.open-meteo.com",
-            "latitude=" LATITUDE "&longitude=" LONGITUDE "&current=temperature_2m,weather_code&apikey=" OPENMETEO_KEY,
+            "api.open-meteo.com",
+            "latitude=" LATITUDE "&longitude=" LONGITUDE "&current=temperature_2m,weather_code",
         },
-#endif // OPENMETEO_KEY
-#if defined(OPENMETEO_KEY) && TEMPERATURE_CELSIUS
+#endif // TEMPERATURE_CELSIUS || TEMPERATURE_KELVIN
+#if defined(OPENMETEO_KEY) && (TEMPERATURE_CELSIUS || TEMPERATURE_KELVIN)
         {
             "customer-api.open-meteo.com",
             "latitude=" LATITUDE "&longitude=" LONGITUDE
@@ -68,7 +64,12 @@ private:
             "latitude=" LATITUDE "&longitude=" LONGITUDE
             "&current=temperature_2m,weather_code&temperature_unit=fahrenheit&apikey=" OPENMETEO_KEY,
         },
-#endif // defined(OPENMETEO_KEY) && TEMPERATURE_CELSIUS
+#elif defined(OPENMETEO_KEY)
+        {
+            "customer-api.open-meteo.com",
+            "latitude=" LATITUDE "&longitude=" LONGITUDE "&current=temperature_2m,weather_code&apikey=" OPENMETEO_KEY,
+        },
+#endif // defined(OPENMETEO_KEY) && (TEMPERATURE_CELSIUS || TEMPERATURE_KELVIN)
     };
 
 public:

--- a/firmware/include/middlewares/WorldWeatherOnlineMiddleware.h
+++ b/firmware/include/middlewares/WorldWeatherOnlineMiddleware.h
@@ -13,15 +13,16 @@ class WorldWeatherOnlineMiddleware final : public WeatherHandler
 {
 private:
     // https://www.worldweatheronline.com/weather-api/api/docs/weather-icons.aspx
-    static constexpr std::array<uint16_t, 1> codesClear{113};
-    static constexpr std::array<uint16_t, 2> codesCloudy{119, 122};
-    static constexpr std::array<uint16_t, 1> codesCloudyPartly{116};
-    static constexpr std::array<uint16_t, 3> codesFog{143, 248, 260};
-    static constexpr std::array<uint16_t, 9> codesRain{176, 263, 266, 293, 296, 299, 302, 305, 308};
-    static constexpr std::array<uint16_t, 11> codesSnow{179, 182, 185, 227, 230, 281, 284, 311, 314, 317, 320};
-    static constexpr std::array<uint16_t, 1> codesThunder{200};
+    static constexpr std::array<uint16_t, 1U> codesClear{113U};
+    static constexpr std::array<uint16_t, 2U> codesCloudy{119U, 122U};
+    static constexpr std::array<uint16_t, 1U> codesCloudyPartly{116U};
+    static constexpr std::array<uint16_t, 3U> codesFog{143U, 248U, 260U};
+    static constexpr std::array<uint16_t, 9U> codesRain{176U, 263U, 266U, 293U, 296U, 299U, 302U, 305U, 308U};
+    static constexpr std::array<uint16_t, 11U> codesSnow{
+        179U, 182U, 185U, 227U, 230U, 281U, 284U, 311U, 314U, 317U, 320U};
+    static constexpr std::array<uint16_t, 1U> codesThunder{200U};
 
-    static constexpr std::array<Codeset16, 7> codesets{{
+    static constexpr std::array<Codeset16, 7U> codesets{{
         {Conditions::CLEAR, codesClear},
         {Conditions::CLOUDY, codesCloudy},
         {Conditions::CLOUDY_PARTLY, codesCloudyPartly},

--- a/firmware/include/middlewares/WttrInMiddleware.h
+++ b/firmware/include/middlewares/WttrInMiddleware.h
@@ -13,17 +13,36 @@ class WttrInMiddleware final : public WeatherHandler
 {
 private:
     // https://github.com/chubin/wttr.in/blob/master/lib/constants.py
-    static constexpr std::array<uint16_t, 1> codesClear{113};
-    static constexpr std::array<uint16_t, 2> codesCloudy{119, 122};
-    static constexpr std::array<uint16_t, 1> codesCloudyPartly{116};
-    static constexpr std::array<uint16_t, 3> codesFog{143, 248, 260};
-    static constexpr std::array<uint16_t, 19> codesRain{
-        176, 293, 296, 299, 302, 305, 308, 311, 314, 353, 356, 359, 386, 389, 263, 266, 281, 284, 185};
-    static constexpr std::array<uint16_t, 14> codesSnow{
-        179, 227, 323, 326, 329, 332, 335, 338, 368, 371, 392, 395, 230, 350};
-    static constexpr std::array<uint16_t, 5> codesThunder{200, 386, 389, 392, 395};
+    static constexpr std::array<uint16_t, 1U> codesClear{113U};
+    static constexpr std::array<uint16_t, 2U> codesCloudy{119U, 122U};
+    static constexpr std::array<uint16_t, 1U> codesCloudyPartly{116U};
+    static constexpr std::array<uint16_t, 3U> codesFog{143U, 248U, 260U};
+    static constexpr std::array<uint16_t, 19U> codesRain{
+        176U,
+        293U,
+        296U,
+        299U,
+        302U,
+        305U,
+        308U,
+        311U,
+        314U,
+        353U,
+        356U,
+        359U,
+        386U,
+        389U,
+        263U,
+        266U,
+        281U,
+        284U,
+        185U,
+    };
+    static constexpr std::array<uint16_t, 14U> codesSnow{
+        179U, 227U, 323U, 326U, 329U, 332U, 335U, 338U, 368U, 371U, 392U, 395U, 230U, 350U};
+    static constexpr std::array<uint16_t, 5U> codesThunder{200U, 386U, 389U, 392U, 395U};
 
-    static constexpr std::array<Codeset16, 7> codesets{{
+    static constexpr std::array<Codeset16, 7U> codesets{{
         {Conditions::CLEAR, codesClear},
         {Conditions::CLOUDY, codesCloudy},
         {Conditions::CLOUDY_PARTLY, codesCloudyPartly},

--- a/firmware/src/middlewares/GoogleWeatherMiddleware.cpp
+++ b/firmware/src/middlewares/GoogleWeatherMiddleware.cpp
@@ -14,13 +14,13 @@ void GoogleWeatherMiddleware::update(std::optional<WeatherHandler::Conditions> &
     }
     query = queries.back();
     std::vector<char> body;
-    const int status = fetch(body, lastMillis);
+    const int status{fetch(body, lastMillis)};
     if (status != 200)
     {
         if (status >= 400 && status < 500)
         {
             queries.pop_back();
-            lastMillis = millis() - interval + (1U << 12U);
+            lastMillis = millis() - interval + (0b1U << 12U);
         }
         return;
     }
@@ -32,12 +32,16 @@ void GoogleWeatherMiddleware::update(std::optional<WeatherHandler::Conditions> &
         doc["temperature"]["degrees"].is<float>() && doc["weatherCondition"]["type"].is<std::string_view>())
     {
         condition = getCondition(doc["weatherCondition"]["type"].as<std::string_view>(), codesets);
+#if TEMPERATURE_KELVIN
+        temperature = static_cast<int16_t>(lroundf(273.15F + doc["temperature"]["degrees"].as<float>()));
+#else
         temperature = static_cast<int16_t>(lroundf(doc["temperature"]["degrees"].as<float>()));
+#endif // TEMPERATURE_KELVIN
         return;
     }
     queries.pop_back();
     ESP_LOGD("Response", "unsupported format"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-    lastMillis = millis() - interval + (1U << 13U);
+    lastMillis = millis() - interval + (0b1U << 13U);
 }
 
 #endif // WEATHER_GOOGLE

--- a/firmware/src/middlewares/OpenMeteoMiddleware.cpp
+++ b/firmware/src/middlewares/OpenMeteoMiddleware.cpp
@@ -15,13 +15,13 @@ void OpenMeteoMiddleware::update(std::optional<WeatherHandler::Conditions> &cond
     host = parts.back().first;
     query = parts.back().second;
     std::vector<char> body;
-    const int status = fetch(body, lastMillis);
+    const int status{fetch(body, lastMillis)};
     if (status != 200)
     {
         if (status >= 400 && status < 500)
         {
             parts.pop_back();
-            lastMillis = millis() - interval + (1U << 12U);
+            lastMillis = millis() - interval + (0b1U << 12U);
         }
         return;
     }
@@ -33,12 +33,16 @@ void OpenMeteoMiddleware::update(std::optional<WeatherHandler::Conditions> &cond
         doc["current"]["temperature_2m"].is<float>() && doc["current"]["weather_code"].is<uint8_t>())
     {
         condition = getCondition(doc["current"]["weather_code"].as<uint8_t>(), codesets);
+#if TEMPERATURE_KELVIN
+        temperature = static_cast<int16_t>(lroundf(273.15F + doc["current"]["temperature_2m"].as<float>()));
+#else
         temperature = static_cast<int16_t>(lroundf(doc["current"]["temperature_2m"].as<float>()));
+#endif // TEMPERATURE_KELVIN
         return;
     }
     parts.pop_back();
     ESP_LOGD("Response", "unsupported format"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-    lastMillis = millis() - interval + (1U << 13U);
+    lastMillis = millis() - interval + (0b1U << 13U);
 }
 
 #endif // WEATHER_OPENMETEO

--- a/firmware/src/middlewares/WorldWeatherOnlineMiddleware.cpp
+++ b/firmware/src/middlewares/WorldWeatherOnlineMiddleware.cpp
@@ -14,43 +14,45 @@ void WorldWeatherOnlineMiddleware::update(std::optional<WeatherHandler::Conditio
     }
     query = queries.back();
     std::vector<char> body;
-    const int status = fetch(body, lastMillis);
+    const int status{fetch(body, lastMillis)};
     if (status != 200)
     {
         if (status >= 400 && status < 500)
         {
             queries.pop_back();
-            lastMillis = millis() - interval + (1U << 12U);
+            lastMillis = millis() - interval + (0b1U << 12U);
         }
         return;
     }
     JsonDocument filter; // NOLINT(misc-const-correctness)
 #if TEMPERATURE_FAHRENHEIT
-    filter["data"]["current_condition"][0]["temp_F"].set(true);
+    filter["data"]["current_condition"][0U]["temp_F"].set(true);
 #else
-    filter["data"]["current_condition"][0]["temp_C"].set(true);
+    filter["data"]["current_condition"][0U]["temp_C"].set(true);
 #endif // TEMPERATURE_FAHRENHEIT
-    filter["data"]["current_condition"][0]["weatherCode"].set(true);
+    filter["data"]["current_condition"][0U]["weatherCode"].set(true);
     JsonDocument doc; // NOLINT(misc-const-correctness)
     if (deserializeJson(doc, body.data(), DeserializationOption::Filter(filter)) == DeserializationError::Code::Ok &&
 #if TEMPERATURE_FAHRENHEIT
-        doc["data"]["current_condition"][0]["temp_F"].is<std::string_view>() &&
+        doc["data"]["current_condition"][0U]["temp_F"].is<std::string_view>() &&
 #else
-        doc["data"]["current_condition"][0]["temp_C"].is<std::string_view>() &&
+        doc["data"]["current_condition"][0U]["temp_C"].is<std::string_view>() &&
 #endif // TEMPERATURE_FAHRENHEIT
-        doc["data"]["current_condition"][0]["weatherCode"].is<std::string_view>())
+        doc["data"]["current_condition"][0U]["weatherCode"].is<std::string_view>())
     {
-        condition = getCondition(doc["data"]["current_condition"][0]["weatherCode"].as<uint16_t>(), codesets);
+        condition = getCondition(doc["data"]["current_condition"][0U]["weatherCode"].as<uint16_t>(), codesets);
 #if TEMPERATURE_FAHRENHEIT
-        temperature = doc["data"]["current_condition"][0]["temp_F"].as<int16_t>();
+        temperature = doc["data"]["current_condition"][0U]["temp_F"].as<int16_t>();
+#elif TEMPERATURE_KELVIN
+        temperature = 273 + doc["data"]["current_condition"][0U]["temp_C"].as<int>();
 #else
-        temperature = doc["data"]["current_condition"][0]["temp_C"].as<int16_t>();
+        temperature = doc["data"]["current_condition"][0U]["temp_C"].as<int16_t>();
 #endif // TEMPERATURE_FAHRENHEIT
         return;
     }
     queries.pop_back();
     ESP_LOGD("Response", "unsupported format"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-    lastMillis = millis() - interval + (1U << 13U);
+    lastMillis = millis() - interval + (0b1U << 13U);
 }
 
 #endif // WEATHER_WORLDWEATHERONLINE

--- a/firmware/src/middlewares/WttrInMiddleware.cpp
+++ b/firmware/src/middlewares/WttrInMiddleware.cpp
@@ -15,43 +15,45 @@ void WttrInMiddleware::update(std::optional<WeatherHandler::Conditions> &conditi
     path = parts.back().first;
     query = parts.back().second;
     std::vector<char> body;
-    const int status = fetch(body, lastMillis);
+    const int status{fetch(body, lastMillis)};
     if (status != 200)
     {
         if (status >= 400 && status < 500)
         {
             parts.pop_back();
-            lastMillis = millis() - interval + (1U << 12U);
+            lastMillis = millis() - interval + (0b1U << 12U);
         }
         return;
     }
     JsonDocument filter; // NOLINT(misc-const-correctness)
 #if TEMPERATURE_FAHRENHEIT
-    filter["current_condition"][0]["temp_F"].set(true);
+    filter["current_condition"][0U]["temp_F"].set(true);
 #else
-    filter["current_condition"][0]["temp_C"].set(true);
+    filter["current_condition"][0U]["temp_C"].set(true);
 #endif // TEMPERATURE_FAHRENHEIT
-    filter["current_condition"][0]["weatherCode"].set(true);
+    filter["current_condition"][0U]["weatherCode"].set(true);
     JsonDocument doc; // NOLINT(misc-const-correctness)
     if (deserializeJson(doc, body.data(), DeserializationOption::Filter(filter)) == DeserializationError::Code::Ok &&
 #if TEMPERATURE_FAHRENHEIT
-        doc["current_condition"][0]["temp_F"].is<std::string_view>() &&
+        doc["current_condition"][0U]["temp_F"].is<std::string_view>() &&
 #else
-        doc["current_condition"][0]["temp_C"].is<std::string_view>() &&
+        doc["current_condition"][0U]["temp_C"].is<std::string_view>() &&
 #endif // TEMPERATURE_FAHRENHEIT
-        doc["current_condition"][0]["weatherCode"].is<std::string_view>())
+        doc["current_condition"][0U]["weatherCode"].is<std::string_view>())
     {
-        condition = getCondition(doc["current_condition"][0]["weatherCode"].as<uint16_t>(), codesets);
+        condition = getCondition(doc["current_condition"][0U]["weatherCode"].as<uint16_t>(), codesets);
 #if TEMPERATURE_FAHRENHEIT
-        temperature = doc["current_condition"][0]["temp_F"].as<int16_t>();
+        temperature = doc["current_condition"][0U]["temp_F"].as<int16_t>();
+#elif TEMPERATURE_KELVIN
+        temperature = static_cast<int16_t>(273 + doc["current_condition"][0U]["temp_C"].as<int>());
 #else
-        temperature = doc["current_condition"][0]["temp_C"].as<int16_t>();
+        temperature = doc["current_condition"][0U]["temp_C"].as<int16_t>();
 #endif // TEMPERATURE_FAHRENHEIT
         return;
     }
     parts.pop_back();
     ESP_LOGD("Response", "unsupported format"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-    lastMillis = millis() - interval + (1U << 13U);
+    lastMillis = millis() - interval + (0b1U << 13U);
 }
 
 #endif // WEATHER_WTTRIN


### PR DESCRIPTION
Introduce Kelvin temperature support for Google Weather, Open Meteo, World Weather Online, and Wttr.in. This enhancement allows users to receive temperature data in Kelvin, improving flexibility for temperature preferences.

### Key changes
- Implemented Kelvin temperature conversion in the middleware for each weather provider.
- Updated temperature handling logic to accommodate Kelvin alongside existing formats.

### Impact
These changes enhance the usability of the weather services by providing an additional temperature unit. Users can now choose Kelvin, which may be particularly beneficial for scientific applications or user preferences.