### PR TITLE
Refactor Mode generator to use unsigned types for array sizes and indices

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -132,7 +132,6 @@ jobs:
           mv DynamicMode.h firmware/include/modes
 
       - name: Clang format
-        if: ${{ matrix.toolchain.python-version != 3.14 }}
         uses: cpp-linter/cpp-linter-action@77c390c5ba9c947ebc185a3e49cc754f1558abb5 # v2.18.0
         id: clang
         env:
@@ -146,7 +145,6 @@ jobs:
           tidy-checks: "-*"
 
       - name: Clang summary
-        if: ${{ matrix.toolchain.python-version != 3.14 }}
         env:
           clang-threshold: 0
         run: |
@@ -205,7 +203,6 @@ jobs:
           mv StaticMode.h firmware/include/modes
 
       - name: Clang format
-        if: ${{ matrix.toolchain.python-version != 3.14 }}
         uses: cpp-linter/cpp-linter-action@77c390c5ba9c947ebc185a3e49cc754f1558abb5 # v2.18.0
         id: clang
         env:
@@ -219,7 +216,6 @@ jobs:
           tidy-checks: "-*"
 
       - name: Clang summary
-        if: ${{ matrix.toolchain.python-version != 3.14 }}
         env:
           clang-threshold: 0
         run: |

--- a/extra/Python/ModeGenerator.py
+++ b/extra/Python/ModeGenerator.py
@@ -48,25 +48,25 @@ class ModeGenerator:
             f"class {self.id}Mode final : public ModeModule",
             "{",
             "private:",
-            "    unsigned long lastMillis = 0;",
-            "",
-            "    uint8_t index = 0;",
-            "",
-            f"    static constexpr std::array<std::array<uint16_t, {self.rows}>, {count // self.rows}> frames{{{{",
+            f"    static constexpr std::array<std::array<uint16_t, {self.rows}U>, {count // self.rows}U> frames{{{{",
         ]
         with self.path.open(newline="") as animation:
             for i, row in enumerate(csv.reader(animation)):
                 if i % self.rows == 0:
                     frames.append("        {")
-                frames.append(f"            0b{self._bits(row)},")
+                frames.append(f"            0b{self._bits(row)}U,")
                 if i % self.rows == self.rows - 1:
                     frames.append("        },")
         frames.extend(
             [
                 "    }};",
                 "",
+                "    size_t index{0U};",
+                "",
+                "    unsigned long lastMillis{0UL};",
+                "",
                 "public:",
-                f'    static constexpr std::string_view name = "{self.name}";',
+                f'    static constexpr std::string_view name{{"{self.name}"}};',
                 "",
                 f"    explicit {self.id}Mode() : ModeModule(name) {{}};",
                 "",
@@ -96,16 +96,16 @@ class ModeGenerator:
                         "",
                         f"void {self.id}Mode::handle()",
                         "{",
-                        "    if (millis() - lastMillis >= 500)",
+                        "    if (millis() - lastMillis >= 500U)",
                         "    {",
                         "        lastMillis = millis();",
                         "        Display.clearFrame();",
                         "        const BitmapHandler bitmap(frames[index]);",
-                        "        bitmap.draw(GRID_COLUMNS - bitmap.getWidth(), 0);",
+                        "        bitmap.draw(GRID_COLUMNS - bitmap.getWidth(), 0U);",
                         "        ++index;",
                         "        if (index >= frames.size())",
                         "        {",
-                        "            index = 0;",
+                        "            index = 0U;",
                         "        }",
                         "    }",
                         "}",
@@ -130,17 +130,17 @@ class ModeGenerator:
             f"class {self.id}Mode final : public ModeModule",
             "{",
             "private:",
-            f"    static constexpr std::array<uint16_t, {count}> frame{{",
+            f"    static constexpr std::array<uint16_t, {count}U> frame{{",
         ]
         with self.path.open(newline="") as drawing:
             for row in csv.reader(drawing):
-                frame.append(f"        0b{self._bits(row)},")
+                frame.append(f"        0b{self._bits(row)}U,")
         frame.extend(
             [
                 "    };",
                 "",
                 "public:",
-                f'    static constexpr std::string_view name = "{self.name}";',
+                f'    static constexpr std::string_view name{{"{self.name}"}};',
                 "",
                 f"    explicit {self.id}Mode() : ModeModule(name) {{}};",
                 "",
@@ -172,7 +172,7 @@ class ModeGenerator:
                         "{",
                         "    Display.clearFrame();",
                         "    const BitmapHandler bitmap(frame);",
-                        "    bitmap.draw(GRID_COLUMNS - bitmap.getWidth(), 0);",
+                        "    bitmap.draw(GRID_COLUMNS - bitmap.getWidth(), 0U);",
                         "}",
                         "",
                     ]


### PR DESCRIPTION
Refactor the Mode generator to utilize unsigned types for array sizes and indices, enhancing type safety and preventing potential negative values.

### Key changes
- Updated array size and index declarations to use unsigned types.
- Adjusted related calculations and conditions to ensure compatibility with the new types.

### Impact
These changes improve the robustness of the Mode generator by eliminating the risk of negative indexing, which could lead to runtime errors. This refactor may also enhance performance slightly by allowing the compiler to optimize for unsigned arithmetic.