### PR TITLE
Use latest-known uv version from astral-sh/setup-uv

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -24,16 +24,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: 3.14
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO environments
         id: config
-        run: echo "environments=$(pio project config --json-output | jq -c '[.[] | .[0] | select(startswith("env:")) | sub("^env:"; "")]')" >> "$GITHUB_OUTPUT"
+        run: echo "environments=$(uv run --only-group platformio pio project config --json-output | jq -c '[.[] | .[0] | select(startswith("env:")) | sub("^env:"; "")]')" >> "$GITHUB_OUTPUT"
 
   format:
     name: Format
@@ -104,12 +100,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: 3.13
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO compilation database
         run: |
@@ -220,7 +212,7 @@ jobs:
           #define WORLDWEATHERONLINE_KEY "redacted"
           EOL
 
-          pio run -t compiledb -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -t compiledb -e ${{ matrix.environment }}
 
       - name: Clang tidy
         uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -28,16 +28,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up Python dependencies
-        run: uv sync --extra font --no-dev
+          version: latest-known
 
       - name: Font generator
         run: |
-          python extra/Python/FontGenerator.py -i DejaVuSans --size 8
+          uv run --extra font --no-dev extra/Python/FontGenerator.py -i DejaVuSans --size 8
 
           mv DejaVuSansFont.cpp firmware/src/fonts
           mv DejaVuSansFont.h firmware/include/fonts

--- a/.github/workflows/ikea-frekvens-led-multi-use-light.yml
+++ b/.github/workflows/ikea-frekvens-led-multi-use-light.yml
@@ -29,20 +29,16 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: 3.14
-          activate-environment: true
-
-      - name: Set up Python packages
-        run: uv sync --only-group nodejs --only-group platformio
+          version: latest-known
 
       - name: Node.js cache
         id: nodejs
-        run: echo "cache=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+        run: echo "cache=$(uv run --only-group nodejs npm config get cache)" >> "$GITHUB_OUTPUT"
 
       - name: PlatformIO environments
         id: platformio
-        run: echo "environments=$(pio project config --json-output | jq -c '[.[] | .[0] | select(startswith("env:")) | sub("^env:"; "")]')" >> "$GITHUB_OUTPUT"
+        run: echo "environments=$(uv run --only-group platformio pio project config --json-output | jq -c '[.[] | .[0] | select(startswith("env:")) | sub("^env:"; "")]')" >> "$GITHUB_OUTPUT"
 
   default:
     name: Default
@@ -116,12 +112,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO build
         run: |
@@ -139,7 +131,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e ${{ matrix.environment }}
 
   minimal:
     name: Minimal
@@ -208,12 +200,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO build
         run: |
@@ -240,7 +228,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e ${{ matrix.environment }}
 
   typical:
     name: Typical
@@ -297,12 +285,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO build
         run: |
@@ -390,7 +374,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e ${{ matrix.environment }}
 
   extensive:
     name: Extensive
@@ -447,12 +431,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO build
         run: |
@@ -572,4 +552,4 @@ jobs:
           #define WORLDWEATHERONLINE_KEY "redacted"
           EOL
 
-          pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e ${{ matrix.environment }}

--- a/.github/workflows/ikea-obegransad-led-wall-lamp.yml
+++ b/.github/workflows/ikea-obegransad-led-wall-lamp.yml
@@ -29,20 +29,16 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: 3.14
-          activate-environment: true
-
-      - name: Set up Python packages
-        run: uv sync --only-group nodejs --only-group platformio
+          version: latest-known
 
       - name: Node.js cache
         id: nodejs
-        run: echo "cache=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+        run: echo "cache=$(uv run --only-group nodejs npm config get cache)" >> "$GITHUB_OUTPUT"
 
       - name: PlatformIO environments
         id: platformio
-        run: echo "environments=$(pio project config --json-output | jq -c '[.[] | .[0] | select(startswith("env:")) | sub("^env:"; "")]')" >> "$GITHUB_OUTPUT"
+        run: echo "environments=$(uv run --only-group platformio pio project config --json-output | jq -c '[.[] | .[0] | select(startswith("env:")) | sub("^env:"; "")]')" >> "$GITHUB_OUTPUT"
 
   default:
     name: Default
@@ -116,12 +112,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO build
         run: |
@@ -138,7 +130,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e ${{ matrix.environment }}
 
   minimal:
     name: Minimal
@@ -207,12 +199,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO build
         run: |
@@ -239,7 +227,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e ${{ matrix.environment }}
 
   typical:
     name: Typical
@@ -296,12 +284,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO build
         run: |
@@ -386,7 +370,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e ${{ matrix.environment }}
 
   extensive:
     name: Extensive
@@ -443,12 +427,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO build
         run: |
@@ -567,4 +547,4 @@ jobs:
           #define WORLDWEATHERONLINE_KEY "redacted"
           EOL
 
-          pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e ${{ matrix.environment }}

--- a/.github/workflows/miscellaneous.yml
+++ b/.github/workflows/miscellaneous.yml
@@ -28,12 +28,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.python-version }}
-          activate-environment: true
-
-      - name: Set up Frekvens tools
-        run: uv sync --no-dev
+          version: latest-known
 
       - name: Animation splitter
         run: |
@@ -74,7 +70,7 @@ jobs:
 
           sed -i 's/\r\{0,1\}$/\r/' Frames.csv
 
-          python -m frekvens.AnimationSplitter -i Frames.csv
+          uv run --no-dev -m frekvens.AnimationSplitter -i Frames.csv
 
       - name: Frame comparison
         run: |
@@ -138,16 +134,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.python-version }}
-          activate-environment: true
-
-      - name: Set up Frekvens tools
-        run: uv sync --no-dev
+          version: latest-known
 
       - name: Set up HTTP server
         run: |
-          python - << 'EOF' &
+          uv run --no-dev - << 'EOF' &
           import http.server
           class Test(http.server.BaseHTTPRequestHandler):
               def do_PATCH(self):
@@ -160,7 +152,7 @@ jobs:
           sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-ports 8080
 
       - name: Home thermometer updater
-        run: python -m frekvens.HomeThermometerUpdater 127.0.0.1 --indoor=22 --outdoor=8
+        run: uv run --no-dev -m frekvens.HomeThermometerUpdater 127.0.0.1 --indoor=22 --outdoor=8
 
   mode-switcher:
     name: Mode switcher
@@ -179,16 +171,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.python-version }}
-          activate-environment: true
-
-      - name: Set up Frekvens tools
-        run: uv sync --no-dev
+          version: latest-known
 
       - name: Set up HTTP server
         run: |
-          python - << 'EOF' &
+          uv run --no-dev - << 'EOF' &
           import http.server
           class Test(http.server.BaseHTTPRequestHandler):
               def do_PATCH(self):
@@ -201,7 +189,7 @@ jobs:
           sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-ports 8080
 
       - name: Mode switcher
-        run: python -m frekvens.ModeSwitcher 127.0.0.1 --mode=Test
+        run: uv run --no-dev -m frekvens.ModeSwitcher 127.0.0.1 --mode=Test
 
   package-lock:
     name: package-lock.json consistency
@@ -235,8 +223,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: 3.14
+          version: latest-known
 
       - name: uv lock check
         run: uv lock --check

--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -22,16 +22,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: 3.14
-          activate-environment: true
-
-      - name: Set up PlatformIO
-        run: uv sync --only-group platformio
+          version: latest-known
 
       - name: PlatformIO lint
         run: |
-          OUTPUT=$(pio project config --lint --json-output)
+          OUTPUT=$(uv run --only-group platformio pio project config --lint --json-output)
           echo "$OUTPUT"
           if [ "$OUTPUT" != "{'errors': [], 'warnings': []}" ]; then
             exit 1

--- a/.github/workflows/stream.yml
+++ b/.github/workflows/stream.yml
@@ -33,16 +33,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up Frekvens tools
-        run: uv sync --no-dev
+          version: latest-known
 
       - name: Set up HTTP server
         run: |
-          python - << 'EOF' &
+          uv run --no-dev - << 'EOF' &
           import http.server
           class Test(http.server.BaseHTTPRequestHandler):
               def do_PATCH(self):
@@ -93,7 +89,7 @@ jobs:
 
           sed -i 's/\r\{0,1\}$/\r/' Animation.csv
 
-          timeout --preserve-status -s INT 10s python -m frekvens.StreamCsv 127.0.0.1:${{ matrix.port }} -i Animation.csv
+          timeout --preserve-status -s INT 10s uv run --no-dev -m frekvens.StreamCsv 127.0.0.1:${{ matrix.port }} -i Animation.csv
 
   drawing:
     name: Drawing
@@ -117,16 +113,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: ${{ matrix.toolchain.python-version }}
-          activate-environment: true
-
-      - name: Set up Frekvens tools
-        run: uv sync --no-dev
+          version: latest-known
 
       - name: Set up HTTP server
         run: |
-          python - << 'EOF' &
+          uv run --no-dev - << 'EOF' &
           import http.server
           class Test(http.server.BaseHTTPRequestHandler):
               def do_PATCH(self):
@@ -161,4 +153,4 @@ jobs:
 
           sed -i 's/\r\{0,1\}$/\r/' Drawing.csv
 
-          python -m frekvens.StreamCsv 127.0.0.1:${{ matrix.port }} -i Drawing.csv
+          uv run --no-dev -m frekvens.StreamCsv 127.0.0.1:${{ matrix.port }} -i Drawing.csv

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -30,12 +30,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version-file: pyproject.toml
           python-version: 3.14
-          activate-environment: true
-
-      - name: Set up Python packages
-        run: uv sync --only-group packaging
+          version: latest-known
 
       - name: Version check
-        run: python .github/scripts/version.py
+        run: uv run --only-group packaging .github/scripts/version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,6 @@ scripts = [
     "tzdata==2026.3",
     "tzlocal==5.4.4",
 ]
-uv = [
-    "uv==0.11.26",
-]
 
 [tool.ruff]
 extend-exclude = [

--- a/scripts/extra_script.py
+++ b/scripts/extra_script.py
@@ -12,7 +12,7 @@ else:
 def main() -> None:
     """
     Run the Frekvens build workflow for the current SCons environment.
-    
+
     The function synchronizes the scripts dependencies, cleans the project for
     clean targets, and otherwise executes the Frekvens workflow. It returns
     without action for the ``erase``, ``menuconfig``, and ``size`` targets.

--- a/scripts/extra_script.py
+++ b/scripts/extra_script.py
@@ -1,6 +1,4 @@
 import os
-import pathlib
-import re
 import subprocess
 import sys
 import typing
@@ -28,12 +26,13 @@ def main() -> None:
         [sys.executable, "-m", "uv", "sync", "--active", "--inexact", "--only-group", "scripts"],
         stderr=subprocess.DEVNULL,
         env=uv_env,
+        check=False,
     )
     if uv.returncode:
-        match = re.search(r'"(uv==\d+\.\d+\.\d+)"', pathlib.Path("pyproject.toml").read_text())
         pip = subprocess.run(
-            [sys.executable, "-m", "pip", "install", match.group(1) if match else "uv"],
+            [sys.executable, "-m", "pip", "install", "uv"],
             stderr=subprocess.DEVNULL,
+            check=False,
         )
         if pip.returncode:
             subprocess.run([sys.executable, "-m", "ensurepip"], check=True)

--- a/scripts/extra_script.py
+++ b/scripts/extra_script.py
@@ -10,6 +10,13 @@ else:
 
 
 def main() -> None:
+    """
+    Run the Frekvens build workflow for the current SCons environment.
+    
+    The function synchronizes the scripts dependencies, cleans the project for
+    clean targets, and otherwise executes the Frekvens workflow. It returns
+    without action for the ``erase``, ``menuconfig``, and ``size`` targets.
+    """
     if COMMAND_LINE_TARGETS in [
         ["erase"],
         ["menuconfig"],

--- a/uv.lock
+++ b/uv.lock
@@ -441,9 +441,6 @@ scripts = [
     { name = "tzdata" },
     { name = "tzlocal" },
 ]
-uv = [
-    { name = "uv" },
-]
 
 [package.metadata]
 requires-dist = [
@@ -471,7 +468,6 @@ scripts = [
     { name = "tzdata", specifier = "==2026.3" },
     { name = "tzlocal", specifier = "==5.4.4" },
 ]
-uv = [{ name = "uv", specifier = "==0.11.26" }]
 
 [[package]]
 name = "h11"
@@ -1207,32 +1203,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
-]
-
-[[package]]
-name = "uv"
-version = "0.11.26"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/cb/5efc713948ddb10b00abfb51bfd429221c720175557f9c7965fea2448fe4/uv-0.11.26.tar.gz", hash = "sha256:2a433ece2ace088dd572d8abb0e6bd9a4ecb0e10bc9856447bbb37545f384f29", size = 4331220, upload-time = "2026-06-30T14:52:03.77Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/71/86dbffac9e26df28a16639c426cf4ba572aaf43d9231463e0dca337895b2/uv-0.11.26-py3-none-linux_armv6l.whl", hash = "sha256:fb97bf04512dfe16d86084e75d8129701fc8da9fb40de8746b73c3aa617c5897", size = 25197324, upload-time = "2026-06-30T14:50:51.75Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/80/525b73c8188e7052343e7109466a08fcd5195055aff4b0346ce3622e48cb/uv-0.11.26-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a58a06e5a4b0035538d3ab4160ad74c716076ea7148eb3317171c6276ac020b4", size = 24179172, upload-time = "2026-06-30T14:50:56.52Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5e/cf7b94ed3b1932c2a62573dcd388ad6c1da5c52111cd71ab7f20faa4a0aa/uv-0.11.26-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7b6d078d2ce83897884c2330c0676f27be4bf3d223fb2a409460f579fb5f0a98", size = 22949576, upload-time = "2026-06-30T14:51:00.538Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/fd/71fa021f6909c4139d8354bea623b5e0ef0ce4a08da250da1a1645528da2/uv-0.11.26-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:1cd9ba4951681ce17f1703106266fcbe27aaa7d37f07d53cce8b5686d68a8755", size = 24936673, upload-time = "2026-06-30T14:51:04.496Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/5e/273425e58a8812423e3d1f6c5da1015e636fbf13a83d104317ca37e16304/uv-0.11.26-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:e4f4c3268e69ac96f01972274a62f5f930c03cbc680adba6f21e63237ba3a639", size = 24719617, upload-time = "2026-06-30T14:51:08.419Z" },
-    { url = "https://files.pythonhosted.org/packages/81/f8/1601e2acc7c54963814b4831eab996d8599e690712722c5acec5114860be/uv-0.11.26-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:efcbe0e187846f5ddba23bcaed17e4f9cd2463da5c45bdb5869616f686d713ff", size = 24734176, upload-time = "2026-06-30T14:51:12.685Z" },
-    { url = "https://files.pythonhosted.org/packages/88/d2/a8a422e54c08cf4b8d51bedb9dbdd3cc233aa290ad8b3ee0438c0c02a3a5/uv-0.11.26-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:120ab2de93164d08cf5950f7fe18cbebe3ff670865ae41a292452bab2346477f", size = 26158780, upload-time = "2026-06-30T14:51:16.514Z" },
-    { url = "https://files.pythonhosted.org/packages/db/e6/647fe5fdc888a3d27f79977877ce4e88052fe9be5398371e51bb134fc262/uv-0.11.26-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9052bf27c7ee426901f35a48715fa9288ce631c1878b91c9a6c950288f4b8633", size = 27009550, upload-time = "2026-06-30T14:51:20.659Z" },
-    { url = "https://files.pythonhosted.org/packages/72/c2/85d8e762ad83b0f14fae2255b0578c4fd7dc915746f81b64ed786342627a/uv-0.11.26-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:efdddfcc9b1b790c5f7985c5c183c851682ced165b44ffa914f4947f5cad1fbf", size = 26183777, upload-time = "2026-06-30T14:51:24.715Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/00/478c3a870dcac690b8c337ee950a60a952e817f574945e85155c3cc0ab34/uv-0.11.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dcf4e0b5b5cbdc242dcb002f1f8d99e7cf8c043609869228a9ce15e095c0b18", size = 26260589, upload-time = "2026-06-30T14:51:28.809Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/51/e4e43e106fb8cdc026b97491ea4600f4194a9c4da0b4e4e30c2a7dceb268/uv-0.11.26-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:866ae8d28f7381c15de0906a284c1e97916424c635bf40f7960b3fc889cd725e", size = 25073850, upload-time = "2026-06-30T14:51:32.717Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c2/e772b7e6c8a835e8bf6739a391cdfc8e8e244c5c496d9b40625068b59ff4/uv-0.11.26-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:22f6d62e794b252ff3a1e2dfe5010cc76208f90b2c906e54971a0223ad6f16bc", size = 25682609, upload-time = "2026-06-30T14:51:36.888Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/69/ea77209a224a23a399cb7f6414f77ef032bd9e083e01199a0ebebf0d3ff2/uv-0.11.26-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:edd0c12b75141a6d830d138a91e366ad66e630f1c1dcaf83b8325b80cbacfcbb", size = 25800556, upload-time = "2026-06-30T14:51:40.937Z" },
-    { url = "https://files.pythonhosted.org/packages/77/60/b6c0c03d2538a016b6624fa251960012e564ea02f841e958c7d60e974685/uv-0.11.26-py3-none-musllinux_1_1_i686.whl", hash = "sha256:af6a45b11a569cc4d2437e89a25a53dcf753f2a02a8f2de96be09b9b942cb3ec", size = 25385658, upload-time = "2026-06-30T14:51:45.103Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/e7/46881ff9164aa2e7c649901837d58eee3c57beb3b0fcc0fea6a4e40cf8f3/uv-0.11.26-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:c28822517d03aebbe9549aaaecc88ad580e4b2b6a927abffe5774a74d6ba09f6", size = 26551013, upload-time = "2026-06-30T14:51:49.062Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/94/380dad6c2bbe12417025aacd12cfc08322ed4c9dd8f760bff7035b86f22d/uv-0.11.26-py3-none-win32.whl", hash = "sha256:79e5c1b3410047e1962290c3b7b8f512d2c1bb95200c60b016f7729287cf34c0", size = 23947180, upload-time = "2026-06-30T14:51:53.065Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/13/9c588226d5b478328d739e654944430719f3ffe8999d6a24d425ec9664ab/uv-0.11.26-py3-none-win_amd64.whl", hash = "sha256:d95567e9470dc48ff03265f420c3c6973f6437f18a79d5e00b6eb4b2d9379907", size = 26909320, upload-time = "2026-06-30T14:51:57.235Z" },
-    { url = "https://files.pythonhosted.org/packages/21/1d/ea66b12813878797126e2b3aca124b1c9c5ef53120702d1c00172f90a21d/uv-0.11.26-py3-none-win_arm64.whl", hash = "sha256:7e69d1569afbb936e7bf4e4ab2f72d606405f4a68f380f088a0b2233e84e056a", size = 25176820, upload-time = "2026-06-30T14:52:01.05Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update workflows to use the latest SHA verified version known by the astral-sh/setup-uv action over a specific uv-pinned version.
Updated PIO extra_script fallback method to always use the latest uv version.

### Key changes

- Refactored workflows to use "latest-known" uv version.
- Refactored workflows to not activate uv as PATH accessible python installation.
- `extra_scripts.py` now uses unpinned uv version as fallback in case uv isn't available already.

### Impact

These changes enhance the project's dependency management by allowing the use of the latest verified version of `uv` known by astral-sh/setup-uv without having to separately pin a version.

Requires #769
