### PR TITLE
Fix scan mode movement issue

### DIFF
--- a/firmware/include/modes/ScanMode.h
+++ b/firmware/include/modes/ScanMode.h
@@ -7,9 +7,9 @@
 class ScanMode final : public ModeModule
 {
 private:
-    uint8_t column = 0;
+    uint8_t column{0U};
 
-    unsigned long lastMillis = 0;
+    unsigned long lastMillis{0UL};
 
 public:
     static constexpr std::string_view name{"Scan"};

--- a/firmware/src/modes/ScanMode.cpp
+++ b/firmware/src/modes/ScanMode.cpp
@@ -3,9 +3,10 @@
 #include "modes/ScanMode.h"
 
 #include "config/constants.h" // NOLINT(misc-include-cleaner)
-#include "extensions/MicrophoneExtension.h"
 #include "services/DisplayService.h"
 #include "services/ExtensionsService.h"
+
+static_assert(GRID_COLUMNS >= 3U, __STRING(MODE_SCAN) " is not compatible with this device's display size.");
 
 void ScanMode::handle()
 {
@@ -16,21 +17,21 @@ void ScanMode::handle()
 #endif // EXTENSION_MICROPHONE
     {
         lastMillis = millis();
-        for (uint8_t y = 0; y < GRID_ROWS; ++y)
+        for (uint8_t y{0U}; y < GRID_ROWS; ++y)
         {
             if (column < GRID_COLUMNS)
             {
                 Display.setPixel(column, y);
             }
-            if (column - 2 >= 0)
+            if (column >= 2U)
             {
-                Display.setPixel(column - 2, y, 0);
+                Display.setPixel(column - 2U, y, 0U);
             }
         }
         ++column;
-        if (column - 2 >= GRID_COLUMNS)
+        if (column >= GRID_COLUMNS + 2U)
         {
-            column = 0;
+            column = 0U;
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where the scanner in Scan mode would light up but not move across the screen as intended.

### Key changes
- Adjusted the logic in Scan mode to ensure proper movement of the scanner across the display.

### Impact
These changes enhance the functionality of the Scan mode, ensuring that the scanner behaves as expected, improving user experience. No compatibility issues are introduced.

