### PR TITLE
Make NAME and HOSTNAME config options optional

### DIFF
--- a/.env
+++ b/.env
@@ -6,8 +6,8 @@
 #
 # General
 #
-NAME='Frekvens'
-HOSTNAME='frekvens'
+#NAME='Frekvens'
+#HOSTNAME='frekvens'
 #OTA_KEY='secret'
 #TEMPERATURE_UNIT='°C'
 

--- a/.github/workflows/ikea-frekvens-led-multi-use-light.yml
+++ b/.github/workflows/ikea-frekvens-led-multi-use-light.yml
@@ -220,14 +220,12 @@ jobs:
           cat <<'EOL' > .env
           EXTENSION_BUTTON='true'
           FONT_MICRO='true'
-          HOSTNAME='frekvens'
           IKEA_FREKVENS='true'
           MODE_ARROW='true'
           MODE_BLINDS='true'
           MODE_EQUALIZER='true'
           MODE_RING='true'
           MODE_WAVEFORM='true'
-          NAME='Frekvens'
           EOL
 
           cat <<'EOL' > firmware/include/config/secrets.h
@@ -332,7 +330,6 @@ jobs:
           FONT_MICRO='true'
           FONT_MINI='true'
           FONT_SMALL='true'
-          HOSTNAME='frekvens'
           IKEA_FREKVENS='true'
           MODE_ANIMATION='true'
           MODE_ARROW='true'

--- a/.github/workflows/ikea-obegransad-led-wall-lamp.yml
+++ b/.github/workflows/ikea-obegransad-led-wall-lamp.yml
@@ -219,7 +219,6 @@ jobs:
           cat <<'EOL' > .env
           EXTENSION_BUTTON='true'
           FONT_MICRO='true'
-          HOSTNAME='obegransad'
           IKEA_OBEGRANSAD='true'
           MODE_CIRCLE='true'
           MODE_LINES='true'
@@ -227,7 +226,6 @@ jobs:
           MODE_RAIN='true'
           MODE_SCAN='true'
           MODE_STARS='true'
-          NAME='Obegränsad'
           EOL
 
           cat <<'EOL' > firmware/include/config/secrets.h
@@ -330,7 +328,6 @@ jobs:
           FONT_MICRO='true'
           FONT_MINI='true'
           FONT_SMALL='true'
-          HOSTNAME='obegransad'
           IKEA_OBEGRANSAD='true'
           MODE_ANIMATION='true'
           MODE_ARROW='true'

--- a/docs/wiki/IKEA-Frekvens.md
+++ b/docs/wiki/IKEA-Frekvens.md
@@ -286,8 +286,8 @@ Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
 IKEA_FREKVENS='true'
 
 # Names
-NAME='Frekvens'
-HOSTNAME='frekvens'
+NAME='Frekvens'     # optional
+HOSTNAME='frekvens' # optional
 ```
 
 Configure in [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h):
@@ -317,6 +317,7 @@ Configure in [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/
 
 A collection of external links for deeper exploration — including teardowns, mods, datasheets, and community projects — provided for reference only and with no formal connection to this project.
 
+- [GitHub: ah01/box-of-life](https://github.com/ah01/box-of-life/blob/master/readme.md)
 - [GitHub: attowatt/frekvensHack](https://github.com/attowatt/frekvensHack/blob/main/README.md)
 - [GitHub: CrazyRobMiles/Frekvens-stuff-from-Rob](https://github.com/CrazyRobMiles/Frekvens-stuff-from-Rob/blob/master/README.md)
 - [GitHub: frumperino/FrekvensPanel](https://github.com/frumperino/FrekvensPanel/blob/master/readme.md)

--- a/docs/wiki/IKEA-Obegransad.md
+++ b/docs/wiki/IKEA-Obegransad.md
@@ -261,8 +261,8 @@ Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
 IKEA_OBEGRANSAD='true'
 
 # Names
-NAME='Obegränsad'
-HOSTNAME='obegransad'
+NAME='Obegränsad'     # optional
+HOSTNAME='obegransad' # optional
 ```
 
 Configure in [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h):

--- a/docs/wiki/Services.md
+++ b/docs/wiki/Services.md
@@ -1,15 +1,15 @@
 # ⚙️ Services
 
-[Connectivity](#-connectivity) | [Device](#️-device) | [Display](#-display) | [Temperature](#-temperature) | [Time](#-time)
+[Connectivity](#-connectivity) | [Device](#️-device) | [Display](#-display) | [Temperature](#%EF%B8%8F-temperature) | [Time](#-time)
 
 ## 🌐 Connectivity
 
 **Hostname:**
 
-Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
+Defaults to device name if not set. Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
 
 ```ini
-HOSTNAME='frekvens'
+HOSTNAME='frekvens' # optional
 ```
 
 **Wi-Fi client:**
@@ -35,7 +35,7 @@ Regulatory country code in *ISO 3166-1 alpha-2* format.
 Configure in [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/include/config/secrets.h):
 
 ```h
-#define WIFI_COUNTRY "01"
+#define WIFI_COUNTRY "01" // ISO 3166-1 alpha-2
 ```
 
 > [!NOTE]
@@ -45,10 +45,10 @@ Configure in [secrets.h](https://github.com/VIPnytt/Frekvens/blob/main/firmware/
 
 **Name:**
 
-Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
+Defaults to device model name if not set. Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
 
 ```ini
-NAME='Frekvens'
+NAME='Frekvens' # optional
 ```
 
 **Power off:**
@@ -125,9 +125,9 @@ TEMPERATURE_UNIT='°C' # °C, °F or °K
 
 **Clock format:**
 
-Whether to use 12-hour or 24-hour format for time display.
+Whether to use 12-hour or 24-hour format.
 
-Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
+Auto-detected if not set. Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
 
 ```ini
 CLOCK_FORMAT='12' # hours
@@ -137,8 +137,8 @@ CLOCK_FORMAT='12' # hours
 
 Time zone in IANA format, eg. `America/New_York`, `Asia/Shanghai` or `Europe/London`.
 
-Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
+Auto-detected if not set. Configure in [.env](https://github.com/VIPnytt/Frekvens/blob/main/.env):
 
 ```ini
-TIME_ZONE='Etc/Universal'
+TIME_ZONE='Etc/Universal' # IANA
 ```

--- a/firmware/include/config/constants.h
+++ b/firmware/include/config/constants.h
@@ -14,7 +14,7 @@
 #elif IKEA_OBEGRANSAD
 #include "config/IkeaObegransad.h"
 #else
-#error "Unsupported device."
+#error "Unknown device."
 #endif
 
 /**

--- a/scripts/src/Frekvens.py
+++ b/scripts/src/Frekvens.py
@@ -1,14 +1,18 @@
 import dotenv
 import os
 import pathlib
+import re
 import shutil
 import typing
+import unicodedata
 
 from .components.Dependency import Dependency
 from .components.Deprecated import Deprecated
 from .components.Partition import Partition
 from .components.Time import Time
 from .config.version import VERSION
+from .devices.IkeaFrekvens import IkeaFrekvens
+from .devices.IkeaObegransad import IkeaObegransad
 from .extensions.Ota import Ota
 from .extensions.WebApp import WebApp
 from .modes.Weather import Weather
@@ -70,6 +74,21 @@ class Frekvens:
         ]:
             self.webapp = WebApp(self)
         self.dotenv = {key: (value if value is not None else "") for key, value in dotenv.dotenv_values(".env").items()}
+        if "NAME" not in self.dotenv:
+            if IkeaFrekvens.ENV_OPTION in self.dotenv and self.dotenv[IkeaFrekvens.ENV_OPTION] == "true":
+                self.dotenv["NAME"] = IkeaFrekvens.NAME
+            elif IkeaObegransad.ENV_OPTION in self.dotenv and self.dotenv[IkeaObegransad.ENV_OPTION] == "true":
+                self.dotenv["NAME"] = IkeaObegransad.NAME
+            else:
+                self.dotenv["NAME"] = "Frekvens"
+        if "HOSTNAME" in self.dotenv:
+            self.dotenv["HOSTNAME"] = self.dotenv["HOSTNAME"].lower()
+        else:
+            self.dotenv["HOSTNAME"] = re.sub(
+                r"[^a-z0-9]+",
+                "-",
+                unicodedata.normalize("NFKD", self.dotenv["NAME"]).encode("ascii", "ignore").decode("ascii").lower(),
+            ).strip("-")
 
     def run(self) -> None:
         print(f"Frekvens {VERSION}")

--- a/scripts/src/devices/IkeaFrekvens.py
+++ b/scripts/src/devices/IkeaFrekvens.py
@@ -1,0 +1,3 @@
+class IkeaFrekvens:
+    ENV_OPTION: str = "IKEA_FREKVENS"
+    NAME: str = "Frekvens"

--- a/scripts/src/devices/IkeaObegransad.py
+++ b/scripts/src/devices/IkeaObegransad.py
@@ -1,0 +1,3 @@
+class IkeaObegransad:
+    ENV_OPTION: str = "IKEA_OBEGRANSAD"
+    NAME: str = "Obegränsad"


### PR DESCRIPTION
This update allows the NAME and HOSTNAME configuration options to be optional, providing flexibility for users who may not want to set these values explicitly.

### Key changes
- Modified the .env file and related workflows to make NAME and HOSTNAME optional.
- Updated documentation to reflect the optional nature of these configurations.
- Implemented logic in the code to auto-generate default values for NAME and HOSTNAME if not provided.

### Impact
These changes simplify the configuration process for users, allowing for a more streamlined setup. Default values will be used if the options are not specified, enhancing usability without breaking existing functionality.