### PR TITLE
Refactor Web app and simplify LittleFS initialization

### DIFF
--- a/firmware/include/extensions/WebAppExtension.h
+++ b/firmware/include/extensions/WebAppExtension.h
@@ -10,6 +10,11 @@ class WebAppExtension final : public ExtensionModule
 {
 private:
     static constexpr std::string_view name{"Web app"};
+    static constexpr std::string_view path{"/webapp/index.html.gz"};
+
+    static inline size_t length{0U};
+
+    static inline std::array<char, 11> etag{'\0'};
 
     static void onGetRoot(AsyncWebServerRequest *request);
     static void onHeadRoot(AsyncWebServerRequest *request);
@@ -18,7 +23,6 @@ public:
     explicit WebAppExtension() : ExtensionModule(name) {};
 
     void configure() override;
-    void begin() override;
 };
 
 #endif // EXTENSION_WEBAPP

--- a/firmware/include/extensions/WebAppExtension.h
+++ b/firmware/include/extensions/WebAppExtension.h
@@ -11,6 +11,7 @@ class WebAppExtension final : public ExtensionModule
 private:
     static constexpr std::string_view name{"Web app"};
 
+    static void onGetRoot(AsyncWebServerRequest *request);
     static void onHeadRoot(AsyncWebServerRequest *request);
 
 public:

--- a/firmware/include/extensions/WebAppExtension.h
+++ b/firmware/include/extensions/WebAppExtension.h
@@ -5,6 +5,7 @@
 #include "modules/ExtensionModule.h"
 
 #include <ESPAsyncWebServer.h>
+#include <array>
 
 class WebAppExtension final : public ExtensionModule
 {

--- a/firmware/include/services/WebServerService.h
+++ b/firmware/include/services/WebServerService.h
@@ -12,7 +12,7 @@ private:
     static void onNotFound(AsyncWebServerRequest *request);
 
 public:
-    AsyncWebServer *http = new AsyncWebServer(80);
+    AsyncWebServer *http{new AsyncWebServer(80U)};
 
     void configure() const;
     void begin() const;

--- a/firmware/src/extensions/WebAppExtension.cpp
+++ b/firmware/src/extensions/WebAppExtension.cpp
@@ -52,6 +52,7 @@ void WebAppExtension::onHeadRoot(AsyncWebServerRequest *request)
     AsyncWebServerResponse *response{request->beginResponse(t_http_codes::HTTP_CODE_OK)};
     response->addHeader("Access-Control-Allow-Methods", "HEAD", false);
     response->addHeader("Access-Control-Allow-Origin", "*", false);
+    response->addHeader("Content-Encoding", "gzip", false);
     response->addHeader("ETag", etag.data(), false);
     response->setContentLength(length);
     request->send(response);

--- a/firmware/src/extensions/WebAppExtension.cpp
+++ b/firmware/src/extensions/WebAppExtension.cpp
@@ -2,7 +2,6 @@
 
 #include "extensions/WebAppExtension.h"
 
-#include "services/ExtensionsService.h"
 #include "services/WebServerService.h"
 
 #include <HTTPClient.h>
@@ -10,15 +9,7 @@
 
 void WebAppExtension::configure()
 {
-    if (!LittleFS.begin(false, "/littlefs", 1, "littlefs") || !LittleFS.exists("/webapp/index.html.gz"))
-    {
-        ESP_LOGE("Web server", "Filesystem Image not found"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-#if EXTENSION_STATUSLED
-        Extensions.StatusLed().error();
-#endif // EXTENSION_STATUSLED
-        return;
-    }
-    WebServer.http->serveStatic("/", LittleFS, "/webapp/", "max-age=3600").setDefaultFile("index.html");
+    WebServer.http->on(AsyncURIMatcher::exact("/"), WebRequestMethod::HTTP_GET, &onGetRoot);
 }
 
 void WebAppExtension::begin()
@@ -26,9 +17,14 @@ void WebAppExtension::begin()
     WebServer.http->on(AsyncURIMatcher::exact("/"), WebRequestMethod::HTTP_HEAD, &onHeadRoot);
 }
 
+void WebAppExtension::onGetRoot(AsyncWebServerRequest *request)
+{
+    request->send(request->beginResponse(LittleFS, "/webapp/index.html", "text/html"));
+}
+
 void WebAppExtension::onHeadRoot(AsyncWebServerRequest *request)
 {
-    AsyncWebServerResponse *response = request->beginResponse(t_http_codes::HTTP_CODE_OK);
+    AsyncWebServerResponse *response{request->beginResponse(t_http_codes::HTTP_CODE_OK)};
     response->addHeader("Access-Control-Allow-Methods", "HEAD");
     response->addHeader("Access-Control-Allow-Origin", "*");
     request->send(response);

--- a/firmware/src/extensions/WebAppExtension.cpp
+++ b/firmware/src/extensions/WebAppExtension.cpp
@@ -35,6 +35,7 @@ void WebAppExtension::onGetRoot(AsyncWebServerRequest *request)
     {
         AsyncWebServerResponse *response{request->beginResponse(t_http_codes::HTTP_CODE_NOT_MODIFIED)};
         response->addHeader("ETag", etag.data(), false);
+        response->setContentLength(length);
         request->send(response);
     }
     else

--- a/firmware/src/extensions/WebAppExtension.cpp
+++ b/firmware/src/extensions/WebAppExtension.cpp
@@ -21,7 +21,7 @@ void WebAppExtension::configure()
     }
     else
     {
-        snprintf(etag.data(), etag.size(), R"("%08lx")", static_cast<uint32_t>(file.getLastWrite()));
+        snprintf(etag.data(), etag.size(), R"("%08lx")", static_cast<unsigned long>(file.getLastWrite()));
         file.close();
         WebServer.http->on(AsyncURIMatcher::exact("/"), WebRequestMethod::HTTP_GET, &onGetRoot);
         WebServer.http->on(AsyncURIMatcher::exact("/"), WebRequestMethod::HTTP_HEAD, &onHeadRoot);

--- a/firmware/src/extensions/WebAppExtension.cpp
+++ b/firmware/src/extensions/WebAppExtension.cpp
@@ -34,14 +34,14 @@ void WebAppExtension::onGetRoot(AsyncWebServerRequest *request)
     if (_etag != nullptr && strcmp(_etag->value().c_str(), etag.data()) == 0)
     {
         AsyncWebServerResponse *response{request->beginResponse(t_http_codes::HTTP_CODE_NOT_MODIFIED)};
-        response->setContentLength(length);
+        response->addHeader("ETag", etag.data(), false);
         request->send(response);
     }
     else
     {
         AsyncWebServerResponse *response{request->beginResponse(LittleFS, path.data(), "text/html")};
         response->addHeader("Content-Encoding", "gzip", false);
-        response->addHeader("Etag", etag.data(), false);
+        response->addHeader("ETag", etag.data(), false);
         request->send(response);
     }
 }
@@ -51,7 +51,7 @@ void WebAppExtension::onHeadRoot(AsyncWebServerRequest *request)
     AsyncWebServerResponse *response{request->beginResponse(t_http_codes::HTTP_CODE_OK)};
     response->addHeader("Access-Control-Allow-Methods", "HEAD", false);
     response->addHeader("Access-Control-Allow-Origin", "*", false);
-    response->addHeader("Etag", etag.data(), false);
+    response->addHeader("ETag", etag.data(), false);
     response->setContentLength(length);
     request->send(response);
 }

--- a/firmware/src/extensions/WebAppExtension.cpp
+++ b/firmware/src/extensions/WebAppExtension.cpp
@@ -2,6 +2,7 @@
 
 #include "extensions/WebAppExtension.h"
 
+#include "services/ExtensionsService.h"
 #include "services/WebServerService.h"
 
 #include <HTTPClient.h>
@@ -9,24 +10,49 @@
 
 void WebAppExtension::configure()
 {
-    WebServer.http->on(AsyncURIMatcher::exact("/"), WebRequestMethod::HTTP_GET, &onGetRoot);
-}
-
-void WebAppExtension::begin()
-{
-    WebServer.http->on(AsyncURIMatcher::exact("/"), WebRequestMethod::HTTP_HEAD, &onHeadRoot);
+    File file{LittleFS.open(path.data())};
+    length = file.size();
+    if (length == 0U)
+    {
+        ESP_LOGE(name.data(), "File not found"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+#if EXTENSION_STATUSLED
+        Extensions.StatusLed().error();
+#endif // EXTENSION_STATUSLED
+    }
+    else
+    {
+        snprintf(etag.data(), etag.size(), R"("%08lx")", static_cast<uint32_t>(file.getLastWrite()));
+        file.close();
+        WebServer.http->on(AsyncURIMatcher::exact("/"), WebRequestMethod::HTTP_GET, &onGetRoot);
+        WebServer.http->on(AsyncURIMatcher::exact("/"), WebRequestMethod::HTTP_HEAD, &onHeadRoot);
+    }
 }
 
 void WebAppExtension::onGetRoot(AsyncWebServerRequest *request)
 {
-    request->send(request->beginResponse(LittleFS, "/webapp/index.html", "text/html"));
+    const AsyncWebHeader *_etag{request->getHeader("If-None-Match")};
+    if (_etag != nullptr && strcmp(_etag->value().c_str(), etag.data()) == 0)
+    {
+        AsyncWebServerResponse *response{request->beginResponse(t_http_codes::HTTP_CODE_NOT_MODIFIED)};
+        response->setContentLength(length);
+        request->send(response);
+    }
+    else
+    {
+        AsyncWebServerResponse *response{request->beginResponse(LittleFS, path.data(), "text/html")};
+        response->addHeader("Content-Encoding", "gzip", false);
+        response->addHeader("Etag", etag.data(), false);
+        request->send(response);
+    }
 }
 
 void WebAppExtension::onHeadRoot(AsyncWebServerRequest *request)
 {
     AsyncWebServerResponse *response{request->beginResponse(t_http_codes::HTTP_CODE_OK)};
-    response->addHeader("Access-Control-Allow-Methods", "HEAD");
-    response->addHeader("Access-Control-Allow-Origin", "*");
+    response->addHeader("Access-Control-Allow-Methods", "HEAD", false);
+    response->addHeader("Access-Control-Allow-Origin", "*", false);
+    response->addHeader("Etag", etag.data(), false);
+    response->setContentLength(length);
     request->send(response);
 }
 

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -7,6 +7,7 @@
 #include "services/ModesService.h"
 #include "services/WebServerService.h"
 
+#include <LittleFS.h>
 #include <array>
 #include <nvs_flash.h>
 #include <string_view>
@@ -15,8 +16,8 @@ void DeviceService::begin()
 {
     Serial.begin(MONITOR_SPEED);
     vTaskDelay(INT8_MAX);
-    ESP_LOGI("Device", "Frekvens " VERSION);    // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-    ESP_LOGD("Device", MANUFACTURER " " MODEL); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+    ESP_LOGI(name.data(), "Frekvens " VERSION);    // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+    ESP_LOGD(name.data(), MANUFACTURER " " MODEL); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 #if SOC_PM_SUPPORT_EXT_WAKEUP || SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
 #if SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
     gpio_deep_sleep_hold_dis();
@@ -89,6 +90,7 @@ void DeviceService::begin()
 #elif SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP && defined(PIN_SW2)
     esp_deep_sleep_enable_gpio_wakeup(1ULL << static_cast<unsigned>(PIN_SW2), ESP_GPIO_WAKEUP_GPIO_LOW);
 #endif // SOC_PM_SUPPORT_EXT_WAKEUP && CONFIG_IDF_TARGET_ESP32 && defined(PIN_INT) && defined(PIN_SW1)
+    LittleFS.begin(false, "/littlefs", 1U, "littlefs");
     taskHandle = xTaskGetCurrentTaskHandle();
     Display.configure();
     Connectivity.configure();
@@ -96,13 +98,13 @@ void DeviceService::begin()
     Extensions.configure();
     Modes.configure();
     operational = true;
-    ESP_LOGV("Status", "operational"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+    ESP_LOGV(name.data(), "operational"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     WebServer.begin();
     Fonts.begin();
     Extensions.begin();
     Modes.begin();
     transmit();
-    ESP_LOGD("Status", "ready"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+    ESP_LOGD(name.data(), "ready"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 }
 
 void DeviceService::handle()

--- a/firmware/src/services/DeviceService.cpp
+++ b/firmware/src/services/DeviceService.cpp
@@ -90,7 +90,12 @@ void DeviceService::begin()
 #elif SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP && defined(PIN_SW2)
     esp_deep_sleep_enable_gpio_wakeup(1ULL << static_cast<unsigned>(PIN_SW2), ESP_GPIO_WAKEUP_GPIO_LOW);
 #endif // SOC_PM_SUPPORT_EXT_WAKEUP && CONFIG_IDF_TARGET_ESP32 && defined(PIN_INT) && defined(PIN_SW1)
-    LittleFS.begin(false, "/littlefs", 1U, "littlefs");
+#if EXTENSION_WEBAPP
+    if (!LittleFS.begin(false, "/littlefs", 1U, "littlefs"))
+    {
+        ESP_LOGE(name.data(), "Filesystem Image not found"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+    }
+#endif // EXTENSION_WEBAPP
     taskHandle = xTaskGetCurrentTaskHandle();
     Display.configure();
     Connectivity.configure();

--- a/firmware/src/services/WebServerService.cpp
+++ b/firmware/src/services/WebServerService.cpp
@@ -5,21 +5,24 @@
 
 void WebServerService::configure() const { http->begin(); }
 
-void WebServerService::begin() const { http->onNotFound(&onNotFound); }
+void WebServerService::begin() const
+{
+#if EXTENSION_WEBAPP
+    http->onNotFound(&onNotFound);
+#endif // EXTENSION_WEBAPP
+}
 
 void WebServerService::onNotFound(AsyncWebServerRequest *request)
 {
-#if EXTENSION_WEBAPP
-    if (WiFiClass::getMode() == wifi_mode_t::WIFI_MODE_AP && request->host() != WiFi.softAPIP().toString())
+    if (WiFiClass::getMode() == wifi_mode_t::WIFI_MODE_AP)
     {
-        ESP_LOGV("HTTP", "redirecting"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        request->redirect("http://" + WiFi.softAPIP().toString(), t_http_codes::HTTP_CODE_FOUND);
+        ESP_LOGV(name.data(), "HTTP 302 Found"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        request->redirect("http://192.168.4.1", t_http_codes::HTTP_CODE_FOUND);
     }
     else
-#endif // EXTENSION_WEBAPP
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-        ESP_LOGW("HTTP", "404 Not Found, %s %s", WebServer.name, request->methodToString(), request->url());
+        ESP_LOGD(name.data(), "HTTP 404 Not Found, %s %s", request->methodToString(), request->url().c_str());
         request->send(t_http_codes::HTTP_CODE_NOT_FOUND);
     }
 }
@@ -33,4 +36,4 @@ WebServerService &WebServerService::getInstance()
 }
 
 // NOLINTNEXTLINE(bugprone-throwing-static-initialization,cert-err58-cpp,cppcoreguidelines-avoid-non-const-global-variables)
-WebServerService &WebServer = WebServerService::getInstance();
+WebServerService &WebServer{WebServerService::getInstance()};

--- a/firmware/src/services/WebServerService.cpp
+++ b/firmware/src/services/WebServerService.cpp
@@ -14,15 +14,17 @@ void WebServerService::begin() const
 
 void WebServerService::onNotFound(AsyncWebServerRequest *request)
 {
+#if EXTENSION_WEBAPP
     if (WiFiClass::getMode() == wifi_mode_t::WIFI_MODE_AP)
     {
-        ESP_LOGV(name.data(), "HTTP 302 Found"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        ESP_LOGV(WebServer.name.data(), "HTTP 302 Found"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
         request->redirect("http://192.168.4.1", t_http_codes::HTTP_CODE_FOUND);
     }
     else
+#endif // EXTENSION_WEBAPP
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-        ESP_LOGD(name.data(), "HTTP 404 Not Found, %s %s", request->methodToString(), request->url().c_str());
+        ESP_LOGD(WebServer.name.data(), "HTTP 404 Not Found, %s %s", request->methodToString(), request->url().c_str());
         request->send(t_http_codes::HTTP_CODE_NOT_FOUND);
     }
 }

--- a/firmware/src/services/WebServerService.cpp
+++ b/firmware/src/services/WebServerService.cpp
@@ -5,17 +5,12 @@
 
 void WebServerService::configure() const { http->begin(); }
 
-void WebServerService::begin() const
-{
-#if EXTENSION_WEBAPP
-    http->onNotFound(&onNotFound);
-#endif // EXTENSION_WEBAPP
-}
+void WebServerService::begin() const { http->onNotFound(&onNotFound); }
 
 void WebServerService::onNotFound(AsyncWebServerRequest *request)
 {
 #if EXTENSION_WEBAPP
-    if (WiFiClass::getMode() == wifi_mode_t::WIFI_MODE_AP)
+    if (WiFiClass::getMode() == wifi_mode_t::WIFI_MODE_AP && strcmp(request->host().c_str(), "192.168.4.1") != 0)
     {
         ESP_LOGV(WebServer.name.data(), "HTTP 302 Found"); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
         request->redirect("http://192.168.4.1", t_http_codes::HTTP_CODE_FOUND);


### PR DESCRIPTION
Refactor the web application structure and streamline the initialization process for LittleFS, enhancing code clarity and maintainability.

### Key changes
- Simplified the LittleFS initialization process.
- Refactored web server request handling for improved routing.
- Updated logging to use consistent naming conventions.

### Impact
These changes improve the overall organization of the web application and reduce complexity in the initialization logic. The refactoring may enhance maintainability and readability for future development efforts.