### PR TITLE
Fix photocell gamma correction at zero ADC readings

### DIFF
--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -46,6 +46,7 @@ void PhotocellExtension::handle()
     {
         _lastMillis = millis();
         raw = analogRead(PIN_LDR);
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         const uint8_t _brightness{static_cast<uint8_t>(std::clamp<int16_t>(
             lroundf(((0b1U << 8U) + 1U) *
                         powf(static_cast<float>(raw + 1U) / static_cast<float>((0b1U << 12U) + 1U), gamma) -

--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -2,10 +2,10 @@
 
 #include "extensions/PhotocellExtension.h"
 
-#include "config/constants.h" // NOLINT(misc-include-cleaner)
+#include "config/constants.h"                  // NOLINT(misc-include-cleaner)
+#include "extensions/HomeAssistantExtension.h" // NOLINT(misc-include-cleaner)
 #include "services/DeviceService.h"
 #include "services/DisplayService.h"
-#include "services/ExtensionsService.h" // NOLINT(misc-include-cleaner)
 
 #include <nvs.h>
 
@@ -46,10 +46,12 @@ void PhotocellExtension::handle()
     {
         _lastMillis = millis();
         raw = analogRead(PIN_LDR);
-        const uint8_t _brightness{static_cast<uint8_t>(
-            static_cast<uint16_t>(powf(static_cast<float>(raw) / static_cast<float>((1U << 12U) - 1U), gamma) *
-                                  static_cast<float>(UINT8_MAX - 1U)) +
-            1U)};
+        const uint8_t _brightness{static_cast<uint8_t>(std::clamp<int16_t>(
+            lroundf(((0b1U << 8U) + 1U) *
+                        powf(static_cast<float>(raw + 1U) / static_cast<float>((0b1U << 12U) + 1U), gamma) -
+                    1U),
+            1,
+            UINT8_MAX))};
         if ((direction && _brightness < brightness) || (!direction && _brightness > brightness))
         {
             direction = !direction;
@@ -126,8 +128,8 @@ void PhotocellExtension::onTransmit(JsonObjectConst payload, std::string_view so
         const uint8_t _brightness{payload["brightness"].as<uint8_t>()};
         if (_brightness != brightness)
         {
-            setGamma(logf(static_cast<float>(_brightness) / static_cast<float>(1U << 8U)) /
-                     logf(static_cast<float>(raw + 1U) / static_cast<float>((1U << 12U) + 1U)));
+            setGamma(logf(static_cast<float>(_brightness + 1U) / static_cast<float>((0b1U << 8U) + 1U)) /
+                     logf(static_cast<float>(raw + 1U) / static_cast<float>((0b1U << 12U) + 1U)));
         }
     }
 }


### PR DESCRIPTION
Fixes photocell brightness scaling when the LDR bridge reports a zero ADC reading.

The previous gamma correction formula used the raw ADC value directly, which made the lower end of the brightness curve less accurate at `raw == 0`. This updates both the calculated brightness and gamma calibration path to use offset values, keeping the formula defined and consistent at the bottom of the ADC range.

### Changes

* Offset the raw photocell reading before applying gamma correction.
* Adjust brightness scaling to match the updated gamma formula.
* Clamp the calculated brightness to the supported display range.

### Impact

This improves automatic brightness behavior in very dark conditions, especially when the photocell reading reaches zero.