### PR TITLE
Clang-tidy verbose logging

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -229,6 +229,8 @@ jobs:
           clang-version: 22
         with:
           version: ${{ env.clang-version }}
+          extra-args: -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_VERBOSE
+          file-annotations: false
           files-changed-only: false
           step-summary: true
           style: ""

--- a/firmware/src/extensions/HomeAssistantExtension.cpp
+++ b/firmware/src/extensions/HomeAssistantExtension.cpp
@@ -94,7 +94,7 @@ void HomeAssistantExtension::undiscover()
                          true,
                          _mqtt.emptyMessage.data(),
                          _mqtt.emptyMessage.size() - 1U);
-    ESP_LOGW("MQTT", "discovery packet removed"); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGW("MQTT", "discovery packet removed"); // NOLINT(cppcoreguidelines-pro-type-vararg)
 }
 
 void HomeAssistantExtension::transmit()

--- a/firmware/src/extensions/HomeAssistantExtension.cpp
+++ b/firmware/src/extensions/HomeAssistantExtension.cpp
@@ -94,7 +94,7 @@ void HomeAssistantExtension::undiscover()
                          true,
                          _mqtt.emptyMessage.data(),
                          _mqtt.emptyMessage.size() - 1U);
-    ESP_LOGW("MQTT", "discovery packet removed"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGW("MQTT", "discovery packet removed"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 }
 
 void HomeAssistantExtension::transmit()

--- a/firmware/src/extensions/MicrophoneExtension.cpp
+++ b/firmware/src/extensions/MicrophoneExtension.cpp
@@ -61,7 +61,7 @@ void MicrophoneExtension::handle()
                         Device.transmit(doc.as<JsonObjectConst>(), name, false);
                         lastMillis = millis();
                     }
-                    ESP_LOGV("Sound", "level %d", activity); // NOLINT(cppcoreguidelines-avoid-do-while)
+                    ESP_LOGV("Sound", "level %d", activity); // NOLINT(cppcoreguidelines-pro-type-vararg)
                 }
                 else if (activity > soundCeiling)
                 {
@@ -79,7 +79,7 @@ void MicrophoneExtension::handle()
             else if (triggered)
             {
                 triggered = false;
-                ESP_LOGV("Silence", "level %d", activity); // NOLINT(cppcoreguidelines-avoid-do-while)
+                ESP_LOGV("Silence", "level %d", activity); // NOLINT(cppcoreguidelines-pro-type-vararg)
             }
             else if (activity < soundFloor)
             {
@@ -121,7 +121,7 @@ void MicrophoneExtension::setActive(bool _active)
         }
         triggered = !active;
         pending = true;
-        ESP_LOGI("Status", "%s", this->active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-avoid-do-while)
+        ESP_LOGI("Status", "%s", this->active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg)
     }
 }
 

--- a/firmware/src/extensions/MicrophoneExtension.cpp
+++ b/firmware/src/extensions/MicrophoneExtension.cpp
@@ -61,7 +61,7 @@ void MicrophoneExtension::handle()
                         Device.transmit(doc.as<JsonObjectConst>(), name, false);
                         lastMillis = millis();
                     }
-                    ESP_LOGV("Sound", "level %d", activity); // NOLINT(cppcoreguidelines-pro-type-vararg)
+                    ESP_LOGV("Sound", "level %d", activity); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
                 }
                 else if (activity > soundCeiling)
                 {
@@ -79,7 +79,7 @@ void MicrophoneExtension::handle()
             else if (triggered)
             {
                 triggered = false;
-                ESP_LOGV("Silence", "level %d", activity); // NOLINT(cppcoreguidelines-pro-type-vararg)
+                ESP_LOGV("Silence", "level %d", activity); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
             }
             else if (activity < soundFloor)
             {
@@ -121,7 +121,8 @@ void MicrophoneExtension::setActive(bool _active)
         }
         triggered = !active;
         pending = true;
-        ESP_LOGI("Status", "%s", this->active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        ESP_LOGI("Status", "%s", this->active ? "active" : "inactive");
     }
 }
 

--- a/firmware/src/extensions/MicrophoneExtension.cpp
+++ b/firmware/src/extensions/MicrophoneExtension.cpp
@@ -121,7 +121,7 @@ void MicrophoneExtension::setActive(bool _active)
         }
         triggered = !active;
         pending = true;
-        ESP_LOGI("Status", "%s", this->active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+        ESP_LOGI("Status", "%s", this->active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     }
 }
 

--- a/firmware/src/extensions/MqttExtension.cpp
+++ b/firmware/src/extensions/MqttExtension.cpp
@@ -62,7 +62,7 @@ void MqttExtension::disconnect()
 
 void MqttExtension::onConnect(bool sessionPresent) // NOLINT(misc-unused-parameters)
 {
-    ESP_LOGD("Wi-Fi", "connected"); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGD("Wi-Fi", "connected"); // NOLINT(cppcoreguidelines-pro-type-vararg)
     Extensions.MQTT().client.subscribe("frekvens/" HOSTNAME "/+/set",
                                        static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS2));
     Extensions.MQTT().client.publish("frekvens/" HOSTNAME "/availability",
@@ -99,8 +99,8 @@ void MqttExtension::onMessage(const espMqttClientTypes::MessageProperties &prope
 
 void MqttExtension::onDisconnect(espMqttClientTypes::DisconnectReason reason) // NOLINT(misc-unused-parameters)
 {
-    ESP_LOGD("MQTT", "disconnected"); // NOLINT(cppcoreguidelines-avoid-do-while)
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
+    ESP_LOGD("MQTT", "disconnected"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     ESP_LOGV("MQTT", "%s", espMqttClientTypes::disconnectReasonToString(reason));
 }
 

--- a/firmware/src/extensions/MqttExtension.cpp
+++ b/firmware/src/extensions/MqttExtension.cpp
@@ -62,7 +62,7 @@ void MqttExtension::disconnect()
 
 void MqttExtension::onConnect(bool sessionPresent) // NOLINT(misc-unused-parameters)
 {
-    ESP_LOGD("Wi-Fi", "connected"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGD("MQTT", "connected"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     Extensions.MQTT().client.subscribe("frekvens/" HOSTNAME "/+/set",
                                        static_cast<uint8_t>(espMqttClientTypes::SubscribeReturncode::QOS2));
     Extensions.MQTT().client.publish("frekvens/" HOSTNAME "/availability",
@@ -99,8 +99,8 @@ void MqttExtension::onMessage(const espMqttClientTypes::MessageProperties &prope
 
 void MqttExtension::onDisconnect(espMqttClientTypes::DisconnectReason reason) // NOLINT(misc-unused-parameters)
 {
-    ESP_LOGD("MQTT", "disconnected"); // NOLINT(cppcoreguidelines-pro-type-vararg)
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGD("MQTT", "disconnected"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     ESP_LOGV("MQTT", "%s", espMqttClientTypes::disconnectReasonToString(reason));
 }
 

--- a/firmware/src/extensions/OtaExtension.cpp
+++ b/firmware/src/extensions/OtaExtension.cpp
@@ -42,7 +42,7 @@ void OtaExtension::handle() { ArduinoOTA.handle(); } // NOLINT(cppcoreguidelines
 
 void OtaExtension::onStart()
 {
-    ESP_LOGI("Status", "updating"); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGI("Status", "updating"); // NOLINT(cppcoreguidelines-pro-type-vararg)
     Modes.setActive(false);
     const LargeFont font;
     Display.clearFrame();

--- a/firmware/src/extensions/OtaExtension.cpp
+++ b/firmware/src/extensions/OtaExtension.cpp
@@ -42,7 +42,7 @@ void OtaExtension::handle() { ArduinoOTA.handle(); } // NOLINT(cppcoreguidelines
 
 void OtaExtension::onStart()
 {
-    ESP_LOGI("Status", "updating"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGI("Status", "updating"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     Modes.setActive(false);
     const LargeFont font;
     Display.clearFrame();
@@ -53,7 +53,7 @@ void OtaExtension::onStart()
 
 void OtaExtension::onEnd()
 {
-    ESP_LOGI("Status", "complete"); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGI("Status", "complete"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 }
 
 #if EXTENSION_STATUSLED

--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -86,7 +86,7 @@ void PhotocellExtension::setActive(bool _active)
         nvs_close(handle);
     }
     pending = true;
-    ESP_LOGI("Status", "%s", active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGI("Status", "%s", active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 }
 
 void PhotocellExtension::setGamma(float _gamma)

--- a/firmware/src/extensions/PhotocellExtension.cpp
+++ b/firmware/src/extensions/PhotocellExtension.cpp
@@ -86,7 +86,7 @@ void PhotocellExtension::setActive(bool _active)
         nvs_close(handle);
     }
     pending = true;
-    ESP_LOGI("Status", "%s", active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGI("Status", "%s", active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg)
 }
 
 void PhotocellExtension::setGamma(float _gamma)

--- a/firmware/src/extensions/PlaylistExtension.cpp
+++ b/firmware/src/extensions/PlaylistExtension.cpp
@@ -87,7 +87,8 @@ void PlaylistExtension::setActive(bool _active)
             nvs_close(handle);
         }
         transmit();
-        ESP_LOGI("Status", "%s", active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        ESP_LOGI("Status", "%s", active ? "active" : "inactive");
     }
 }
 

--- a/firmware/src/extensions/PlaylistExtension.cpp
+++ b/firmware/src/extensions/PlaylistExtension.cpp
@@ -87,7 +87,7 @@ void PlaylistExtension::setActive(bool _active)
             nvs_close(handle);
         }
         transmit();
-        ESP_LOGI("Status", "%s", active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-avoid-do-while)
+        ESP_LOGI("Status", "%s", active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg)
     }
 }
 

--- a/firmware/src/extensions/PlaylistExtension.cpp
+++ b/firmware/src/extensions/PlaylistExtension.cpp
@@ -87,7 +87,7 @@ void PlaylistExtension::setActive(bool _active)
             nvs_close(handle);
         }
         transmit();
-        ESP_LOGI("Status", "%s", active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+        ESP_LOGI("Status", "%s", active ? "active" : "inactive"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     }
 }
 

--- a/firmware/src/modes/StreamMode.cpp
+++ b/firmware/src/modes/StreamMode.cpp
@@ -26,7 +26,7 @@ void StreamMode::begin()
     if (udp.listen(port))
     {
         udp.onPacket(&onPacket);
-        ESP_LOGD("Status", "listening at " HOSTNAME ".local:%d", port); // NOLINT(cppcoreguidelines-avoid-do-while)
+        ESP_LOGD("Status", "listening at " HOSTNAME ".local:%d", port); // NOLINT(cppcoreguidelines-pro-type-vararg)
     }
 }
 
@@ -46,7 +46,7 @@ void StreamMode::set(uint16_t _port)
     }
     if (udp.listen(port))
     {
-        ESP_LOGD("Status", "listening at " HOSTNAME ".local:%d", port); // NOLINT(cppcoreguidelines-avoid-do-while)
+        ESP_LOGD("Status", "listening at " HOSTNAME ".local:%d", port); // NOLINT(cppcoreguidelines-pro-type-vararg)
         transmit();
     }
 }

--- a/firmware/src/modes/StreamMode.cpp
+++ b/firmware/src/modes/StreamMode.cpp
@@ -26,7 +26,8 @@ void StreamMode::begin()
     if (udp.listen(port))
     {
         udp.onPacket(&onPacket);
-        ESP_LOGD("Status", "listening at " HOSTNAME ".local:%d", port); // NOLINT(cppcoreguidelines-pro-type-vararg)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        ESP_LOGD("Status", "listening at " HOSTNAME ".local:%d", port);
     }
 }
 
@@ -46,7 +47,8 @@ void StreamMode::set(uint16_t _port)
     }
     if (udp.listen(port))
     {
-        ESP_LOGD("Status", "listening at " HOSTNAME ".local:%d", port); // NOLINT(cppcoreguidelines-pro-type-vararg)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        ESP_LOGD("Status", "listening at " HOSTNAME ".local:%d", port);
         transmit();
     }
 }

--- a/firmware/src/services/ConnectivityService.cpp
+++ b/firmware/src/services/ConnectivityService.cpp
@@ -210,8 +210,8 @@ void ConnectivityService::onDisconnected(WiFiEvent_t event, // NOLINT(misc-unuse
 void ConnectivityService::onIPv4(WiFiEvent_t event,    // NOLINT(misc-unused-parameters)
                                  WiFiEventInfo_t info) // NOLINT(misc-unused-parameters)
 {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-    ESP_LOGI("Wi-Fi", "IPv4 %s", WiFi.localIP().toString().c_str()); // NOLINT(hicpp-vararg)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+    ESP_LOGI("Wi-Fi", "IPv4 %s", WiFi.localIP().toString().c_str());
     if (!Connectivity.routable)
     {
         onRoutable();

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -118,8 +118,9 @@ void DeviceService::handle()
 
 void DeviceService::setPower(bool power)
 {
-    ESP_LOGI("Status", "%s...", power ? "rebooting" : "powering off"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-    JsonDocument doc;                                                  // NOLINT(misc-const-correctness)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+    ESP_LOGI("Status", "%s...", power ? "rebooting" : "powering off");
+    JsonDocument doc; // NOLINT(misc-const-correctness)
     doc["event"].set(power ? "reboot" : "power");
     Device.transmit(doc.as<JsonObjectConst>(), name, false);
     Modes.setActive(false);

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -15,8 +15,8 @@ void DeviceService::begin()
 {
     Serial.begin(MONITOR_SPEED);
     vTaskDelay(INT8_MAX);
-    ESP_LOGI("Device", "Frekvens " VERSION);    // NOLINT(cppcoreguidelines-avoid-do-while)
-    ESP_LOGD("Device", MANUFACTURER " " MODEL); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGI("Device", "Frekvens " VERSION);    // NOLINT(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGD("Device", MANUFACTURER " " MODEL); // NOLINT(cppcoreguidelines-pro-type-vararg)
 #if SOC_PM_SUPPORT_EXT_WAKEUP || SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
 #if SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
     gpio_deep_sleep_hold_dis();
@@ -96,13 +96,13 @@ void DeviceService::begin()
     Extensions.configure();
     Modes.configure();
     operational = true;
-    ESP_LOGV("Status", "operational"); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGV("Status", "operational"); // NOLINT(cppcoreguidelines-pro-type-vararg)
     WebServer.begin();
     Fonts.begin();
     Extensions.begin();
     Modes.begin();
     transmit();
-    ESP_LOGD("Status", "ready"); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGD("Status", "ready"); // NOLINT(cppcoreguidelines-pro-type-vararg)
 }
 
 void DeviceService::handle()
@@ -118,7 +118,7 @@ void DeviceService::handle()
 
 void DeviceService::setPower(bool power)
 {
-    ESP_LOGI("Status", "%s...", power ? "rebooting" : "powering off"); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGI("Status", "%s...", power ? "rebooting" : "powering off"); // NOLINT(cppcoreguidelines-pro-type-vararg)
     JsonDocument doc;                                                  // NOLINT(misc-const-correctness)
     doc["event"].set(power ? "reboot" : "power");
     Device.transmit(doc.as<JsonObjectConst>(), name, false);
@@ -141,7 +141,7 @@ void DeviceService::setPower(bool power)
 
 void DeviceService::restore()
 {
-    ESP_LOGW("Status", "restoring..."); // NOLINT(cppcoreguidelines-avoid-do-while)
+    ESP_LOGW("Status", "restoring..."); // NOLINT(cppcoreguidelines-pro-type-vararg)
     Modes.setActive(false);
     Display.setPower(false);
 #if EXTENSION_HOMEASSISTANT
@@ -190,7 +190,7 @@ void DeviceService::transmit(JsonObjectConst payload, std::string_view source, b
     }
     if (operational)
     {
-        ESP_LOGV("Status", "transmitting"); // NOLINT(cppcoreguidelines-avoid-do-while)
+        ESP_LOGV("Status", "transmitting"); // NOLINT(cppcoreguidelines-pro-type-vararg)
         for (ExtensionModule *extension : Extensions.getAll())
         {
             extension->onTransmit(payload, source);
@@ -203,7 +203,7 @@ void DeviceService::receive(JsonObjectConst payload, std::string_view source, st
 {
     if (operational)
     {
-        ESP_LOGV("Status", "receiving"); // NOLINT(cppcoreguidelines-avoid-do-while)
+        ESP_LOGV("Status", "receiving"); // NOLINT(cppcoreguidelines-pro-type-vararg)
         if (Connectivity.name == destination)
         {
             Connectivity.onReceive(payload, source);

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -15,8 +15,8 @@ void DeviceService::begin()
 {
     Serial.begin(MONITOR_SPEED);
     vTaskDelay(INT8_MAX);
-    ESP_LOGI("Device", "Frekvens " VERSION);    // NOLINT(cppcoreguidelines-pro-type-vararg)
-    ESP_LOGD("Device", MANUFACTURER " " MODEL); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGI("Device", "Frekvens " VERSION);    // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+    ESP_LOGD("Device", MANUFACTURER " " MODEL); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 #if SOC_PM_SUPPORT_EXT_WAKEUP || SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
 #if SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
     gpio_deep_sleep_hold_dis();
@@ -96,13 +96,13 @@ void DeviceService::begin()
     Extensions.configure();
     Modes.configure();
     operational = true;
-    ESP_LOGV("Status", "operational"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGV("Status", "operational"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     WebServer.begin();
     Fonts.begin();
     Extensions.begin();
     Modes.begin();
     transmit();
-    ESP_LOGD("Status", "ready"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGD("Status", "ready"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 }
 
 void DeviceService::handle()
@@ -118,7 +118,7 @@ void DeviceService::handle()
 
 void DeviceService::setPower(bool power)
 {
-    ESP_LOGI("Status", "%s...", power ? "rebooting" : "powering off"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGI("Status", "%s...", power ? "rebooting" : "powering off"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     JsonDocument doc;                                                  // NOLINT(misc-const-correctness)
     doc["event"].set(power ? "reboot" : "power");
     Device.transmit(doc.as<JsonObjectConst>(), name, false);
@@ -141,7 +141,7 @@ void DeviceService::setPower(bool power)
 
 void DeviceService::restore()
 {
-    ESP_LOGW("Status", "restoring..."); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    ESP_LOGW("Status", "restoring..."); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     Modes.setActive(false);
     Display.setPower(false);
 #if EXTENSION_HOMEASSISTANT
@@ -190,7 +190,7 @@ void DeviceService::transmit(JsonObjectConst payload, std::string_view source, b
     }
     if (operational)
     {
-        ESP_LOGV("Status", "transmitting"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+        ESP_LOGV("Status", "transmitting"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
         for (ExtensionModule *extension : Extensions.getAll())
         {
             extension->onTransmit(payload, source);
@@ -203,7 +203,7 @@ void DeviceService::receive(JsonObjectConst payload, std::string_view source, st
 {
     if (operational)
     {
-        ESP_LOGV("Status", "receiving"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+        ESP_LOGV("Status", "receiving"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
         if (Connectivity.name == destination)
         {
             Connectivity.onReceive(payload, source);

--- a/firmware/src/services/WebServerService.cpp
+++ b/firmware/src/services/WebServerService.cpp
@@ -12,13 +12,13 @@ void WebServerService::onNotFound(AsyncWebServerRequest *request)
 #if EXTENSION_WEBAPP
     if (WiFiClass::getMode() == wifi_mode_t::WIFI_MODE_AP && request->host() != WiFi.softAPIP().toString())
     {
-        ESP_LOGV("HTTP", "redirecting"); // NOLINT(cppcoreguidelines-avoid-do-while)
+        ESP_LOGV("HTTP", "redirecting"); // NOLINT(cppcoreguidelines-pro-type-vararg)
         request->redirect("http://" + WiFi.softAPIP().toString(), t_http_codes::HTTP_CODE_FOUND);
     }
     else
 #endif // EXTENSION_WEBAPP
     {
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
         ESP_LOGW("HTTP", "404 Not Found, %s %s", WebServer.name, request->methodToString(), request->url());
         request->send(t_http_codes::HTTP_CODE_NOT_FOUND);
     }

--- a/firmware/src/services/WebServerService.cpp
+++ b/firmware/src/services/WebServerService.cpp
@@ -12,7 +12,7 @@ void WebServerService::onNotFound(AsyncWebServerRequest *request)
 #if EXTENSION_WEBAPP
     if (WiFiClass::getMode() == wifi_mode_t::WIFI_MODE_AP && request->host() != WiFi.softAPIP().toString())
     {
-        ESP_LOGV("HTTP", "redirecting"); // NOLINT(cppcoreguidelines-pro-type-vararg)
+        ESP_LOGV("HTTP", "redirecting"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
         request->redirect("http://" + WiFi.softAPIP().toString(), t_http_codes::HTTP_CODE_FOUND);
     }
     else


### PR DESCRIPTION
This pull request updates the Clang tidy configuration to enable verbose logging and disable file annotations, improving the clarity of the logging output.

### Key changes

Updated the Clang tidy configuration in the workflow to set the debug level to verbose and adjusted file annotation settings.

### Impact

These changes enhance the logging detail during Clang tidy runs, which can aid in debugging and understanding the analysis process. No compatibility issues are expected.