### PR TITLE
Fix Game of Life clock area pixel clearing on initialization

### DIFF
--- a/firmware/src/modes/GameOfLifeMode.cpp
+++ b/firmware/src/modes/GameOfLifeMode.cpp
@@ -40,8 +40,9 @@ void GameOfLifeMode::begin()
         nvs_close(handle);
         if (static_cast<bool>(_clock))
         {
-            clock = std::make_unique<ClockHandler>();
             yMin = 5U;
+            clock = std::make_unique<ClockHandler>();
+            clock->clear();
         }
     }
 }


### PR DESCRIPTION
This pull request addresses a bug where some pixels were not cleared during the initialization of the Game of Life mode when the clock feature is enabled.

### Key changes
- Ensured that the clock area is cleared upon initialization by invoking the `clear()` method on the `ClockHandler`.

### Impact
These changes improve the visual consistency of the Game of Life mode when the clock is active, ensuring that no residual pixels remain from previous states. This enhances the user experience and maintains the expected behavior of the application.

