### PR TITLE
Fix heap memory leak and reporting of saved Wi-Fi networks

### DIFF
--- a/firmware/include/services/ConnectivityService.h
+++ b/firmware/include/services/ConnectivityService.h
@@ -27,12 +27,12 @@ private:
     void connect(const char *ssid, const char *key);
     void transmit();
 
-    static void onConnected(WiFiEvent_t event, WiFiEventInfo_t info);
-    static void onDisconnected(WiFiEvent_t event, WiFiEventInfo_t info);
-    static void onIPv4(WiFiEvent_t event, WiFiEventInfo_t info);
-    static void onIPv6(WiFiEvent_t event, WiFiEventInfo_t info);
+    static void onConnected(WiFiEvent_t event);
+    static void onDisconnected(WiFiEvent_t event, const WiFiEventInfo_t &info);
+    static void onIPv4(WiFiEvent_t, const WiFiEventInfo_t &info);
+    static void onIPv6(WiFiEvent_t, WiFiEventInfo_t info);
     static void onRoutable();
-    static void onScan(WiFiEvent_t event, WiFiEventInfo_t info);
+    static void onScan(WiFiEvent_t event);
 
 public:
     void configure();

--- a/firmware/include/services/ConnectivityService.h
+++ b/firmware/include/services/ConnectivityService.h
@@ -28,9 +28,9 @@ private:
     void transmit();
 
     static void onConnected(WiFiEvent_t event);
-    static void onDisconnected(WiFiEvent_t event, const WiFiEventInfo_t &info);
-    static void onIPv4(WiFiEvent_t, const WiFiEventInfo_t &info);
-    static void onIPv6(WiFiEvent_t, WiFiEventInfo_t info);
+    static void onDisconnected(WiFiEvent_t event, WiFiEventInfo_t info);
+    static void onIPv4(WiFiEvent_t event, WiFiEventInfo_t info);
+    static void onIPv6(WiFiEvent_t event, WiFiEventInfo_t info);
     static void onRoutable();
     static void onScan(WiFiEvent_t event);
 

--- a/firmware/include/services/ConnectivityService.h
+++ b/firmware/include/services/ConnectivityService.h
@@ -12,11 +12,11 @@ class ConnectivityService final : public ServiceModule
 private:
     explicit ConnectivityService() : ServiceModule("Connectivity") {};
 
-    bool mDNS = false;
-    bool pending = false;
-    bool routable = false;
+    bool mdns{false};
+    bool pending{false};
+    bool routable{false};
 
-    unsigned long lastMillis = 0;
+    unsigned long lastMillis{0UL};
 
     std::unique_ptr<DNSServer> dns{};
 

--- a/firmware/include/services/ConnectivityService.h
+++ b/firmware/include/services/ConnectivityService.h
@@ -27,12 +27,12 @@ private:
     void connect(const char *ssid, const char *key);
     void transmit();
 
-    static void onConnected(WiFiEvent_t event);
-    static void onDisconnected(WiFiEvent_t event, WiFiEventInfo_t info);
-    static void onIPv4(WiFiEvent_t event, WiFiEventInfo_t info);
-    static void onIPv6(WiFiEvent_t event, WiFiEventInfo_t info);
+    static void onConnected(arduino_event_id_t event);
+    static void onDisconnected(arduino_event_id_t event, arduino_event_info_t info);
+    static void onIPv4(arduino_event_id_t event, arduino_event_info_t info);
+    static void onIPv6(arduino_event_id_t event, arduino_event_info_t info);
     static void onRoutable();
-    static void onScan(WiFiEvent_t event);
+    static void onScan(arduino_event_id_t event);
 
 public:
     void configure();

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -210,10 +210,7 @@ void ConnectivityService::onIPv4(arduino_event_id_t event, // NOLINT(misc-unused
                  static_cast<unsigned>((info.got_ip.ip_info.ip.addr >> 8U) & 0xFFU),
                  static_cast<unsigned>((info.got_ip.ip_info.ip.addr >> 16U) & 0xFFU),
                  static_cast<unsigned>((info.got_ip.ip_info.ip.addr >> 24U) & 0xFFU));
-        if (!Connectivity.routable)
-        {
-            onRoutable();
-        }
+        onRoutable();
     }
 }
 
@@ -233,41 +230,41 @@ void ConnectivityService::onIPv6(arduino_event_id_t event, // NOLINT(misc-unused
                  static_cast<unsigned>(__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[2]) & 0xFFFFU),
                  static_cast<unsigned>((__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[3]) >> 16U) & 0xFFFFU),
                  static_cast<unsigned>(__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[3]) & 0xFFFFU));
-        if (!Connectivity.routable)
-        {
-            onRoutable();
-        }
+        onRoutable();
     }
 }
 
 void ConnectivityService::onRoutable()
 {
-    Connectivity.routable = true;
-    if (WiFiClass::getMode() != wifi_mode_t::WIFI_MODE_STA)
+    if (!Connectivity.routable)
     {
-        JsonDocument doc; // NOLINT(misc-const-correctness)
-        doc["event"].set("connected");
-        Device.transmit(doc.as<JsonObjectConst>(), Connectivity.name, false);
-        ESP_LOGD("Wi-Fi", "terminating Wi-Fi hotspot"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        Connectivity.dns.reset();
-        WiFiClass::mode(wifi_mode_t::WIFI_MODE_STA);
-    }
-    if (!Connectivity.mdns && MDNS.begin(HOSTNAME))
-    {
-        Connectivity.mdns = true;
-        MDNS.setInstanceName(NAME);
+        Connectivity.routable = true;
+        if (WiFiClass::getMode() != wifi_mode_t::WIFI_MODE_STA)
+        {
+            JsonDocument doc; // NOLINT(misc-const-correctness)
+            doc["event"].set("connected");
+            Device.transmit(doc.as<JsonObjectConst>(), Connectivity.name, false);
+            ESP_LOGD("Wi-Fi", "terminating Wi-Fi hotspot"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+            Connectivity.dns.reset();
+            WiFiClass::mode(wifi_mode_t::WIFI_MODE_STA);
+        }
+        if (!Connectivity.mdns && MDNS.begin(HOSTNAME))
+        {
+            Connectivity.mdns = true;
+            MDNS.setInstanceName(NAME);
 #if EXTENSION_ALEXA
-        AlexaExtension::onMdns();
+            AlexaExtension::onMdns();
 #endif // EXTENSION_ALEXA
 #if EXTENSION_RESTFUL || EXTENSION_WEBAPP
-        MDNS.addService("http", "tcp", 80U);
+            MDNS.addService("http", "tcp", 80U);
 #endif
 #if EXTENSION_WEBSOCKET
-        MDNS.addService("ws", "tcp", 80U);
+            MDNS.addService("ws", "tcp", 80U);
 #endif // EXTENSION_WEBSOCKET
+        }
+        timeval tv{};
+        sntp_sync_time(&tv);
     }
-    timeval tv{};
-    sntp_sync_time(&tv);
 }
 
 void ConnectivityService::onScan(arduino_event_id_t event) // NOLINT(misc-unused-parameters)

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -204,7 +204,7 @@ void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parame
 {
     if (WiFi.STA.hasIP())
     {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-pro-type-cstyle-cast)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-vararg)
         ESP_LOGI("Wi-Fi", "IPv4 " IPSTR, IP2STR(&info.got_ip.ip_info.ip));
         if (!Connectivity.routable)
         {
@@ -218,6 +218,7 @@ void ConnectivityService::onIPv6(WiFiEvent_t event, // NOLINT(misc-unused-parame
 {
     if (WiFi.STA.hasGlobalIPv6())
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
         ESP_LOGI("Wi-Fi", "IPv6 " IPV6STR, IPV62STR(info.got_ip6.ip6_info));
         if (!Connectivity.routable)
         {

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -162,7 +162,7 @@ void ConnectivityService::connect(const char *ssid, const char *key) // NOLINT(b
     multi.run();
 }
 
-void ConnectivityService::onConnected(WiFiEvent_t)
+void ConnectivityService::onConnected(WiFiEvent_t event) // NOLINT(misc-unused-parameters)
 {
     ESP_LOGD("Wi-Fi", "connected");           // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     ESP_LOGV("Wi-Fi", "%d dBm", WiFi.RSSI()); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
@@ -183,7 +183,8 @@ void ConnectivityService::onConnected(WiFiEvent_t)
 #endif // WIFI_COUNTRY
 }
 
-void ConnectivityService::onDisconnected(WiFiEvent_t, const WiFiEventInfo_t &info)
+void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
+                                         WiFiEventInfo_t info)
 {
     Connectivity.routable = false;
     if (Connectivity.mdns)
@@ -197,7 +198,8 @@ void ConnectivityService::onDisconnected(WiFiEvent_t, const WiFiEventInfo_t &inf
         "Wi-Fi", "%s", WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason)));
 }
 
-void ConnectivityService::onIPv4(WiFiEvent_t, const WiFiEventInfo_t &info)
+void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
+                                 WiFiEventInfo_t info)
 {
     if (WiFi.STA.hasIP())
     {
@@ -210,7 +212,8 @@ void ConnectivityService::onIPv4(WiFiEvent_t, const WiFiEventInfo_t &info)
     }
 }
 
-void ConnectivityService::onIPv6(WiFiEvent_t, WiFiEventInfo_t info)
+void ConnectivityService::onIPv6(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
+                                 WiFiEventInfo_t info)
 {
     if (WiFi.STA.hasGlobalIPv6())
     {
@@ -253,7 +256,7 @@ void ConnectivityService::onRoutable()
     sntp_sync_time(&tv);
 }
 
-void ConnectivityService::onScan(WiFiEvent_t)
+void ConnectivityService::onScan(WiFiEvent_t event) // NOLINT(misc-unused-parameters)
 {
     const int16_t count{WiFi.scanComplete()};
     if (count > 0)
@@ -302,7 +305,8 @@ void ConnectivityService::transmit()
     Device.transmit(doc.as<JsonObjectConst>(), name);
 }
 
-void ConnectivityService::onReceive(JsonObjectConst payload, std::string_view)
+void ConnectivityService::onReceive(JsonObjectConst payload,
+                                    std::string_view source) // NOLINT(misc-unused-parameters)
 {
     // Connect
     if (payload["ssid"].is<const char *>())

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -257,7 +257,7 @@ void ConnectivityService::onRoutable()
 #endif // EXTENSION_ALEXA
 #if EXTENSION_RESTFUL || EXTENSION_WEBAPP
             MDNS.addService("http", "tcp", 80U);
-#endif
+#endif // EXTENSION_RESTFUL || EXTENSION_WEBAPP
 #if EXTENSION_WEBSOCKET
             MDNS.addService("ws", "tcp", 80U);
 #endif // EXTENSION_WEBSOCKET

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -29,7 +29,7 @@ void ConnectivityService::configure()
     esp_wifi_set_country_code(WIFI_COUNTRY, false);
 #else
     nvs_handle_t handle{};
-    if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
+    if (nvs_open(name.data(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
     {
         std::array<char, 3U> country{};
         size_t length{country.size()}; // NOLINT(cppcoreguidelines-init-variables)
@@ -84,7 +84,7 @@ void ConnectivityService::initStation()
 {
     JsonDocument doc; // NOLINT(misc-const-correctness)
     nvs_handle_t handle{};
-    if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
+    if (nvs_open(name.data(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
     {
         size_t _length{0U};
         if (nvs_get_blob(handle, "Wi-Fi", nullptr, &_length) == ESP_OK && _length != 0U)
@@ -118,7 +118,7 @@ void ConnectivityService::initStation()
     const size_t length{measureJson(doc) + 1U};
     std::vector<char> buffer(length);
     serializeJson(doc, reinterpret_cast<char *>(buffer.data()), length);
-    if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
+    if (nvs_open(name.data(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
     {
         nvs_set_blob(handle, "Wi-Fi", buffer.data(), length);
         nvs_commit(handle);
@@ -172,7 +172,7 @@ void ConnectivityService::onConnected(WiFiEvent_t event,    // NOLINT(misc-unuse
     nvs_handle_t handle{};
     std::array<char, 3U> country{};
     if (esp_wifi_get_country_code(country.data()) == ESP_OK &&
-        nvs_open(std::string(Connectivity.name).c_str(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
+        nvs_open(Connectivity.name.data(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
     {
         if (strncmp(country.data(), "01", 2U) == 0 ? nvs_erase_key(handle, "country") == ESP_OK
                                                    : nvs_set_str(handle, "country", country.data()) == ESP_OK)
@@ -199,7 +199,8 @@ void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unuse
         "Wi-Fi", "%s", WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason)));
 }
 
-void ConnectivityService::onIPv4(WiFiEvent_t event, WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
+void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
+                                 WiFiEventInfo_t info)
 {
     if (WiFi.STA.hasIP())
     {
@@ -282,7 +283,7 @@ void ConnectivityService::transmit()
     doc["rssi"].set(WiFi.RSSI());
     {
         nvs_handle_t handle{};
-        if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
+        if (nvs_open(name.data(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
         {
             size_t length{0U};
             if (nvs_get_blob(handle, "Wi-Fi", nullptr, &length) == ESP_OK && length != 0U)

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -162,8 +162,7 @@ void ConnectivityService::connect(const char *ssid, const char *key) // NOLINT(b
     multi.run();
 }
 
-void ConnectivityService::onConnected(WiFiEvent_t event,    // NOLINT(misc-unused-parameters)
-                                      WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
+void ConnectivityService::onConnected(WiFiEvent_t)
 {
     ESP_LOGD("Wi-Fi", "connected");           // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     ESP_LOGV("Wi-Fi", "%d dBm", WiFi.RSSI()); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
@@ -184,8 +183,7 @@ void ConnectivityService::onConnected(WiFiEvent_t event,    // NOLINT(misc-unuse
 #endif // WIFI_COUNTRY
 }
 
-void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
-                                         WiFiEventInfo_t info)
+void ConnectivityService::onDisconnected(WiFiEvent_t, const WiFiEventInfo_t &info)
 {
     Connectivity.routable = false;
     if (Connectivity.mdns)
@@ -199,8 +197,7 @@ void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unuse
         "Wi-Fi", "%s", WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason)));
 }
 
-void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
-                                 WiFiEventInfo_t info)
+void ConnectivityService::onIPv4(WiFiEvent_t, const WiFiEventInfo_t &info)
 {
     if (WiFi.STA.hasIP())
     {
@@ -213,8 +210,7 @@ void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parame
     }
 }
 
-void ConnectivityService::onIPv6(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
-                                 WiFiEventInfo_t info)
+void ConnectivityService::onIPv6(WiFiEvent_t, WiFiEventInfo_t info)
 {
     if (WiFi.STA.hasGlobalIPv6())
     {
@@ -257,8 +253,7 @@ void ConnectivityService::onRoutable()
     sntp_sync_time(&tv);
 }
 
-void ConnectivityService::onScan(WiFiEvent_t event,    // NOLINT(misc-unused-parameters)
-                                 WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
+void ConnectivityService::onScan(WiFiEvent_t)
 {
     const int16_t count{WiFi.scanComplete()};
     if (count > 0)
@@ -307,8 +302,7 @@ void ConnectivityService::transmit()
     Device.transmit(doc.as<JsonObjectConst>(), name);
 }
 
-void ConnectivityService::onReceive(JsonObjectConst payload,
-                                    std::string_view source) // NOLINT(misc-unused-parameters)
+void ConnectivityService::onReceive(JsonObjectConst payload, std::string_view)
 {
     // Connect
     if (payload["ssid"].is<const char *>())

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -204,7 +204,7 @@ void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parame
 {
     if (WiFi.STA.hasIP())
     {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-vararg)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-vararg,hicpp-vararg)
         ESP_LOGI("Wi-Fi", "IPv4 " IPSTR, IP2STR(&info.got_ip.ip_info.ip));
         if (!Connectivity.routable)
         {
@@ -218,7 +218,7 @@ void ConnectivityService::onIPv6(WiFiEvent_t event, // NOLINT(misc-unused-parame
 {
     if (WiFi.STA.hasGlobalIPv6())
     {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
         ESP_LOGI("Wi-Fi", "IPv6 " IPV6STR, IPV62STR(info.got_ip6.ip6_info));
         if (!Connectivity.routable)
         {

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -199,19 +199,13 @@ void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unuse
         "Wi-Fi", "%s", WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason)));
 }
 
-void ConnectivityService::onIPv4(WiFiEvent_t event,    // NOLINT(misc-unused-parameters)
-                                 WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
+void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
+                                 WiFiEventInfo_t info)
 {
     if (WiFi.STA.hasIP())
     {
-        const IPAddress ipv4 = WiFi.STA.localIP();
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-        ESP_LOGI("Wi-Fi",
-                 "IPv4 %u.%u.%u.%u",
-                 static_cast<unsigned>(ipv4[0]),
-                 static_cast<unsigned>(ipv4[1]),
-                 static_cast<unsigned>(ipv4[2]),
-                 static_cast<unsigned>(ipv4[3]));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        ESP_LOGI("Wi-Fi", "IPv4 " IPSTR, IP2STR(&info.got_ip.ip_info.ip));
         if (!Connectivity.routable)
         {
             onRoutable();
@@ -219,23 +213,13 @@ void ConnectivityService::onIPv4(WiFiEvent_t event,    // NOLINT(misc-unused-par
     }
 }
 
-void ConnectivityService::onIPv6(WiFiEvent_t event,    // NOLINT(misc-unused-parameters)
-                                 WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
+void ConnectivityService::onIPv6(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
+                                 WiFiEventInfo_t info)
 {
     if (WiFi.STA.hasGlobalIPv6())
     {
-        const IPAddress ipv6 = WiFi.STA.globalIPv6();
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-        ESP_LOGI("Wi-Fi",
-                 "IPv6 %x:%x:%x:%x:%x:%x:%x:%x",
-                 (static_cast<unsigned>(ipv6[0]) << 8U) | static_cast<unsigned>(ipv6[1]),
-                 (static_cast<unsigned>(ipv6[2]) << 8U) | static_cast<unsigned>(ipv6[3]),
-                 (static_cast<unsigned>(ipv6[4]) << 8U) | static_cast<unsigned>(ipv6[5]),
-                 (static_cast<unsigned>(ipv6[6]) << 8U) | static_cast<unsigned>(ipv6[7]),
-                 (static_cast<unsigned>(ipv6[8]) << 8U) | static_cast<unsigned>(ipv6[9]),
-                 (static_cast<unsigned>(ipv6[10]) << 8U) | static_cast<unsigned>(ipv6[11]),
-                 (static_cast<unsigned>(ipv6[12]) << 8U) | static_cast<unsigned>(ipv6[13]),
-                 (static_cast<unsigned>(ipv6[14]) << 8U) | static_cast<unsigned>(ipv6[15]));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        ESP_LOGI("Wi-Fi", "IPv6 " IPV6STR, IPV62STR(info.got_ip6.ip6_info));
         if (!Connectivity.routable)
         {
             onRoutable();

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -203,8 +203,13 @@ void ConnectivityService::onIPv4(arduino_event_id_t event, // NOLINT(misc-unused
 {
     if (WiFi.STA.hasIP())
     {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        ESP_LOGI("Wi-Fi", "IPv4 " IPSTR, IP2STR(&info.got_ip.ip_info.ip));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        ESP_LOGI("Wi-Fi",
+                 "IPv4 %u.%u.%u.%u",
+                 static_cast<unsigned>(info.got_ip.ip_info.ip.addr & 0xFFU),
+                 static_cast<unsigned>((info.got_ip.ip_info.ip.addr >> 8U) & 0xFFU),
+                 static_cast<unsigned>((info.got_ip.ip_info.ip.addr >> 16U) & 0xFFU),
+                 static_cast<unsigned>((info.got_ip.ip_info.ip.addr >> 24U) & 0xFFU));
         if (!Connectivity.routable)
         {
             onRoutable();
@@ -218,7 +223,16 @@ void ConnectivityService::onIPv6(arduino_event_id_t event, // NOLINT(misc-unused
     if (WiFi.STA.hasGlobalIPv6())
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        ESP_LOGI("Wi-Fi", "IPv6 " IPV6STR, IPV62STR(info.got_ip6.ip6_info.ip));
+        ESP_LOGI("Wi-Fi",
+                 "IPv6 %x:%x:%x:%x:%x:%x:%x:%x",
+                 static_cast<unsigned>((__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[0]) >> 16U) & 0xFFFFU),
+                 static_cast<unsigned>(__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[0]) & 0xFFFFU),
+                 static_cast<unsigned>((__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[1]) >> 16U) & 0xFFFFU),
+                 static_cast<unsigned>(__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[1]) & 0xFFFFU),
+                 static_cast<unsigned>((__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[2]) >> 16U) & 0xFFFFU),
+                 static_cast<unsigned>(__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[2]) & 0xFFFFU),
+                 static_cast<unsigned>((__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[3]) >> 16U) & 0xFFFFU),
+                 static_cast<unsigned>(__builtin_bswap32(info.got_ip6.ip6_info.ip.addr[3]) & 0xFFFFU));
         if (!Connectivity.routable)
         {
             onRoutable();

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -202,21 +202,40 @@ void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unuse
 void ConnectivityService::onIPv4(WiFiEvent_t event,    // NOLINT(misc-unused-parameters)
                                  WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
 {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-    ESP_LOGI("Wi-Fi", "IPv4 %s", WiFi.localIP().toString().c_str()); // NOLINT(hicpp-vararg)
-    if (!Connectivity.routable)
+    if (WiFi.STA.hasIP())
     {
-        onRoutable();
+        const IPAddress ipv4 = WiFi.STA.localIP();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        ESP_LOGI("Wi-Fi",
+                 "IPv4 %u.%u.%u.%u",
+                 static_cast<unsigned>(ipv4[0]),
+                 static_cast<unsigned>(ipv4[1]),
+                 static_cast<unsigned>(ipv4[2]),
+                 static_cast<unsigned>(ipv4[3]));
+        if (!Connectivity.routable)
+        {
+            onRoutable();
+        }
     }
 }
 
 void ConnectivityService::onIPv6(WiFiEvent_t event,    // NOLINT(misc-unused-parameters)
                                  WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
 {
-    const char *const ipv6{WiFi.globalIPv6().toString().c_str()};
-    if (strcmp(ipv6, "") != 0)
+    if (WiFi.STA.hasGlobalIPv6())
     {
-        ESP_LOGI("Wi-Fi", "IPv6 %s", ipv6); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        const IPAddress ipv6 = WiFi.STA.globalIPv6();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        ESP_LOGI("Wi-Fi",
+                 "IPv6 %x:%x:%x:%x:%x:%x:%x:%x",
+                 (static_cast<unsigned>(ipv6[0]) << 8U) | static_cast<unsigned>(ipv6[1]),
+                 (static_cast<unsigned>(ipv6[2]) << 8U) | static_cast<unsigned>(ipv6[3]),
+                 (static_cast<unsigned>(ipv6[4]) << 8U) | static_cast<unsigned>(ipv6[5]),
+                 (static_cast<unsigned>(ipv6[6]) << 8U) | static_cast<unsigned>(ipv6[7]),
+                 (static_cast<unsigned>(ipv6[8]) << 8U) | static_cast<unsigned>(ipv6[9]),
+                 (static_cast<unsigned>(ipv6[10]) << 8U) | static_cast<unsigned>(ipv6[11]),
+                 (static_cast<unsigned>(ipv6[12]) << 8U) | static_cast<unsigned>(ipv6[13]),
+                 (static_cast<unsigned>(ipv6[14]) << 8U) | static_cast<unsigned>(ipv6[15]));
         if (!Connectivity.routable)
         {
             onRoutable();

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -204,7 +204,7 @@ void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parame
 {
     if (WiFi.STA.hasIP())
     {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-pro-type-cstyle-cast)
         ESP_LOGI("Wi-Fi", "IPv4 " IPSTR, IP2STR(&info.got_ip.ip_info.ip));
         if (!Connectivity.routable)
         {
@@ -218,7 +218,6 @@ void ConnectivityService::onIPv6(WiFiEvent_t event, // NOLINT(misc-unused-parame
 {
     if (WiFi.STA.hasGlobalIPv6())
     {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
         ESP_LOGI("Wi-Fi", "IPv6 " IPV6STR, IPV62STR(info.got_ip6.ip6_info));
         if (!Connectivity.routable)
         {

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -32,7 +32,7 @@ void ConnectivityService::configure()
     if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
     {
         std::array<char, 3U> country{};
-        size_t length{country.size()};
+        size_t length{country.size()}; // NOLINT(cppcoreguidelines-init-variables)
         if (nvs_get_str(handle, "country", country.data(), &length) == ESP_OK && length == country.size())
         {
             esp_wifi_set_country_code(country.data(), true);

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -20,11 +20,11 @@ void ConnectivityService::configure()
     WiFiClass::setHostname(HOSTNAME);
     WiFiClass::mode(wifi_mode_t::WIFI_MODE_STA);
     WiFi.enableIPv6();
-    WiFi.onEvent(&onConnected, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_CONNECTED);
-    WiFi.onEvent(&onDisconnected, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
-    WiFi.onEvent(&onIPv4, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
-    WiFi.onEvent(&onIPv6, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP6);
-    WiFi.onEvent(&onScan, WiFiEvent_t::ARDUINO_EVENT_WIFI_SCAN_DONE);
+    WiFi.onEvent(&onConnected, arduino_event_id_t::ARDUINO_EVENT_WIFI_STA_CONNECTED);
+    WiFi.onEvent(&onDisconnected, arduino_event_id_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+    WiFi.onEvent(&onIPv4, arduino_event_id_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
+    WiFi.onEvent(&onIPv6, arduino_event_id_t::ARDUINO_EVENT_WIFI_STA_GOT_IP6);
+    WiFi.onEvent(&onScan, arduino_event_id_t::ARDUINO_EVENT_WIFI_SCAN_DONE);
 #ifdef WIFI_COUNTRY
     esp_wifi_set_country_code(WIFI_COUNTRY, false);
 #else
@@ -162,7 +162,7 @@ void ConnectivityService::connect(const char *ssid, const char *key) // NOLINT(b
     multi.run();
 }
 
-void ConnectivityService::onConnected(WiFiEvent_t event) // NOLINT(misc-unused-parameters)
+void ConnectivityService::onConnected(arduino_event_id_t event) // NOLINT(misc-unused-parameters)
 {
     ESP_LOGD("Wi-Fi", "connected");           // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     ESP_LOGV("Wi-Fi", "%d dBm", WiFi.RSSI()); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
@@ -183,8 +183,8 @@ void ConnectivityService::onConnected(WiFiEvent_t event) // NOLINT(misc-unused-p
 #endif // WIFI_COUNTRY
 }
 
-void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
-                                         WiFiEventInfo_t info)
+void ConnectivityService::onDisconnected(arduino_event_id_t event, // NOLINT(misc-unused-parameters)
+                                         arduino_event_info_t info)
 {
     Connectivity.routable = false;
     if (Connectivity.mdns)
@@ -198,8 +198,8 @@ void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unuse
         "Wi-Fi", "%s", WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason)));
 }
 
-void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
-                                 WiFiEventInfo_t info)
+void ConnectivityService::onIPv4(arduino_event_id_t event, // NOLINT(misc-unused-parameters)
+                                 arduino_event_info_t info)
 {
     if (WiFi.STA.hasIP())
     {
@@ -212,13 +212,13 @@ void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parame
     }
 }
 
-void ConnectivityService::onIPv6(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
-                                 WiFiEventInfo_t info)
+void ConnectivityService::onIPv6(arduino_event_id_t event, // NOLINT(misc-unused-parameters)
+                                 arduino_event_info_t info)
 {
     if (WiFi.STA.hasGlobalIPv6())
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        ESP_LOGI("Wi-Fi", "IPv6 " IPV6STR, IPV62STR(info.got_ip6.ip6_info));
+        ESP_LOGI("Wi-Fi", "IPv6 " IPV6STR, IPV62STR(info.got_ip6.ip6_info.ip));
         if (!Connectivity.routable)
         {
             onRoutable();
@@ -256,7 +256,7 @@ void ConnectivityService::onRoutable()
     sntp_sync_time(&tv);
 }
 
-void ConnectivityService::onScan(WiFiEvent_t event) // NOLINT(misc-unused-parameters)
+void ConnectivityService::onScan(arduino_event_id_t event) // NOLINT(misc-unused-parameters)
 {
     const int16_t count{WiFi.scanComplete()};
     if (count > 0)

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -31,17 +31,13 @@ void ConnectivityService::configure()
     nvs_handle_t handle{};
     if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
     {
-        std::array<char, 3> country{};
-        size_t len{country.size()}; // NOLINT(cppcoreguidelines-init-variables)
-        if (nvs_get_str(handle, "country", country.data(), &len) == ESP_OK)
+        std::array<char, 3U> country{};
+        size_t length{country.size()};
+        if (nvs_get_str(handle, "country", country.data(), &length) == ESP_OK && length == country.size())
         {
-            nvs_close(handle);
             esp_wifi_set_country_code(country.data(), true);
         }
-        else
-        {
-            nvs_close(handle);
-        }
+        nvs_close(handle);
     }
 #endif // WIFI_COUNTRY
 #if defined(PIN_SW1) || defined(PIN_SW2)
@@ -90,45 +86,41 @@ void ConnectivityService::initStation()
     nvs_handle_t handle{};
     if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
     {
-        size_t _len{0};
-        if (nvs_get_blob(handle, "Wi-Fi", nullptr, &_len) == ESP_OK && _len > 0)
+        size_t _length{0U};
+        if (nvs_get_blob(handle, "Wi-Fi", nullptr, &_length) == ESP_OK && _length != 0U)
         {
-            std::vector<char> _buffer(_len);
-            if (nvs_get_blob(handle, "Wi-Fi", _buffer.data(), &_len) == ESP_OK)
+            std::vector<char> _buffer(_length);
+            if (nvs_get_blob(handle, "Wi-Fi", _buffer.data(), &_length) == ESP_OK)
             {
-                nvs_close(handle);
-                deserializeJson(doc, _buffer.data(), _len);
-            }
-            else
-            {
-                nvs_close(handle);
+                deserializeJson(doc, _buffer.data(), _length);
             }
         }
+        nvs_close(handle);
     }
     wifi_config_t config;
     if (esp_wifi_get_config(wifi_interface_t::WIFI_IF_STA, &config) == ESP_OK)
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        const char *const ssid_ptr = reinterpret_cast<const char *>(config.sta.ssid);
+        const char *const ssid_ptr{reinterpret_cast<const char *>(config.sta.ssid)};
         const std::string_view ssid(ssid_ptr, strnlen(ssid_ptr, sizeof(config.sta.ssid)));
         if (!ssid.empty())
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            const char *const key_ptr = reinterpret_cast<const char *>(config.sta.password);
+            const char *const key_ptr{reinterpret_cast<const char *>(config.sta.password)};
             const std::string_view key(key_ptr, strnlen(key_ptr, sizeof(config.sta.password)));
-            doc[ssid] = key.length() ? key : nullptr;
+            doc[ssid].set(key.length() ? key : nullptr);
         }
     }
     if (doc[WIFI_SSID].isUnbound())
     {
-        doc[WIFI_SSID] = WIFI_KEY;
+        doc[WIFI_SSID].set(WIFI_KEY);
     }
-    const size_t len = measureJson(doc);
-    std::vector<uint8_t> buffer(len + 1);
-    serializeJson(doc, reinterpret_cast<char *>(buffer.data()), len + 1);
+    const size_t length{measureJson(doc) + 1U};
+    std::vector<char> buffer(length);
+    serializeJson(doc, reinterpret_cast<char *>(buffer.data()), length);
     if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
     {
-        nvs_set_blob(handle, "Wi-Fi", buffer.data(), len + 1);
+        nvs_set_blob(handle, "Wi-Fi", buffer.data(), length);
         nvs_commit(handle);
         nvs_close(handle);
     }
@@ -148,7 +140,7 @@ void ConnectivityService::initHotspot()
     {
         dns = std::make_unique<DNSServer>();
         dns->setErrorReplyCode(DNSReplyCode::NoError);
-        dns->start(53, "*", WiFi.softAPIP());
+        dns->start(53U, "*", WiFi.softAPIP());
     }
 #if EXTENSION_WEBAPP
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
@@ -178,12 +170,12 @@ void ConnectivityService::onConnected(WiFiEvent_t event,    // NOLINT(misc-unuse
     ESP_LOGI("Wi-Fi", HOSTNAME ".local");     // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 #ifndef WIFI_COUNTRY
     nvs_handle_t handle{};
-    std::array<char, 3> country{};
+    std::array<char, 3U> country{};
     if (esp_wifi_get_country_code(country.data()) == ESP_OK &&
-        nvs_open(Connectivity.name.data(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
+        nvs_open(std::string(Connectivity.name).c_str(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
     {
-        if (strncmp(country.data(), "01", 2) == 0 ? nvs_erase_key(handle, "country") == ESP_OK
-                                                  : nvs_set_str(handle, "country", country.data()) == ESP_OK)
+        if (strncmp(country.data(), "01", 2U) == 0 ? nvs_erase_key(handle, "country") == ESP_OK
+                                                   : nvs_set_str(handle, "country", country.data()) == ESP_OK)
         {
             nvs_commit(handle);
         }
@@ -196,10 +188,10 @@ void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unuse
                                          WiFiEventInfo_t info)
 {
     Connectivity.routable = false;
-    if (Connectivity.mDNS)
+    if (Connectivity.mdns)
     {
         MDNS.end();
-        Connectivity.mDNS = false;
+        Connectivity.mdns = false;
     }
     ESP_LOGI("Wi-Fi", "disconnected"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
                                        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
@@ -221,7 +213,7 @@ void ConnectivityService::onIPv4(WiFiEvent_t event,    // NOLINT(misc-unused-par
 void ConnectivityService::onIPv6(WiFiEvent_t event,    // NOLINT(misc-unused-parameters)
                                  WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
 {
-    const char *const ipv6 = WiFi.globalIPv6().toString().c_str();
+    const char *const ipv6{WiFi.globalIPv6().toString().c_str()};
     if (strcmp(ipv6, "") != 0)
     {
         ESP_LOGI("Wi-Fi", "IPv6 %s", ipv6); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
@@ -244,18 +236,18 @@ void ConnectivityService::onRoutable()
         Connectivity.dns.reset();
         WiFiClass::mode(wifi_mode_t::WIFI_MODE_STA);
     }
-    if (!Connectivity.mDNS && MDNS.begin(HOSTNAME))
+    if (!Connectivity.mdns && MDNS.begin(HOSTNAME))
     {
-        Connectivity.mDNS = true;
+        Connectivity.mdns = true;
         MDNS.setInstanceName(NAME);
 #if EXTENSION_ALEXA
         AlexaExtension::onMdns();
 #endif // EXTENSION_ALEXA
 #if EXTENSION_RESTFUL || EXTENSION_WEBAPP
-        MDNS.addService("http", "tcp", 80);
+        MDNS.addService("http", "tcp", 80U);
 #endif
 #if EXTENSION_WEBSOCKET
-        MDNS.addService("ws", "tcp", 80);
+        MDNS.addService("ws", "tcp", 80U);
 #endif // EXTENSION_WEBSOCKET
     }
     timeval tv{};
@@ -265,12 +257,12 @@ void ConnectivityService::onRoutable()
 void ConnectivityService::onScan(WiFiEvent_t event,    // NOLINT(misc-unused-parameters)
                                  WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
 {
-    const int16_t count = WiFi.scanComplete();
+    const int16_t count{WiFi.scanComplete()};
     if (count > 0)
     {
         JsonDocument doc; // NOLINT(misc-const-correctness)
         JsonArray scan{doc["scan"].to<JsonArray>()};
-        for (int16_t i = 0; i < count; ++i)
+        for (int16_t i{0}; i < count; ++i)
         {
             JsonObject _scan{scan.add<JsonObject>()};
             _scan["encrypted"].set(WiFi.encryptionType(i) != wifi_auth_mode_t::WIFI_AUTH_OPEN);
@@ -290,28 +282,22 @@ void ConnectivityService::transmit()
         nvs_handle_t handle{};
         if (nvs_open(std::string(name).c_str(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
         {
-            size_t len{0};
-            if (nvs_get_blob(handle, "saved", nullptr, &len) == ESP_OK && len > 0)
+            size_t length{0U};
+            if (nvs_get_blob(handle, "Wi-Fi", nullptr, &length) == ESP_OK && length != 0U)
             {
-                std::vector<uint8_t> buffer(len);
-                if (nvs_get_blob(handle, "Wi-Fi", &buffer, &len) == ESP_OK)
+                JsonDocument _saved; // NOLINT(misc-const-correctness)
+                std::vector<char> buffer(length);
+                if (nvs_get_blob(handle, "Wi-Fi", buffer.data(), &length) == ESP_OK &&
+                    deserializeJson(_saved, buffer.data(), length) == DeserializationError::Code::Ok)
                 {
-                    nvs_close(handle);
-                    JsonDocument _saved; // NOLINT(misc-const-correctness)
-                    if (deserializeJson(_saved, buffer.data(), len) == DeserializationError::Code::Ok)
+                    JsonArray saved{doc["saved"].to<JsonArray>()};
+                    for (const JsonPairConst pair : _saved.as<JsonObjectConst>())
                     {
-                        JsonArray saved{doc["saved"].to<JsonArray>()};
-                        for (const JsonPairConst pair : _saved.as<JsonObjectConst>())
-                        {
-                            saved.add(pair.key());
-                        }
+                        saved.add(pair.key());
                     }
                 }
-                else
-                {
-                    nvs_close(handle);
-                }
             }
+            nvs_close(handle);
         }
     }
     doc["ssid"].set(WiFi.SSID());
@@ -365,4 +351,4 @@ ConnectivityService &ConnectivityService::getInstance()
 }
 
 // NOLINTNEXTLINE(bugprone-throwing-static-initialization,cert-err58-cpp,cppcoreguidelines-avoid-non-const-global-variables)
-ConnectivityService &Connectivity = ConnectivityService::getInstance();
+ConnectivityService &Connectivity{ConnectivityService::getInstance()};

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -199,8 +199,7 @@ void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unuse
         "Wi-Fi", "%s", WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason)));
 }
 
-void ConnectivityService::onIPv4(WiFiEvent_t event, // NOLINT(misc-unused-parameters)
-                                 WiFiEventInfo_t info)
+void ConnectivityService::onIPv4(WiFiEvent_t event, WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
 {
     if (WiFi.STA.hasIP())
     {

--- a/webapp/src/services/Connectivity.tsx
+++ b/webapp/src/services/Connectivity.tsx
@@ -131,7 +131,7 @@ export const MainThird: Component = () => {
 
 export const SidebarThird: Component = () => {
     const handleSelect = (ssid: string) => {
-        if (window.innerWidth < 800) {
+        if (innerWidth < 800) {
             WebAppSidebarSet(false);
         }
         setCredentialSsid(ssid);


### PR DESCRIPTION
This pull request addresses various bugs related to Wi-Fi network reporting and improves the NVS (Non-Volatile Storage) handling logic, enhancing overall connectivity reliability.

### Key changes
- Fixed reporting of saved Wi-Fi networks.
- Resolved a memory leak in NVS handle management.
- Refactored NVS logic for better clarity and performance.
- Refactored IP address logging for better clarity
- Updated code styling for consistency.

### Impact
These changes improve the stability and performance of the connectivity service, ensuring more reliable Wi-Fi network management. Users may experience fewer issues, and the codebase becomes easier to maintain for contributors.