### PR TITLE
Hardcode version in TypeScript and adjust type in Python

### DIFF
--- a/.github/scripts/version.py
+++ b/.github/scripts/version.py
@@ -19,6 +19,7 @@ class Consistency:
             self._package_lock_json(),
             self._version_h(),
             self._version_py(),
+            self._version_ts(),
         ]
 
     def check(self) -> bool:
@@ -56,7 +57,12 @@ class Consistency:
 
     def _version_py(self) -> tuple[pathlib.Path, str]:
         path = pathlib.Path("scripts") / "src" / "config" / "version.py"
-        match = re.search(r'^VERSION:\sstr\s=\s"([^"]+)"$', path.read_text(), re.MULTILINE)
+        match = re.search(r'^VERSION:\styping\.Final\[str\]\s=\s"([^"]+)"$', path.read_text(), re.MULTILINE)
+        return path, match.group(1) if match else ""
+
+    def _version_ts(self) -> tuple[pathlib.Path, str]:
+        path = pathlib.Path("webapp") / "src" / "config" / "version.ts"
+        match = re.search(r'^export\sconst\sVERSION:\sstring\s=\s"([^"]+)";$', path.read_text(), re.MULTILINE)
         return path, match.group(1) if match else ""
 
 

--- a/.github/scripts/version.py
+++ b/.github/scripts/version.py
@@ -10,6 +10,13 @@ class Consistency:
     semver: list[tuple[pathlib.Path, str]]
 
     def __init__(self) -> None:
+        """
+        Collect version values from the project files used for consistency checks.
+        
+        Attributes:
+            pep (list[tuple[pathlib.Path, str]]): Version values using PEP 440 formatting.
+            semver (list[tuple[pathlib.Path, str]]): Version values using semantic versioning.
+        """
         self.pep = [
             self._pyproject_toml(),
             self._uv_lock(),
@@ -23,6 +30,12 @@ class Consistency:
         ]
 
     def check(self) -> bool:
+        """
+        Display the collected versions and verify consistency across all sources.
+        
+        Returns:
+            bool: True if all semver sources match and all PEP sources match the normalized semver value, otherwise false.
+        """
         cwd = pathlib.Path()
         for path, version in sorted(
             self.semver + self.pep,
@@ -56,11 +69,22 @@ class Consistency:
         return path, match.group(1) if match else ""
 
     def _version_py(self) -> tuple[pathlib.Path, str]:
+        """Extract the version from the Python configuration file.
+        
+        Returns:
+        	tuple[pathlib.Path, str]: The file path and extracted version, or an empty string if no version declaration is found.
+        """
         path = pathlib.Path("scripts") / "src" / "config" / "version.py"
         match = re.search(r'^VERSION:\styping\.Final\[str\]\s=\s"([^"]+)"$', path.read_text(), re.MULTILINE)
         return path, match.group(1) if match else ""
 
     def _version_ts(self) -> tuple[pathlib.Path, str]:
+        """
+        Extract the version declared in the TypeScript configuration file.
+        
+        Returns:
+        	tuple[pathlib.Path, str]: The source file path and the extracted version, or an empty string if no matching declaration is found.
+        """
         path = pathlib.Path("webapp") / "src" / "config" / "version.ts"
         match = re.search(r'^export\sconst\sVERSION:\sstring\s=\s"([^"]+)";$', path.read_text(), re.MULTILINE)
         return path, match.group(1) if match else ""

--- a/.github/scripts/version.py
+++ b/.github/scripts/version.py
@@ -12,7 +12,7 @@ class Consistency:
     def __init__(self) -> None:
         """
         Collect version values from the project files used for consistency checks.
-        
+
         Attributes:
             pep (list[tuple[pathlib.Path, str]]): Version values using PEP 440 formatting.
             semver (list[tuple[pathlib.Path, str]]): Version values using semantic versioning.
@@ -32,7 +32,7 @@ class Consistency:
     def check(self) -> bool:
         """
         Display the collected versions and verify consistency across all sources.
-        
+
         Returns:
             bool: True if all semver sources match and all PEP sources match the normalized semver value, otherwise false.
         """
@@ -70,9 +70,9 @@ class Consistency:
 
     def _version_py(self) -> tuple[pathlib.Path, str]:
         """Extract the version from the Python configuration file.
-        
+
         Returns:
-        	tuple[pathlib.Path, str]: The file path and extracted version, or an empty string if no version declaration is found.
+            tuple[pathlib.Path, str]: The file path and extracted version, or an empty string if no version declaration is found.
         """
         path = pathlib.Path("scripts") / "src" / "config" / "version.py"
         match = re.search(r'^VERSION:\styping\.Final\[str\]\s=\s"([^"]+)"$', path.read_text(), re.MULTILINE)
@@ -81,9 +81,9 @@ class Consistency:
     def _version_ts(self) -> tuple[pathlib.Path, str]:
         """
         Extract the version declared in the TypeScript configuration file.
-        
+
         Returns:
-        	tuple[pathlib.Path, str]: The source file path and the extracted version, or an empty string if no matching declaration is found.
+            tuple[pathlib.Path, str]: The source file path and the extracted version, or an empty string if no matching declaration is found.
         """
         path = pathlib.Path("webapp") / "src" / "config" / "version.ts"
         match = re.search(r'^export\sconst\sVERSION:\sstring\s=\s"([^"]+)";$', path.read_text(), re.MULTILINE)

--- a/scripts/src/config/version.py
+++ b/scripts/src/config/version.py
@@ -1,1 +1,3 @@
-VERSION: str = "2.5.2-dev0"
+import typing
+
+VERSION: typing.Final[str] = "2.5.2-dev0"

--- a/webapp/src/config/version.ts
+++ b/webapp/src/config/version.ts
@@ -1,3 +1,1 @@
-import packageLockJson from "../../package-lock.json";
-
-export const VERSION: string = packageLockJson.version;
+export const VERSION: string = "2.5.2-dev0";


### PR DESCRIPTION
Hard-coding the version in TypeScript reduces the bundle size by avoiding the loading of package-lock.json during runtime. The Python equivalent type has been adjusted for improved typing.

### Key changes
- Hard-coded the version in TypeScript.
- Updated the type of the version variable in Python to `typing.Final`.

### Impact
These changes improve performance by minimizing runtime dependencies and ensure type consistency across the project. 