### PR TITLE
Remove redundant FontsService has() method

### DIFF
--- a/firmware/include/services/FontsService.h
+++ b/firmware/include/services/FontsService.h
@@ -25,7 +25,6 @@ public:
     void begin();
 
     [[nodiscard]] std::unique_ptr<const FontModule> get(std::string_view fontName) const;
-    [[nodiscard]] bool has(std::string_view fontName) const;
 
     static constexpr auto names{std::to_array<std::string_view>({
 #if FONT_BRAILLE

--- a/firmware/src/modes/ClockMode.cpp
+++ b/firmware/src/modes/ClockMode.cpp
@@ -106,7 +106,7 @@ void ClockMode::drawTicker(uint8_t brightness) const
 
 void ClockMode::setFont(std::string_view _fontName)
 {
-    if (Fonts.has(_fontName))
+    if (std::ranges::find(FontsService::names, _fontName) != FontsService::names.end())
     {
         fontName = _fontName;
         nvs_handle_t handle{};

--- a/firmware/src/modes/CountdownMode.cpp
+++ b/firmware/src/modes/CountdownMode.cpp
@@ -117,7 +117,7 @@ void CountdownMode::save()
 
 void CountdownMode::setFont(std::string_view _fontName)
 {
-    if (Fonts.has(_fontName))
+    if (std::ranges::find(FontsService::names, _fontName) != FontsService::names.end())
     {
         fontName = _fontName;
         nvs_handle_t handle{};

--- a/firmware/src/modes/TickerMode.cpp
+++ b/firmware/src/modes/TickerMode.cpp
@@ -106,7 +106,7 @@ void TickerMode::handle()
 
 void TickerMode::setFont(std::string_view fontName)
 {
-    if (Fonts.has(fontName))
+    if (std::ranges::find(FontsService::names, fontName) != FontsService::names.end())
     {
         font = Fonts.get(fontName);
         nvs_handle_t handle{};

--- a/firmware/src/services/FontsService.cpp
+++ b/firmware/src/services/FontsService.cpp
@@ -57,18 +57,6 @@ std::unique_ptr<const FontModule> FontsService::get(std::string_view fontName) c
     return nullptr;
 }
 
-bool FontsService::has(std::string_view fontName) const
-{
-    for (const std::string_view name : names)
-    {
-        if (fontName == name)
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
 void FontsService::transmit()
 {
     JsonDocument doc; // NOLINT(misc-const-correctness)


### PR DESCRIPTION
Eliminate the redundant `has()` method from the `FontsService` class, simplifying the codebase.

### Key changes
- Removed the `has()` method from `FontsService`.
- Updated font checks in `ClockMode`, `CountdownMode`, and `TickerMode` to use `std::ranges::find` instead.

### Impact
These changes streamline the font checking process, improving code clarity and maintainability. The behavior remains consistent as the functionality is preserved through alternative checks.