### PR TITLE
Update bug report template version options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,8 @@ body:
       description: Which version did you encounter the bug on?
       options:
         - main branch (development)
-        - v2.4.1 (latest release)
+        - v2.5.0 (latest release)
+        - v2.4.1
         - v2.4.0
         - v2.3.2
         - v2.3.1
@@ -23,14 +24,7 @@ body:
         - v2.2.0
         - v2.1.0
         - v2.0.0
-        - v1.3.1
-        - v1.3.0
-        - v1.2.0
-        - v1.1.1
-        - v1.1.0
-        - v1.0.1
-        - v1.0.0
-        - Other (please specify below)
+        - Fork/other (please elaborate below)
 
   - type: textarea
     id: bug-summary


### PR DESCRIPTION
The bug report template has been updated to reflect the latest version of the software, ensuring users can accurately report issues based on the most recent release.  

### Key changes  
- Updated the version options in the bug report template to include v2.5.0 as the latest release.  
- Removed outdated version options and replaced them with a more general "Fork/other" option for better clarity.  

### Impact  
These changes improve the accuracy of bug reports by aligning the template with the current software version, enhancing the reporting process for users and contributors.