### PR TITLE
Refactor CI workflows to use Python 3.10 only*

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: 3.14
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO environments
@@ -100,7 +100,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: 3.13
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO compilation database

--- a/.github/workflows/end-of-life.yml
+++ b/.github/workflows/end-of-life.yml
@@ -77,19 +77,10 @@ jobs:
     needs: idle-check
     runs-on: ubuntu-slim
     if: ${{ fromJSON(needs.idle-check.outputs.active) }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - python-version: '3.10'
-          - python-version: 3.13
-          - python-version: 3.14
-
     steps:
       - name: End-of-Life
         uses: sindrel/endoflife-github-action@5f91adaabc542a346876290ff0f447c7bc355f99 # v1.0.3
         with:
           product: python
-          version: ${{ matrix.python-version }}
+          version: "3.10"
           fail_on_eol: true

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -14,13 +14,6 @@ jobs:
   font-dejavusans:
     name: DejaVuSans font
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -28,7 +21,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: Font generator
@@ -39,7 +32,6 @@ jobs:
           mv DejaVuSansFont.h firmware/include/fonts
 
       - name: Clang format
-        if: ${{ matrix.toolchain.python-version != 3.14 }}
         uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0
         id: clang
         env:
@@ -53,7 +45,6 @@ jobs:
           tidy-checks: "-*"
 
       - name: Clang summary
-        if: ${{ matrix.toolchain.python-version != 3.14 }}
         env:
           clang-threshold: 0
         run: |
@@ -69,13 +60,6 @@ jobs:
   mode-dynamic:
     name: Dynamic mode
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -83,7 +67,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
 
       - name: Generate mode
         run: |
@@ -156,13 +140,6 @@ jobs:
   mode-static:
     name: Static mode
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -170,7 +147,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
 
       - name: Generate mode
         run: |

--- a/.github/workflows/ikea-frekvens-led-multi-use-light.yml
+++ b/.github/workflows/ikea-frekvens-led-multi-use-light.yml
@@ -150,6 +150,19 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
+        exclude:
+          - environment: adafruit_qtpy_esp32s2
+          - environment: adafruit_qtpy_esp32s3_n4r2
+          - environment: esp32-c3-devkitm-1
+          - environment: esp32-c5-devkitc-1
+          - environment: esp32-c6-devkitm-1
+          - environment: esp32dev
+          - environment: lolin_d32
+          - environment: lolin_d32_pro
+          - environment: lolin_s3_mini
+          - environment: seeed_xiao_esp32c3
+          - environment: seeed_xiao_esp32c6
+          - environment: wemos_d1_mini32
 
     steps:
       - name: Checkout
@@ -269,6 +282,19 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
+        exclude:
+          - environment: adafruit_qtpy_esp32s2
+          - environment: adafruit_qtpy_esp32s3_n4r2
+          - environment: esp32-c3-devkitm-1
+          - environment: esp32-c5-devkitc-1
+          - environment: esp32-c6-devkitm-1
+          - environment: esp32dev
+          - environment: lolin_d32
+          - environment: lolin_d32_pro
+          - environment: lolin_s3_mini
+          - environment: seeed_xiao_esp32c3
+          - environment: seeed_xiao_esp32c6
+          - environment: wemos_d1_mini32
 
     steps:
       - name: Checkout

--- a/.github/workflows/ikea-frekvens-led-multi-use-light.yml
+++ b/.github/workflows/ikea-frekvens-led-multi-use-light.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: 3.14
+          python-version: "3.10"
           version: latest-known
 
       - name: Node.js cache
@@ -48,50 +48,6 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
-        exclude:
-          - environment: adafruit_qtpy_esp32s2
-            toolchain:
-              python-version: '3.10'
-
-          - environment: adafruit_qtpy_esp32s3_n4r2
-            toolchain:
-              python-version: '3.10'
-
-          - environment: adafruit_qtpy_esp32s3_nopsram
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_d32
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_d32_pro
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_s3_mini
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32c3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32c6
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32s3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: wemos_d1_mini32
-            toolchain:
-              python-version: '3.10'
 
     steps:
       - name: Checkout
@@ -112,7 +68,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO build
@@ -141,50 +97,6 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
-        exclude:
-          - environment: adafruit_qtpy_esp32s2
-            toolchain:
-              python-version: '3.10'
-
-          - environment: adafruit_qtpy_esp32s3_n4r2
-            toolchain:
-              python-version: '3.10'
-
-          - environment: adafruit_qtpy_esp32s3_nopsram
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_d32
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_d32_pro
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_s3_mini
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32c3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32c6
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32s3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: wemos_d1_mini32
-            toolchain:
-              python-version: '3.10'
 
     steps:
       - name: Checkout
@@ -200,7 +112,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO build
@@ -238,33 +150,6 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
-        exclude:
-          - environment: adafruit_qtpy_esp32s2
-          - environment: adafruit_qtpy_esp32s3_n4r2
-
-          - environment: adafruit_qtpy_esp32s3_nopsram
-            toolchain:
-              python-version: '3.10'
-
-          - environment: esp32-c3-devkitm-1
-          - environment: esp32-c5-devkitc-1
-          - environment: esp32-c6-devkitm-1
-          - environment: esp32dev
-          - environment: lolin_d32
-          - environment: lolin_d32_pro
-          - environment: lolin_s3_mini
-          - environment: seeed_xiao_esp32c3
-          - environment: seeed_xiao_esp32c6
-
-          - environment: seeed_xiao_esp32s3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: wemos_d1_mini32
 
     steps:
       - name: Checkout
@@ -285,7 +170,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO build
@@ -384,33 +269,6 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
-        exclude:
-          - environment: adafruit_qtpy_esp32s2
-          - environment: adafruit_qtpy_esp32s3_n4r2
-
-          - environment: adafruit_qtpy_esp32s3_nopsram
-            toolchain:
-              python-version: '3.10'
-
-          - environment: esp32-c3-devkitm-1
-          - environment: esp32-c5-devkitc-1
-          - environment: esp32-c6-devkitm-1
-          - environment: esp32dev
-          - environment: lolin_d32
-          - environment: lolin_d32_pro
-          - environment: lolin_s3_mini
-          - environment: seeed_xiao_esp32c3
-          - environment: seeed_xiao_esp32c6
-
-          - environment: seeed_xiao_esp32s3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: wemos_d1_mini32
 
     steps:
       - name: Checkout
@@ -431,7 +289,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO build

--- a/.github/workflows/ikea-obegransad-led-wall-lamp.yml
+++ b/.github/workflows/ikea-obegransad-led-wall-lamp.yml
@@ -149,6 +149,19 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
+        exclude:
+          - environment: adafruit_qtpy_esp32s2
+          - environment: adafruit_qtpy_esp32s3_n4r2
+          - environment: esp32-c3-devkitm-1
+          - environment: esp32-c5-devkitc-1
+          - environment: esp32-c6-devkitm-1
+          - environment: esp32dev
+          - environment: lolin_d32
+          - environment: lolin_d32_pro
+          - environment: lolin_s3_mini
+          - environment: seeed_xiao_esp32c3
+          - environment: seeed_xiao_esp32c6
+          - environment: wemos_d1_mini32
 
     steps:
       - name: Checkout
@@ -265,6 +278,19 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
+        exclude:
+          - environment: adafruit_qtpy_esp32s2
+          - environment: adafruit_qtpy_esp32s3_n4r2
+          - environment: esp32-c3-devkitm-1
+          - environment: esp32-c5-devkitc-1
+          - environment: esp32-c6-devkitm-1
+          - environment: esp32dev
+          - environment: lolin_d32
+          - environment: lolin_d32_pro
+          - environment: lolin_s3_mini
+          - environment: seeed_xiao_esp32c3
+          - environment: seeed_xiao_esp32c6
+          - environment: wemos_d1_mini32
 
     steps:
       - name: Checkout

--- a/.github/workflows/ikea-obegransad-led-wall-lamp.yml
+++ b/.github/workflows/ikea-obegransad-led-wall-lamp.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: 3.14
+          python-version: "3.10"
           version: latest-known
 
       - name: Node.js cache
@@ -48,50 +48,6 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
-        exclude:
-          - environment: adafruit_qtpy_esp32s2
-            toolchain:
-              python-version: '3.10'
-
-          - environment: adafruit_qtpy_esp32s3_n4r2
-            toolchain:
-              python-version: '3.10'
-
-          - environment: adafruit_qtpy_esp32s3_nopsram
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_d32
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_d32_pro
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_s3_mini
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32c3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32c6
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32s3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: wemos_d1_mini32
-            toolchain:
-              python-version: '3.10'
 
     steps:
       - name: Checkout
@@ -112,7 +68,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO build
@@ -140,50 +96,6 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
-        exclude:
-          - environment: adafruit_qtpy_esp32s2
-            toolchain:
-              python-version: '3.10'
-
-          - environment: adafruit_qtpy_esp32s3_n4r2
-            toolchain:
-              python-version: '3.10'
-
-          - environment: adafruit_qtpy_esp32s3_nopsram
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_d32
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_d32_pro
-            toolchain:
-              python-version: '3.10'
-
-          - environment: lolin_s3_mini
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32c3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32c6
-            toolchain:
-              python-version: '3.10'
-
-          - environment: seeed_xiao_esp32s3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: wemos_d1_mini32
-            toolchain:
-              python-version: '3.10'
 
     steps:
       - name: Checkout
@@ -199,7 +111,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO build
@@ -237,33 +149,6 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
-        exclude:
-          - environment: adafruit_qtpy_esp32s2
-          - environment: adafruit_qtpy_esp32s3_n4r2
-
-          - environment: adafruit_qtpy_esp32s3_nopsram
-            toolchain:
-              python-version: '3.10'
-
-          - environment: esp32-c3-devkitm-1
-          - environment: esp32-c5-devkitc-1
-          - environment: esp32-c6-devkitm-1
-          - environment: esp32dev
-          - environment: lolin_d32
-          - environment: lolin_d32_pro
-          - environment: lolin_s3_mini
-          - environment: seeed_xiao_esp32c3
-          - environment: seeed_xiao_esp32c6
-
-          - environment: seeed_xiao_esp32s3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: wemos_d1_mini32
 
     steps:
       - name: Checkout
@@ -284,7 +169,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO build
@@ -380,33 +265,6 @@ jobs:
     strategy:
       matrix:
         environment: ${{ fromJSON(needs.context.outputs.pio-environments) }}
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
-        exclude:
-          - environment: adafruit_qtpy_esp32s2
-          - environment: adafruit_qtpy_esp32s3_n4r2
-
-          - environment: adafruit_qtpy_esp32s3_nopsram
-            toolchain:
-              python-version: '3.10'
-
-          - environment: esp32-c3-devkitm-1
-          - environment: esp32-c5-devkitc-1
-          - environment: esp32-c6-devkitm-1
-          - environment: esp32dev
-          - environment: lolin_d32
-          - environment: lolin_d32_pro
-          - environment: lolin_s3_mini
-          - environment: seeed_xiao_esp32c3
-          - environment: seeed_xiao_esp32c6
-
-          - environment: seeed_xiao_esp32s3
-            toolchain:
-              python-version: '3.10'
-
-          - environment: wemos_d1_mini32
 
     steps:
       - name: Checkout
@@ -427,7 +285,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO build

--- a/.github/workflows/miscellaneous.yml
+++ b/.github/workflows/miscellaneous.yml
@@ -14,13 +14,6 @@ jobs:
   animation-splitter:
     name: Animation splitter
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        include:
-          - python-version: '3.10'
-          - python-version: 3.14
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -28,7 +21,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: Animation splitter
@@ -120,13 +113,6 @@ jobs:
   homethermometer-updater:
     name: Home thermometer updater
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        include:
-          - python-version: '3.10'
-          - python-version: 3.14
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -134,7 +120,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: Set up HTTP server
@@ -157,13 +143,6 @@ jobs:
   mode-switcher:
     name: Mode switcher
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        include:
-          - python-version: '3.10'
-          - python-version: 3.14
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -171,7 +150,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: Set up HTTP server
@@ -223,7 +202,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: 3.14
+          python-version: "3.10"
           version: latest-known
 
       - name: uv lock check

--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: 3.14
+          python-version: "3.10"
           version: latest-known
 
       - name: PlatformIO lint

--- a/.github/workflows/stream.yml
+++ b/.github/workflows/stream.yml
@@ -22,10 +22,6 @@ jobs:
           - 5568
           - 6454
 
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -33,7 +29,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: Set up HTTP server
@@ -102,10 +98,6 @@ jobs:
           - 5568
           - 6454
 
-        toolchain:
-          - python-version: '3.10'
-          - python-version: 3.14
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -113,7 +105,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.toolchain.python-version }}
+          python-version: "3.10"
           version: latest-known
 
       - name: Set up HTTP server

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: "3.10"
+          python-version: 3.11
           version: latest-known
 
       - name: Version check

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: 3.14
+          python-version: "3.10"
           version: latest-known
 
       - name: Version check


### PR DESCRIPTION
This pull request standardizes the CI workflows to use Python 3.10 exclusively*, eliminating the previous mix of Python versions.

### Key changes
- Updated all* CI workflow files to set the Python version to 3.10. There's one exception, the "Version" workflow, which is 3.11 due to lack of support.
- Removed references to Python 3.13 and 3.14 from the workflows.

### Impact
These changes simplify the CI configuration, ensuring consistency across testing environments.