### PR TITLE
Bump Clang to v23

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -47,7 +47,7 @@ jobs:
         uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0
         id: format
         env:
-          clang-version: 22
+          clang-version: 23
         with:
           version: ${{ env.clang-version }}
           files-changed-only: false
@@ -226,7 +226,7 @@ jobs:
         uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0
         id: tidy
         env:
-          clang-version: 22
+          clang-version: 23
         with:
           version: ${{ env.clang-version }}
           extra-args: -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_VERBOSE

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -47,7 +47,7 @@ jobs:
         uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0
         id: clang
         env:
-          clang-version: 22
+          clang-version: 23
         with:
           version: ${{ env.clang-version }}
           files-changed-only: false
@@ -135,7 +135,7 @@ jobs:
         uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0
         id: clang
         env:
-          clang-version: 22
+          clang-version: 23
         with:
           version: ${{ env.clang-version }}
           files-changed-only: false
@@ -206,7 +206,7 @@ jobs:
         uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0
         id: clang
         env:
-          clang-version: 22
+          clang-version: 23
         with:
           version: ${{ env.clang-version }}
           files-changed-only: false


### PR DESCRIPTION
Update the Clang version used in the workflows to v23 to leverage new features and improvements.

### Key changes
- Changed the Clang version from 22 to 23 in workflows.

### Impact
These changes ensure the project uses the latest Clang version, which may improve build performance and compatibility with modern C++ standards.