### PR TITLE
feat(metaballs): Make speed and radius configurable in metaballs mode

### DIFF
--- a/firmware/include/modes/MetaballsMode.h
+++ b/firmware/include/modes/MetaballsMode.h
@@ -22,7 +22,11 @@ private:
     static inline float speed{static_cast<float>(speedFactor) * baseSpeed};
 
     static constexpr uint8_t multiplier{1U << 3U};
-    static constexpr uint16_t feathering{(GRID_COLUMNS * GRID_ROWS) - 1U};
+    // How many discrete distance steps a ball's brightness falloff is quantized into, from its
+    // center (0) to its edge (falloffResolution); this is the resolution of contributions below.
+    static constexpr uint8_t falloffResolution{UINT8_MAX};
+    // Size must stay equal to falloffResolution + 1
+    std::array<uint8_t, falloffResolution + 1U> contributions{};
 
     struct Ball
     {
@@ -34,7 +38,6 @@ private:
 
     static constexpr uint8_t numBalls{(GRID_COLUMNS * GRID_ROWS / 50U)};
 
-    std::array<uint8_t, GRID_COLUMNS * GRID_ROWS> contributions{};
     std::array<Ball, numBalls> balls{};
 
     void setSpeed(uint8_t _speed);

--- a/firmware/include/modes/MetaballsMode.h
+++ b/firmware/include/modes/MetaballsMode.h
@@ -18,7 +18,7 @@ private:
     static inline float radiusSq{radius * radius};
 
     static constexpr float baseSpeed{1e-6F * static_cast<float>(GRID_COLUMNS * GRID_ROWS)};
-    static inline uint8_t speedFactor{2U};
+    static inline uint8_t speedFactor{4U};
     static inline float speed{static_cast<float>(speedFactor) * baseSpeed};
 
     static constexpr uint8_t multiplier{1U << 3U};
@@ -39,6 +39,7 @@ private:
 
     void setSpeed(uint8_t _speed);
     void setRadius(uint8_t _radius);
+    void updateRadius();
     void transmit();
 
 public:

--- a/firmware/include/modes/MetaballsMode.h
+++ b/firmware/include/modes/MetaballsMode.h
@@ -36,9 +36,10 @@ private:
         float yVelocity;
     };
 
-    static constexpr uint8_t numBalls{(GRID_COLUMNS * GRID_ROWS / 50U)};
+    static constexpr uint8_t numBallsMax{25U};
+    static inline uint8_t numBalls{(GRID_COLUMNS * GRID_ROWS / 50U)};
 
-    std::array<Ball, numBalls> balls{};
+    std::array<Ball, numBallsMax> balls{};
 
     void setSpeed(uint8_t _speed);
     void setRadius(uint8_t _radius);

--- a/firmware/include/modes/MetaballsMode.h
+++ b/firmware/include/modes/MetaballsMode.h
@@ -10,14 +10,19 @@
 class MetaballsMode final : public ModeModule
 {
 private:
-    static constexpr float radius{
+    static constexpr float maxRadius{
         min<float>(static_cast<float>(GRID_COLUMNS * PITCH_HORIZONTAL) / static_cast<float>(PITCH_VERTICAL),
-                   static_cast<float>(GRID_ROWS *PITCH_VERTICAL) / static_cast<float>(PITCH_HORIZONTAL)) /
-        5.0F};
-    static constexpr float radiusSq{radius * radius};
-    static constexpr float speed{1e-6F * static_cast<float>(GRID_COLUMNS * GRID_ROWS)};
+                   static_cast<float>(GRID_ROWS *PITCH_VERTICAL) / static_cast<float>(PITCH_HORIZONTAL))};
+    static inline uint8_t radiusFactor{2U};
+    static inline float radius{maxRadius / static_cast<float>(radiusFactor)};
+    static inline float radiusSq{radius * radius};
 
-    static constexpr uint8_t multiplier{1U << 4U};
+    static constexpr float baseSpeed{1e-6F * static_cast<float>(GRID_COLUMNS * GRID_ROWS)};
+    static inline uint8_t speedFactor{2U};
+    static inline float speed{static_cast<float>(speedFactor) * baseSpeed};
+
+    static constexpr uint8_t multiplier{1U << 3U};
+    static constexpr uint8_t feathering{(GRID_COLUMNS * GRID_ROWS) - 1U};
 
     struct Ball
     {
@@ -27,16 +32,24 @@ private:
         float yVelocity;
     };
 
+    static constexpr uint8_t numBalls{(GRID_COLUMNS * GRID_ROWS / 50U) - 1};
+
     std::array<uint8_t, GRID_COLUMNS * GRID_ROWS> contributions{};
-    std::array<Ball, GRID_COLUMNS * GRID_ROWS / 50U> balls{};
+    std::array<Ball, numBalls> balls{};
+
+    void setSpeed(uint8_t _speed);
+    void setRadius(uint8_t _radius);
+    void transmit();
 
 public:
     static constexpr std::string_view name{"Metaballs"};
 
     explicit MetaballsMode() : ModeModule(name) {};
 
+    void configure() override;
     void begin() override;
     void handle() override;
+    void onReceive(JsonObjectConst payload, std::string_view source) override;
 };
 
 #endif // MODE_METABALLS

--- a/firmware/include/modes/MetaballsMode.h
+++ b/firmware/include/modes/MetaballsMode.h
@@ -22,7 +22,7 @@ private:
     static inline float speed{static_cast<float>(speedFactor) * baseSpeed};
 
     static constexpr uint8_t multiplier{1U << 3U};
-    static constexpr uint8_t feathering{(GRID_COLUMNS * GRID_ROWS) - 1U};
+    static constexpr uint16_t feathering{(GRID_COLUMNS * GRID_ROWS) - 1U};
 
     struct Ball
     {
@@ -32,7 +32,7 @@ private:
         float yVelocity;
     };
 
-    static constexpr uint8_t numBalls{(GRID_COLUMNS * GRID_ROWS / 50U) - 1};
+    static constexpr uint8_t numBalls{(GRID_COLUMNS * GRID_ROWS / 50U)};
 
     std::array<uint8_t, GRID_COLUMNS * GRID_ROWS> contributions{};
     std::array<Ball, numBalls> balls{};

--- a/firmware/src/modes/MetaballsMode.cpp
+++ b/firmware/src/modes/MetaballsMode.cpp
@@ -217,6 +217,9 @@ void MetaballsMode::setRadius(uint8_t _radius)
     transmit();
 }
 
+/**
+ * @brief Updates the radius of the metaballs based on the current radius factor.
+ */
 void MetaballsMode::updateRadius()
 {
     radius = maxRadius / static_cast<float>(radiusFactor);

--- a/firmware/src/modes/MetaballsMode.cpp
+++ b/firmware/src/modes/MetaballsMode.cpp
@@ -29,8 +29,7 @@ void MetaballsMode::configure()
         if (nvs_get_u8(handle, "radius", &_radius) == ESP_OK)
         {
             radiusFactor = _radius;
-            radius = maxRadius / static_cast<float>(radiusFactor);
-            radiusSq = radius * radius;
+            updateRadius();
         }
         nvs_close(handle);
     }
@@ -53,6 +52,7 @@ void MetaballsMode::begin()
         ball.xVelocity = speed * static_cast<float>(random(1, multiplier) * ((random(2) * 2) - 1));
         ball.yVelocity = speed * static_cast<float>(random(1, multiplier) * ((random(2) * 2) - 1));
     }
+    Display.fillFrame(0U);
 }
 
 /**
@@ -182,7 +182,7 @@ void MetaballsMode::setSpeed(uint8_t _speed)
 /**
  * @brief Sets the radius of the metaballs and stores it in non-volatile storage.
  *
- * Uses arbitrary units for radius, where 1 is the smallest and 10 is the largest.
+ * Uses arbitrary units for _radius, where 1 is the smallest and 10 is the largest.
  * The actual radius is calculated based on the maximum radius and the radius factor.
  *
  * @param _radius New radius factor for the metaballs.
@@ -202,8 +202,10 @@ void MetaballsMode::setRadius(uint8_t _radius)
         radiusFactor = 11U - _radius;
     }
 
-    radius = maxRadius / static_cast<float>(radiusFactor);
-    radiusSq = radius * radius;
+    updateRadius();
+    /* After changing the radius, we need to clear the display to avoid visual
+       artifacts from the previous radius. */
+    Display.fillFrame(0U);
 
     nvs_handle_t handle{};
     if (nvs_open(name.data(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
@@ -213,6 +215,12 @@ void MetaballsMode::setRadius(uint8_t _radius)
         nvs_close(handle);
     }
     transmit();
+}
+
+void MetaballsMode::updateRadius()
+{
+    radius = maxRadius / static_cast<float>(radiusFactor);
+    radiusSq = radius * radius;
 }
 
 /**

--- a/firmware/src/modes/MetaballsMode.cpp
+++ b/firmware/src/modes/MetaballsMode.cpp
@@ -2,12 +2,44 @@
 
 #include "modes/MetaballsMode.h"
 
+#include "services/DeviceService.h"
 #include "services/DisplayService.h" // NOLINT(misc-include-cleaner)
 #include "services/ExtensionsService.h"
+
+#include <nvs.h>
 
 static_assert(GRID_COLUMNS * GRID_ROWS >= 50U,
               __STRING(MODE_METABALLS) " is not compatible with this device's display size.");
 
+/**
+ * @brief Loads persisted metaballs settings and publishes the active configuration.
+ */
+void MetaballsMode::configure()
+{
+    nvs_handle_t handle{};
+    if (nvs_open(name.data(), nvs_open_mode_t::NVS_READONLY, &handle) == ESP_OK)
+    {
+        uint8_t _speed{0U};
+        if (nvs_get_u8(handle, "speed", &_speed) == ESP_OK)
+        {
+            speedFactor = _speed;
+            speed = static_cast<float>(speedFactor) * baseSpeed;
+        }
+        uint8_t _radius{0U};
+        if (nvs_get_u8(handle, "radius", &_radius) == ESP_OK)
+        {
+            radiusFactor = _radius;
+            radius = maxRadius / static_cast<float>(radiusFactor);
+            radiusSq = radius * radius;
+        }
+        nvs_close(handle);
+    }
+    transmit();
+}
+
+/**
+ * @brief Initializes metaballs positions and velocities.
+ */
 void MetaballsMode::begin()
 {
     for (size_t idx{0U}; idx < contributions.size(); ++idx)
@@ -23,6 +55,12 @@ void MetaballsMode::begin()
     }
 }
 
+/**
+ * @brief Updates the metaballs positions and calculates their contributions to the display.
+ *
+ * The metaballs are represented as circles that move across the display, and their brightness
+ * contributions are calculated based on their distance from each pixel.
+ */
 void MetaballsMode::handle()
 {
 #if EXTENSION_MICROPHONE
@@ -65,10 +103,10 @@ void MetaballsMode::handle()
                     const float distanceSq{(xDistance * xDistance) + (yDistance * yDistance)};
                     if (distanceSq < radiusSq)
                     {
-                        brightness = static_cast<uint8_t>(
-                            min<uint16_t>(static_cast<uint16_t>(brightness) +
-                                              contributions[static_cast<uint8_t>(distanceSq * (0b1U << 6U) / radiusSq)],
-                                          UINT8_MAX));
+                        brightness = static_cast<uint8_t>(min<uint16_t>(
+                            static_cast<uint16_t>(brightness) + contributions[static_cast<uint8_t>(min<float>(
+                                                                    distanceSq * feathering / radiusSq, 255.0F))],
+                            UINT8_MAX));
                         if (brightness == UINT8_MAX)
                         {
                             break;
@@ -103,6 +141,106 @@ void MetaballsMode::handle()
             ball.y = GRID_ROWS - 1U;
             ball.yVelocity = -speed * static_cast<float>(random(1, multiplier));
         }
+    }
+}
+
+/**
+ * @brief Sets the base speed of the metaballs and stores it in non-volatile storage.
+ *
+ * Uses arbitrary units for speed, where 1 is the slowest and 11 is the fastest.
+ * The actual speed is calculated based on the base speed and the speed factor.
+ *
+ * @param _speed New speed factor for the metaballs.
+ */
+void MetaballsMode::setSpeed(uint8_t _speed)
+{
+    if (_speed < 1U)
+    {
+        speedFactor = 1U;
+    }
+    else if (_speed > 11U)
+    {
+        speedFactor = 11U;
+    }
+    else
+    {
+        speedFactor = _speed;
+    }
+
+    speed = baseSpeed * static_cast<float>(speedFactor);
+
+    nvs_handle_t handle{};
+    if (nvs_open(name.data(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
+    {
+        nvs_set_u8(handle, "speed", static_cast<uint8_t>(speedFactor));
+        nvs_commit(handle);
+        nvs_close(handle);
+    }
+    transmit();
+}
+
+/**
+ * @brief Sets the radius of the metaballs and stores it in non-volatile storage.
+ *
+ * Uses arbitrary units for radius, where 1 is the smallest and 10 is the largest.
+ * The actual radius is calculated based on the maximum radius and the radius factor.
+ *
+ * @param _radius New radius factor for the metaballs.
+ */
+void MetaballsMode::setRadius(uint8_t _radius)
+{
+    if (_radius < 1U)
+    {
+        radiusFactor = 10U;
+    }
+    else if (_radius > 10U)
+    {
+        radiusFactor = 1U;
+    }
+    else
+    {
+        radiusFactor = 11U - _radius;
+    }
+
+    radius = maxRadius / static_cast<float>(radiusFactor);
+    radiusSq = radius * radius;
+
+    nvs_handle_t handle{};
+    if (nvs_open(name.data(), nvs_open_mode_t::NVS_READWRITE, &handle) == ESP_OK)
+    {
+        nvs_set_u8(handle, "radius", static_cast<uint8_t>(radiusFactor));
+        nvs_commit(handle);
+        nvs_close(handle);
+    }
+    transmit();
+}
+
+/**
+ * @brief Publishes the current base speed and ball radius in arbitrary units.
+ */
+void MetaballsMode::transmit()
+{
+    JsonDocument doc{};
+    doc["speed"].set(speedFactor);
+    doc["radius"].set(11U - radiusFactor);
+    Device.transmit(doc.as<JsonObjectConst>(), name);
+}
+
+/**
+ * @brief Applies speed and radius from a received payload.
+ *
+ * @param payload Received configuration fields.
+ * @param source Source identifier for the received payload.
+ */
+void MetaballsMode::onReceive(JsonObjectConst payload, std::string_view source)
+{
+    if (payload["speed"].is<uint8_t>())
+    {
+        setSpeed(payload["speed"].as<uint8_t>());
+    }
+    if (payload["radius"].is<uint8_t>())
+    {
+        setRadius(payload["radius"].as<uint8_t>());
     }
 }
 

--- a/firmware/src/modes/MetaballsMode.cpp
+++ b/firmware/src/modes/MetaballsMode.cpp
@@ -41,9 +41,16 @@ void MetaballsMode::configure()
  */
 void MetaballsMode::begin()
 {
+    // Builds a lookup table of a single ball's brightness contribution by distance: full brightness
+    // at the center (idx 0), fading quadratically to none at the edge (idx == falloffResolution).
+    // Multiple overlapping balls add their contributions together, so peakBrightness is kept well
+    // below UINT8_MAX to require several overlapping balls before a pixel reaches full brightness.
+    constexpr float peakBrightness{64.0F};
+    constexpr float span{static_cast<float>(falloffResolution) + 1.0F};
     for (size_t idx{0U}; idx < contributions.size(); ++idx)
     {
-        contributions[idx] = ((UINT8_MAX - idx) * (UINT8_MAX - idx) * (0b1U << 6U)) >> (0b1U << 4U);
+        const float normalizedDistance{static_cast<float>(falloffResolution - idx) / span};
+        contributions[idx] = static_cast<uint8_t>(peakBrightness * normalizedDistance * normalizedDistance);
     }
     for (Ball &ball : balls)
     {
@@ -104,8 +111,9 @@ void MetaballsMode::handle()
                     if (distanceSq < radiusSq)
                     {
                         brightness = static_cast<uint8_t>(min<uint16_t>(
-                            static_cast<uint16_t>(brightness) + contributions[static_cast<uint8_t>(min<float>(
-                                                                    distanceSq * feathering / radiusSq, 255.0F))],
+                            static_cast<uint16_t>(brightness) +
+                                contributions[static_cast<uint8_t>(min<float>(distanceSq * falloffResolution / radiusSq,
+                                                                              static_cast<float>(falloffResolution)))],
                             UINT8_MAX));
                         if (brightness == UINT8_MAX)
                         {

--- a/firmware/src/modes/MetaballsMode.cpp
+++ b/firmware/src/modes/MetaballsMode.cpp
@@ -7,6 +7,7 @@
 #include "services/ExtensionsService.h"
 
 #include <nvs.h>
+#include <span>
 
 static_assert(GRID_COLUMNS * GRID_ROWS >= 50U,
               __STRING(MODE_METABALLS) " is not compatible with this device's display size.");
@@ -52,6 +53,8 @@ void MetaballsMode::begin()
         const float normalizedDistance{static_cast<float>(falloffResolution - idx) / span};
         contributions[idx] = static_cast<uint8_t>(peakBrightness * normalizedDistance * normalizedDistance);
     }
+    // All balls are initialized (not just the active numBalls) so they can simply be (de)activated
+    // by adjusting numBalls, without needing to (re)spawn any of them.
     for (Ball &ball : balls)
     {
         ball.x = static_cast<float>(random(GRID_COLUMNS));
@@ -83,7 +86,7 @@ void MetaballsMode::handle()
     const float yRatio{static_cast<float>(2U * (rotated ? PITCH_HORIZONTAL : PITCH_VERTICAL)) /
                        static_cast<float>(PITCH_VERTICAL + PITCH_HORIZONTAL)};
 #endif // PITCH_HORIZONTAL != PITCH_VERTICAL
-    for (const Ball &ball : balls)
+    for (const Ball &ball : std::span<const Ball>{balls}.first(numBalls))
     {
         const uint8_t yMax{static_cast<uint8_t>(
             min<int8_t>(static_cast<int8_t>(ceilf(ball.y + radius - min(ball.yVelocity, .0F))), GRID_ROWS - 1U))};
@@ -98,7 +101,7 @@ void MetaballsMode::handle()
             for (uint8_t y{yMin}; y <= yMax; ++y)
             {
                 uint8_t brightness{0U};
-                for (const Ball &ball : balls)
+                for (const Ball &ball : std::span<const Ball>{balls}.first(numBalls))
                 {
 #if PITCH_HORIZONTAL == PITCH_VERTICAL
                     const float xDistance{ball.x - static_cast<float>(x)};
@@ -125,7 +128,7 @@ void MetaballsMode::handle()
             }
         }
     }
-    for (Ball &ball : balls)
+    for (Ball &ball : std::span<Ball>{balls}.first(numBalls))
     {
         ball.x += ball.xVelocity;
         ball.y += ball.yVelocity;

--- a/webapp/src/modes/Metaballs.tsx
+++ b/webapp/src/modes/Metaballs.tsx
@@ -1,8 +1,74 @@
-import { mdiBasketball } from "@mdi/js";
-import type { Component } from "solid-js";
-
+import { mdiBasketball, mdiCircleExpand, mdiSpeedometer } from "@mdi/js";
+import { type Component, createSignal } from "solid-js";
+import { Icon } from "../components/Icon";
+import { SidebarSection } from "../extensions/WebApp";
+import { WebSocketWS } from "../extensions/WebSocket";
 import { MainComponent as ModesMainComponent } from "../services/Modes";
+import { Tooltip } from "../components/Tooltip";
 
 export const name = "Metaballs";
 
+const [getSpeed, setSpeed] = createSignal<number>(1);
+const [getRadius, setRadius] = createSignal<number>(5);
+
+export const receiver = (json: { speed?: number; radius?: number }) => {
+    json?.speed !== undefined && setSpeed(json.speed);
+    json?.radius !== undefined && setRadius(json.radius);
+};
+
 export const Main: Component = () => <ModesMainComponent icon={mdiBasketball} />;
+
+export const Sidebar: Component = () => {
+    const handleSpeed = (speed: number) => {
+        setSpeed(speed);
+        WebSocketWS.send(
+            JSON.stringify({
+                [name]: {
+                    speed: getSpeed(),
+                },
+            }),
+        );
+    };
+
+    const handleRadius = (radius: number) => {
+        setRadius(radius);
+        WebSocketWS.send(
+            JSON.stringify({
+                [name]: {
+                    radius: getRadius(),
+                },
+            }),
+        );
+    };
+
+    return (
+        <SidebarSection>
+            <div class="action grid-cols-[--spacing(4)_1fr]">
+                <Icon path={mdiSpeedometer} />
+                <Tooltip text={`Metaball speed ${getSpeed()}`}>
+                    <input
+                        class="w-full"
+                        max="10"
+                        min="1"
+                        onInput={(e) => handleSpeed(e.currentTarget.valueAsNumber)}
+                        type="range"
+                        value={getSpeed()}
+                    />
+                </Tooltip>
+            </div>
+            <div class="action grid-cols-[--spacing(4)_1fr]">
+                <Icon path={mdiCircleExpand} />
+                <Tooltip text={`Metaball radius ${getRadius()}`}>
+                    <input
+                        class="w-full"
+                        max="10"
+                        min="1"
+                        onInput={(e) => handleRadius(e.currentTarget.valueAsNumber)}
+                        type="range"
+                        value={getRadius()}
+                    />
+                </Tooltip>
+            </div>
+        </SidebarSection>
+    );
+};

--- a/webapp/src/modes/Metaballs.tsx
+++ b/webapp/src/modes/Metaballs.tsx
@@ -47,15 +47,17 @@ const radiusOptions = [
 ];
 
 export const Sidebar: Component = () => {
-    const handleSpeed = (speed: number) => {
-        setSpeed(speed);
-        WebSocketWS.send(
-            JSON.stringify({
-                [name]: {
-                    speed: getSpeed(),
-                },
-            }),
-        );
+    const handleSpeed = (value: number, send: boolean = false) => {
+        setSpeed(value);
+        if (send) {
+            WebSocketWS.send(
+                JSON.stringify({
+                    [name]: {
+                        speed: getSpeed(),
+                    },
+                }),
+            );
+        }
     };
 
     const handleRadius = (radius: number) => {
@@ -78,10 +80,13 @@ export const Sidebar: Component = () => {
                 <Tooltip text={`Metaball speed ${getSpeed()}`}>
                     <input
                         class="w-full"
+                        aria-label="Metaball speed"
+                        type="range"
                         max="11"
                         min="1"
-                        onInput={(e) => handleSpeed(e.currentTarget.valueAsNumber)}
-                        type="range"
+                        onInput={(e) => handleSpeed(e.currentTarget.valueAsNumber, false)}
+                        onKeyUp={() => handleSpeed(getSpeed(), true)}
+                        onPointerUp={() => handleSpeed(getSpeed(), true)}
                         value={getSpeed()}
                     />
                 </Tooltip>
@@ -91,6 +96,7 @@ export const Sidebar: Component = () => {
                 <Tooltip text={`Metaball radius`}>
                     <select
                         class="w-full"
+                        aria-label="Metaball radius"
                         onchange={(e) => handleRadius(Number(e.currentTarget.value))}
                         value={getRadius()}
                     >

--- a/webapp/src/modes/Metaballs.tsx
+++ b/webapp/src/modes/Metaballs.tsx
@@ -1,10 +1,10 @@
 import { mdiBasketball, mdiCircleExpand, mdiSpeedometer } from "@mdi/js";
-import { type Component, createSignal } from "solid-js";
+import { type Component, createSignal, For } from "solid-js";
 import { Icon } from "../components/Icon";
+import { Tooltip } from "../components/Tooltip";
 import { SidebarSection } from "../extensions/WebApp";
 import { WebSocketWS } from "../extensions/WebSocket";
 import { MainComponent as ModesMainComponent } from "../services/Modes";
-import { Tooltip } from "../components/Tooltip";
 
 export const name = "Metaballs";
 
@@ -17,6 +17,34 @@ export const receiver = (json: { speed?: number; radius?: number }) => {
 };
 
 export const Main: Component = () => <ModesMainComponent icon={mdiBasketball} />;
+
+// Radius values the visualization actually renders sensibly.
+const radiusOptions = [
+    {
+        value: 4,
+        label: "Tiny",
+    },
+    {
+        value: 5,
+        label: "Small",
+    },
+    {
+        value: 6,
+        label: "Medium",
+    },
+    {
+        value: 7,
+        label: "Large",
+    },
+    {
+        value: 8,
+        label: "Huge",
+    },
+    {
+        value: 9,
+        label: "Massive",
+    },
+];
 
 export const Sidebar: Component = () => {
     const handleSpeed = (speed: number) => {
@@ -44,11 +72,13 @@ export const Sidebar: Component = () => {
     return (
         <SidebarSection>
             <div class="action grid-cols-[--spacing(4)_1fr]">
-                <Icon path={mdiSpeedometer} />
+                <Tooltip text={`"These go to eleven!"`}>
+                    <Icon path={mdiSpeedometer} />
+                </Tooltip>
                 <Tooltip text={`Metaball speed ${getSpeed()}`}>
                     <input
                         class="w-full"
-                        max="10"
+                        max="11"
                         min="1"
                         onInput={(e) => handleSpeed(e.currentTarget.valueAsNumber)}
                         type="range"
@@ -59,14 +89,13 @@ export const Sidebar: Component = () => {
             <div class="action grid-cols-[--spacing(4)_1fr]">
                 <Icon path={mdiCircleExpand} />
                 <Tooltip text={`Metaball radius ${getRadius()}`}>
-                    <input
+                    <select
                         class="w-full"
-                        max="10"
-                        min="1"
-                        onInput={(e) => handleRadius(e.currentTarget.valueAsNumber)}
-                        type="range"
+                        onchange={(e) => handleRadius(Number(e.currentTarget.value))}
                         value={getRadius()}
-                    />
+                    >
+                        <For each={radiusOptions}>{({ value, label }) => <option value={value}>{label}</option>}</For>
+                    </select>
                 </Tooltip>
             </div>
         </SidebarSection>

--- a/webapp/src/modes/Metaballs.tsx
+++ b/webapp/src/modes/Metaballs.tsx
@@ -72,7 +72,7 @@ export const Sidebar: Component = () => {
     return (
         <SidebarSection>
             <div class="action grid-cols-[--spacing(4)_1fr]">
-                <Tooltip text={`"These go to eleven!"`}>
+                <Tooltip text={`"These go to eleven."`}>
                     <Icon path={mdiSpeedometer} />
                 </Tooltip>
                 <Tooltip text={`Metaball speed ${getSpeed()}`}>
@@ -88,7 +88,7 @@ export const Sidebar: Component = () => {
             </div>
             <div class="action grid-cols-[--spacing(4)_1fr]">
                 <Icon path={mdiCircleExpand} />
-                <Tooltip text={`Metaball radius ${getRadius()}`}>
+                <Tooltip text={`Metaball radius`}>
                     <select
                         class="w-full"
                         onchange={(e) => handleRadius(Number(e.currentTarget.value))}

--- a/webapp/src/modes/Metaballs.tsx
+++ b/webapp/src/modes/Metaballs.tsx
@@ -8,8 +8,8 @@ import { MainComponent as ModesMainComponent } from "../services/Modes";
 
 export const name = "Metaballs";
 
-const [getSpeed, setSpeed] = createSignal<number>(1);
-const [getRadius, setRadius] = createSignal<number>(5);
+const [getSpeed, setSpeed] = createSignal<number>(4);
+const [getRadius, setRadius] = createSignal<number>(9);
 
 export const receiver = (json: { speed?: number; radius?: number }) => {
     json?.speed !== undefined && setSpeed(json.speed);
@@ -18,7 +18,9 @@ export const receiver = (json: { speed?: number; radius?: number }) => {
 
 export const Main: Component = () => <ModesMainComponent icon={mdiBasketball} />;
 
-// Radius values the visualization actually renders sensibly.
+/**
+ * Radius values the visualization actually renders sensibly.
+ */
 const radiusOptions = [
     {
         value: 4,
@@ -60,8 +62,8 @@ export const Sidebar: Component = () => {
         }
     };
 
-    const handleRadius = (radius: number) => {
-        setRadius(radius);
+    const handleRadius = (value: number) => {
+        setRadius(value);
         WebSocketWS.send(
             JSON.stringify({
                 [name]: {

--- a/webapp/src/services/Modes.tsx
+++ b/webapp/src/services/Modes.tsx
@@ -78,7 +78,11 @@ import {
 } from "../modes/HomeThermometer";
 import { Main as ModeLeafFallMain, name as ModeLeafFallName } from "../modes/LeafFall";
 import { Main as ModeLinesMain, name as ModeLinesName } from "../modes/Lines";
-import { Main as ModeMetaballsMain, name as ModeMetaballsName } from "../modes/Metaballs";
+import {
+    Main as ModeMetaballsMain,
+    name as ModeMetaballsName,
+    Sidebar as ModeMetaballsSidebar,
+} from "../modes/Metaballs";
 import { Main as ModeNoiseMain, name as ModeNoiseName } from "../modes/Noise";
 import { Main as ModePingPongMain, name as ModePingPongName, Sidebar as ModePingPongSidebar } from "../modes/PingPong";
 import { Main as ModePixelSequenceMain, name as ModePixelSequenceName } from "../modes/PixelSequence";
@@ -328,6 +332,11 @@ export const Sidebar: Component = () => {
                 {MODE_GAMEOFLIFE && (
                     <Match when={getMode() === ModeGameOfLifeName}>
                         <ModeGameOfLifeSidebar />
+                    </Match>
+                )}
+                {MODE_METABALLS && (
+                    <Match when={getMode() === ModeMetaballsName}>
+                        <ModeMetaballsSidebar />
                     </Match>
                 )}
                 {MODE_PINGPONG && (


### PR DESCRIPTION
<!-- Briefly summarize what this pull request does and why. What problem does it solve, or what improvement does it bring? -->
This adds parameters to configure speed and size of the balls from the frontend.

### Key changes

<!-- List or describe the main updates included in this PR — code changes, documentation updates, new features, bug fixes, etc. -->
* Exposes speed and radius parameters in the firmware
* Adds sidebar components for metaballs in the webapp

### Impact

<!-- Explain how these changes affect the project, users, or contributors. Mention anything worth noting, such as compatibility, behavior changes, or maintenance impact. -->
* Users can now manipulate the speed of the balls with a slider.
  * Balls will use the new value only after the next bounce from a wall.
  * Increased the default speed and reduced the multiplier to get a more uniform movement. (Multiplier could be made configurable in a follow up.
* Users can now select the size of the balls with a dropdown
  * I initially added a slider, but not all values make sense (that's also why the backend accepts numerical values)

### ToDo

Add config parameters for multiplier, feathering and number of balls.

