### PR TITLE
Fix Y-axis boundary and refactor BlindsMode

### DIFF
--- a/firmware/include/modes/BlindsMode.h
+++ b/firmware/include/modes/BlindsMode.h
@@ -8,13 +8,13 @@
 class BlindsMode final : public ModeModule
 {
 private:
-    static constexpr uint8_t moduloMax = GRID_ROWS / 3;
+    static constexpr uint8_t moduloMax{GRID_ROWS / 3U};
 
-    bool direction = true;
+    bool direction{true};
 
-    uint8_t modulo = moduloMax;
+    uint8_t modulo{moduloMax};
 
-    unsigned long lastMillis = 0;
+    unsigned long lastMillis{0UL};
 
 public:
     static constexpr std::string_view name{"Blinds"};

--- a/firmware/src/modes/BlindsMode.cpp
+++ b/firmware/src/modes/BlindsMode.cpp
@@ -2,9 +2,10 @@
 
 #include "modes/BlindsMode.h"
 
-#include "extensions/MicrophoneExtension.h"
 #include "services/DisplayService.h"
 #include "services/ExtensionsService.h"
+
+static_assert(GRID_ROWS >= 3U, __STRING(MODE_BLINDS) " is not compatible with this device's display size.");
 
 void BlindsMode::handle()
 {
@@ -16,14 +17,14 @@ void BlindsMode::handle()
     {
         lastMillis = millis();
         Display.clearFrame();
-        for (uint8_t y = modulo / 2; y < GRID_COLUMNS; y += modulo)
+        for (uint8_t y{static_cast<uint8_t>(modulo / 2U)}; y < GRID_ROWS; y += modulo)
         {
-            for (uint8_t x = 0; x < GRID_COLUMNS; ++x)
+            for (uint8_t x{0U}; x < GRID_COLUMNS; ++x)
             {
-                Display.setPixel(x, y);
+                Display.setPixel(x, y, UINT8_MAX);
             }
         }
-        if (modulo <= 1 || modulo >= moduloMax)
+        if (modulo == 1U || modulo == moduloMax)
         {
             direction = !direction;
         }

--- a/firmware/src/modes/BlindsMode.cpp
+++ b/firmware/src/modes/BlindsMode.cpp
@@ -5,7 +5,7 @@
 #include "services/DisplayService.h"
 #include "services/ExtensionsService.h"
 
-static_assert(GRID_ROWS >= 3U, __STRING(MODE_BLINDS) " is not compatible with this device's display size.");
+static_assert(GRID_ROWS >= 6U, __STRING(MODE_BLINDS) " is not compatible with this device's display size.");
 
 void BlindsMode::handle()
 {


### PR DESCRIPTION
Corrects the Y-axis boundary for the BlindsMode and improves code readability through refactoring and compile-time checks.

### Key changes
- Adjusted the Y-axis boundary condition in the BlindsMode implementation.
- Added compile-time assertions to ensure compatibility with display size.
- Refactored variable initializations for clarity.

### Impact
These changes enhance the reliability of the BlindsMode by preventing potential runtime errors related to display size and improve code maintainability for future development.

### Note for end-users
This bug affects custom displays only. Neither Frekvens nor Obegransad were affected.