### PR TITLE
Migrate update check to urllib library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,15 +36,12 @@ where = [
 
 [dependency-groups]
 dependabot = [
-    { include-group = "httpx" },
     { include-group = "packaging" },
+    "httpx==0.28.1",
 ]
 dev = [
     { include-group = "nodejs" },
     { include-group = "ruff" },
-]
-httpx = [
-    "httpx==0.28.1",
 ]
 nodejs = [
     "nodejs-wheel==24.16.0",
@@ -62,7 +59,6 @@ scons = [
     "scons==4.10.1",
 ]
 scripts = [
-    { include-group = "httpx" },
     { include-group = "nodejs" },
     { include-group = "packaging" },
     "python-dotenv==1.2.2",

--- a/scripts/src/components/Dependency.py
+++ b/scripts/src/components/Dependency.py
@@ -1,7 +1,9 @@
-import httpx
+import json
 import logging
 import packaging.version
 import typing
+import urllib.error
+import urllib.request
 
 from ..config.version import VERSION
 
@@ -16,24 +18,25 @@ class Dependency:
         self.project = project
 
     def initialize(self) -> None:
-        local = packaging.version.parse(VERSION)
         try:
-            latest = packaging.version.parse(
-                httpx.get(
-                    "https://api.github.com/repos/VIPnytt/Frekvens/releases/latest",
-                    headers={
-                        "Accept": "application/vnd.github+json",
-                        "User-Agent": f"Frekvens/{VERSION} (+https://github.com/VIPnytt/Frekvens)",
-                        "X-GitHub-Api-Version": "2022-11-28",
-                    },
+            tag = json.load(
+                urllib.request.urlopen(
+                    urllib.request.Request(
+                        "https://api.github.com/repos/VIPnytt/Frekvens/releases/latest",
+                        headers={
+                            "Accept": "application/vnd.github+json",
+                            "User-Agent": f"Frekvens/{VERSION} (+https://github.com/VIPnytt/Frekvens)",
+                            "X-GitHub-Api-Version": "2022-11-28",
+                        },
+                    )
                 )
-                .raise_for_status()
-                .json()["tag_name"]
-            )
+            )["tag_name"]
+            local = packaging.version.parse(VERSION)
+            latest = packaging.version.parse(tag)
             if latest > local:
                 print(
                     f"\033[93m[notice] A new release of Frekvens is available: {local.public} -> {latest.public}\033[0m"
                 )
-                print("Release notes: https://github.com/VIPnytt/Frekvens/releases/latest")
-        except httpx.HTTPError as e:
-            logging.warning("Update check failed: %s", e)
+                print(f"Release notes: https://github.com/VIPnytt/Frekvens/releases/tag/{tag}")
+        except urllib.error.URLError as e:
+            logging.debug("Update check failed: %s", e)

--- a/uv.lock
+++ b/uv.lock
@@ -423,9 +423,6 @@ dev = [
     { name = "nodejs-wheel" },
     { name = "ruff" },
 ]
-httpx = [
-    { name = "httpx" },
-]
 nodejs = [
     { name = "nodejs-wheel" },
 ]
@@ -442,7 +439,6 @@ scons = [
     { name = "scons" },
 ]
 scripts = [
-    { name = "httpx" },
     { name = "nodejs-wheel" },
     { name = "packaging" },
     { name = "python-dotenv" },
@@ -471,14 +467,12 @@ dev = [
     { name = "nodejs-wheel", specifier = "==24.16.0" },
     { name = "ruff", specifier = "==0.15.17" },
 ]
-httpx = [{ name = "httpx", specifier = "==0.28.1" }]
 nodejs = [{ name = "nodejs-wheel", specifier = "==24.16.0" }]
 packaging = [{ name = "packaging", specifier = "==26.2" }]
 platformio = [{ name = "platformio", specifier = "==6.1.19" }]
 ruff = [{ name = "ruff", specifier = "==0.15.17" }]
 scons = [{ name = "scons", specifier = "==4.10.1" }]
 scripts = [
-    { name = "httpx", specifier = "==0.28.1" },
     { name = "nodejs-wheel", specifier = "==24.16.0" },
     { name = "packaging", specifier = "==26.2" },
     { name = "python-dotenv", specifier = "==1.2.2" },


### PR DESCRIPTION
This update replaces the use of the `httpx` library with `urllib` for checking the latest release of the project, improving dependency management and reducing external library reliance.

### Key changes
- Removed `httpx` dependency from the core project.
- Implemented `urllib` for making HTTP requests to fetch the latest release information.

### Impact
These changes streamline the dependency requirements, potentially improving compatibility and reducing maintenance overhead. Users will experience no change in functionality, as the update check behavior remains the same.