### PR TITLE
Set actions/checkout to not persist credentials and improve workflow logic

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Biome
         uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2.7.1
@@ -34,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Biome
         uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2.7.1

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Clang format
         uses: cpp-linter/cpp-linter-action@cab1143a2c149bc41e85b070a9de81716974c18f # v2.21.0
@@ -89,6 +93,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Cache for PlatformIO
         continue-on-error: true

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -110,6 +110,8 @@ jobs:
           version: latest-known
 
       - name: PlatformIO compilation database
+        env:
+          PIO_ENVIRONMENT: ${{ matrix.environment }}
         run: |
           cat <<'EOL' > .env
           ${{ matrix.device-id }}='true'
@@ -218,7 +220,7 @@ jobs:
           #define WORLDWEATHERONLINE_KEY "redacted"
           EOL
 
-          uv run --only-group platformio pio run -t compiledb -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -t compiledb -e "$PIO_ENVIRONMENT"
 
       - name: Clang tidy
         uses: cpp-linter/cpp-linter-action@cab1143a2c149bc41e85b070a9de81716974c18f # v2.21.0

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: PlatformIO Dependency Updater
         uses: VIPnytt/platformio-dependency-updater@151e4688a6696cc129b69b33de262f4be58b7904 # v1.0.2

--- a/.github/workflows/end-of-life.yml
+++ b/.github/workflows/end-of-life.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Node.js wheel binaries version
         id: lock

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -48,7 +48,6 @@ jobs:
 
       - name: Clang summary
         run: |
-          echo "Status: ${{ steps.clang.outputs.checks-failed }} checks failed, threshold for success is ${{ env.clang-threshold }}."
           echo "Clang report:"
           if [ -n "${{ github.event.pull_request.number }}" ]; then
             echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }}"

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -63,6 +65,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -143,6 +147,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -47,8 +47,6 @@ jobs:
           tidy-checks: "-*"
 
       - name: Clang summary
-        env:
-          clang-threshold: 0
         run: |
           echo "Status: ${{ steps.clang.outputs.checks-failed }} checks failed, threshold for success is ${{ env.clang-threshold }}."
           echo "Clang report:"
@@ -57,7 +55,7 @@ jobs:
           else
             echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
-          exit $(( ${{ steps.clang.outputs.checks-failed }} > ${{ env.clang-threshold }} ))
+          exit $(( ${{ steps.clang.outputs.checks-failed }} != 0 ))
 
   mode-dynamic:
     name: Dynamic mode
@@ -129,17 +127,14 @@ jobs:
           tidy-checks: "-*"
 
       - name: Clang summary
-        env:
-          clang-threshold: 0
         run: |
-          echo "Status: ${{ steps.clang.outputs.checks-failed }} checks failed, threshold for success is ${{ env.clang-threshold }}."
           echo "Clang report:"
           if [ -n "${{ github.event.pull_request.number }}" ]; then
             echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }}"
           else
             echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
-          exit $(( ${{ steps.clang.outputs.checks-failed }} > ${{ env.clang-threshold }} ))
+          exit $(( ${{ steps.clang.outputs.checks-failed }} != 0 ))
 
   mode-static:
     name: Static mode
@@ -195,14 +190,11 @@ jobs:
           tidy-checks: "-*"
 
       - name: Clang summary
-        env:
-          clang-threshold: 0
         run: |
-          echo "Status: ${{ steps.clang.outputs.checks-failed }} checks failed, threshold for success is ${{ env.clang-threshold }}."
           echo "Clang report:"
           if [ -n "${{ github.event.pull_request.number }}" ]; then
             echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }}"
           else
             echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
-          exit $(( ${{ steps.clang.outputs.checks-failed }} > ${{ env.clang-threshold }} ))
+          exit $(( ${{ steps.clang.outputs.checks-failed }} != 0 ))

--- a/.github/workflows/ikea-frekvens-led-multi-use-light.yml
+++ b/.github/workflows/ikea-frekvens-led-multi-use-light.yml
@@ -76,6 +76,8 @@ jobs:
           version: latest-known
 
       - name: PlatformIO build
+        env:
+          PIO_ENVIRONMENT: ${{ matrix.environment }}
         run: |
           echo "IKEA_FREKVENS='true'" >> .env
 
@@ -91,7 +93,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          uv run --only-group platformio pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e "$PIO_ENVIRONMENT"
 
   minimal:
     name: Minimal
@@ -122,6 +124,8 @@ jobs:
           version: latest-known
 
       - name: PlatformIO build
+        env:
+          PIO_ENVIRONMENT: ${{ matrix.environment }}
         run: |
           cat <<'EOL' > .env
           EXTENSION_BUTTON='true'
@@ -146,7 +150,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          uv run --only-group platformio pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e "$PIO_ENVIRONMENT"
 
   typical:
     name: Typical
@@ -195,6 +199,8 @@ jobs:
           version: latest-known
 
       - name: PlatformIO build
+        env:
+          PIO_ENVIRONMENT: ${{ matrix.environment }}
         run: |
           cat <<'EOL' > .env
           EXTENSION_ALEXA='true'
@@ -280,7 +286,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          uv run --only-group platformio pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e "$PIO_ENVIRONMENT"
 
   extensive:
     name: Extensive
@@ -329,6 +335,8 @@ jobs:
           version: latest-known
 
       - name: PlatformIO build
+        env:
+          PIO_ENVIRONMENT: ${{ matrix.environment }}
         run: |
           cat <<'EOL' > .env
           EXTENSION_ALEXA='true'
@@ -446,4 +454,4 @@ jobs:
           #define WORLDWEATHERONLINE_KEY "redacted"
           EOL
 
-          uv run --only-group platformio pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e "$PIO_ENVIRONMENT"

--- a/.github/workflows/ikea-frekvens-led-multi-use-light.yml
+++ b/.github/workflows/ikea-frekvens-led-multi-use-light.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -52,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Cache for Node.js
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -101,6 +105,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Cache for PlatformIO
         continue-on-error: true
@@ -167,6 +173,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Cache for Node.js
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -299,6 +307,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Cache for Node.js
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ikea-frekvens-led-spotlight.yml
+++ b/.github/workflows/ikea-frekvens-led-spotlight.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: ESPHome minimum version
         id: config
@@ -40,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up ESPHome secrets.yaml
         run: |

--- a/.github/workflows/ikea-frekvens-led-spotlight.yml
+++ b/.github/workflows/ikea-frekvens-led-spotlight.yml
@@ -31,9 +31,9 @@ jobs:
     name: ESPHome
     needs: esphome
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.esphome-version == 'latest' }}
 
     strategy:
-      fail-fast: false
       matrix:
         esphome-version:
           - ${{ needs.esphome.outputs.min_version }}

--- a/.github/workflows/ikea-frekvens-led-spotlight.yml
+++ b/.github/workflows/ikea-frekvens-led-spotlight.yml
@@ -31,9 +31,9 @@ jobs:
     name: ESPHome
     needs: esphome
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     strategy:
+      fail-fast: false
       matrix:
         esphome-version:
           - ${{ needs.esphome.outputs.min_version }}

--- a/.github/workflows/ikea-obegransad-led-wall-lamp.yml
+++ b/.github/workflows/ikea-obegransad-led-wall-lamp.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -52,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Cache for Node.js
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -100,6 +104,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Cache for PlatformIO
         continue-on-error: true
@@ -166,6 +172,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Cache for Node.js
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -295,6 +303,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Cache for Node.js
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ikea-obegransad-led-wall-lamp.yml
+++ b/.github/workflows/ikea-obegransad-led-wall-lamp.yml
@@ -76,6 +76,8 @@ jobs:
           version: latest-known
 
       - name: PlatformIO build
+        env:
+          PIO_ENVIRONMENT: ${{ matrix.environment }}
         run: |
           echo "IKEA_OBEGRANSAD='true'" >> .env
 
@@ -90,7 +92,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          uv run --only-group platformio pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e "$PIO_ENVIRONMENT"
 
   minimal:
     name: Minimal
@@ -121,6 +123,8 @@ jobs:
           version: latest-known
 
       - name: PlatformIO build
+        env:
+          PIO_ENVIRONMENT: ${{ matrix.environment }}
         run: |
           cat <<'EOL' > .env
           EXTENSION_BUTTON='true'
@@ -145,7 +149,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          uv run --only-group platformio pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e "$PIO_ENVIRONMENT"
 
   typical:
     name: Typical
@@ -194,6 +198,8 @@ jobs:
           version: latest-known
 
       - name: PlatformIO build
+        env:
+          PIO_ENVIRONMENT: ${{ matrix.environment }}
         run: |
           cat <<'EOL' > .env
           EXTENSION_ALEXA='true'
@@ -276,7 +282,7 @@ jobs:
           #define WIFI_SSID "redacted"
           EOL
 
-          uv run --only-group platformio pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e "$PIO_ENVIRONMENT"
 
   extensive:
     name: Extensive
@@ -325,6 +331,8 @@ jobs:
           version: latest-known
 
       - name: PlatformIO build
+        env:
+          PIO_ENVIRONMENT: ${{ matrix.environment }}
         run: |
           cat <<'EOL' > .env
           EXTENSION_ALEXA='true'
@@ -441,4 +449,4 @@ jobs:
           #define WORLDWEATHERONLINE_KEY "redacted"
           EOL
 
-          uv run --only-group platformio pio run -e ${{ matrix.environment }}
+          uv run --only-group platformio pio run -e "$PIO_ENVIRONMENT"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Labeler
         uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0

--- a/.github/workflows/miscellaneous.yml
+++ b/.github/workflows/miscellaneous.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -116,6 +118,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -146,6 +150,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -177,6 +183,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -198,6 +206,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Ruff check
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
@@ -32,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Ruff format
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0

--- a/.github/workflows/stream.yml
+++ b/.github/workflows/stream.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -101,6 +103,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Wiki
         uses: Andrew-Chen-Wang/github-wiki-action@1bbb4280446f9630e8e21a18012cbacf3b0f992e # v5.0.6


### PR DESCRIPTION
This pull request enhances the security of the CI workflows by disabling credential persistence during the checkout process and refactoring the workflow logic for clarity.

### Key changes

- Set `persist-credentials` to false in the `actions/checkout` step across multiple workflows.
- Utilized environment variables for CLI variables to streamline configuration.
- Cleaned up workflow logic for better readability.

### Impact

These changes improve security by reducing the risk of credential leakage and enhance maintainability of the CI workflows. Users and contributors will benefit from clearer and more secure workflows without any breaking changes.