### PR TITLE
Improve visuals in MetaballsMode

### DIFF
--- a/firmware/include/modes/MetaballsMode.h
+++ b/firmware/include/modes/MetaballsMode.h
@@ -18,6 +18,11 @@ private:
     static constexpr float speed{1e-6F * static_cast<float>(GRID_COLUMNS * GRID_ROWS)};
 
     static constexpr uint8_t multiplier{1U << 4U};
+    // How many discrete distance steps a ball's brightness falloff is quantized into, from its
+    // center (0) to its edge (falloffResolution); this is the resolution of contributions below.
+    static constexpr uint8_t falloffResolution{UINT8_MAX};
+    // Size must stay equal to falloffResolution + 1
+    std::array<uint8_t, falloffResolution + 1U> contributions{};
 
     struct Ball
     {
@@ -27,7 +32,6 @@ private:
         float yVelocity;
     };
 
-    std::array<uint8_t, GRID_COLUMNS * GRID_ROWS> contributions{};
     std::array<Ball, GRID_COLUMNS * GRID_ROWS / 50U> balls{};
 
 public:

--- a/firmware/src/modes/MetaballsMode.cpp
+++ b/firmware/src/modes/MetaballsMode.cpp
@@ -10,9 +10,16 @@ static_assert(GRID_COLUMNS * GRID_ROWS >= 50U,
 
 void MetaballsMode::begin()
 {
+    // Builds a lookup table of a single ball's brightness contribution by distance: full brightness
+    // at the center (idx 0), fading quadratically to none at the edge (idx == falloffResolution).
+    // Multiple overlapping balls add their contributions together, so peakBrightness is kept well
+    // below UINT8_MAX to require several overlapping balls before a pixel reaches full brightness.
+    constexpr float peakBrightness{64.0F};
+    constexpr float span{static_cast<float>(falloffResolution) + 1.0F};
     for (size_t idx{0U}; idx < contributions.size(); ++idx)
     {
-        contributions[idx] = ((UINT8_MAX - idx) * (UINT8_MAX - idx) * (0b1U << 6U)) >> (0b1U << 4U);
+        const float normalizedDistance{static_cast<float>(falloffResolution - idx) / span};
+        contributions[idx] = static_cast<uint8_t>(peakBrightness * normalizedDistance * normalizedDistance);
     }
     for (Ball &ball : balls)
     {
@@ -65,10 +72,11 @@ void MetaballsMode::handle()
                     const float distanceSq{(xDistance * xDistance) + (yDistance * yDistance)};
                     if (distanceSq < radiusSq)
                     {
-                        brightness = static_cast<uint8_t>(
-                            min<uint16_t>(static_cast<uint16_t>(brightness) +
-                                              contributions[static_cast<uint8_t>(distanceSq * (0b1U << 6U) / radiusSq)],
-                                          UINT8_MAX));
+                        brightness = static_cast<uint8_t>(min<uint16_t>(
+                            static_cast<uint16_t>(brightness) +
+                                contributions[static_cast<uint8_t>(min<float>(distanceSq * falloffResolution / radiusSq,
+                                                                              static_cast<float>(falloffResolution)))],
+                            UINT8_MAX));
                         if (brightness == UINT8_MAX)
                         {
                             break;


### PR DESCRIPTION
Creating a separate PR for the refinement of the contribution calculation from #788 

Currently the brightness calculation does not use the entire contributions array, due to the hard coded `1<<6`:

```cpp
brightness = static_cast<uint8_t>(
    min<uint16_t>(static_cast<uint16_t>(brightness) +
                        contributions[static_cast<uint8_t>(distanceSq * (0b1U << 6U) / radiusSq)],
                  UINT8_MAX));
```

This factor should be related to the size of the contributions array.

Also the initialization of the contributions array is not very intuitive, so I tried to make it clearer.

<!-- Briefly summarize what this pull request does and why. What problem does it solve, or what improvement does it bring? -->

### Key changes

<!-- List or describe the main updates included in this PR — code changes, documentation updates, new features, bug fixes, etc. -->

- Use named variables instead of magic numbers in initialization of contributions array
- Use same factor `falloffResolution` during init of contributions and in calculation of brightness

### Impact

<!-- Explain how these changes affect the project, users, or contributors. Mention anything worth noting, such as compatibility, behavior changes, or maintenance impact. -->

- Better visuals, avoiding sudden brightness drops at the edges of balls
